### PR TITLE
Addition of tolerances and match rates

### DIFF
--- a/datacompy/sparkcompare.py
+++ b/datacompy/sparkcompare.py
@@ -122,9 +122,14 @@ class SparkCompare(object):
         have done some work deduping the input dataframes. If
         ``cache_intermediates=False``, the instantiation of this object is lazy.
     """
-
-    def __init__(self, spark_session, base_df, compare_df, join_columns, column_mapping=None,
-                 cache_intermediates=False, known_differences=None):
+    def __init__(self, spark_session, base_df, compare_df, join_columns,rel_tol=0, abs_tol=0,column_mapping=None,
+                 cache_intermediates=False, known_differences=None,show_all_columns=False,match_rates=False):
+        self.rel_tol = rel_tol
+        self.abs_tol = abs_tol
+        if self.rel_tol<0 or self.abs_tol<0:
+            raise ValueError("Please enter positive valued tolerances")
+        self.show_all_columns=show_all_columns
+        self.match_rates=match_rates
 
         self._original_base_df = base_df
         self._original_compare_df = compare_df
@@ -467,7 +472,12 @@ class SparkCompare(object):
         compare_dtype = [d[1] for d in self.compare_df.dtypes if d[0] == name][0]
 
         if _is_comparable(base_dtype, compare_dtype):
-            equal_comparisons.append('(A.{name}=B.{name})')
+
+            #equal_comparisons.append('(A.{name}=B.{name})')
+            if (base_dtype in NUMERIC_SPARK_TYPES) and (compare_dtype in NUMERIC_SPARK_TYPES ):#numeric tolerance comparison
+                equal_comparisons.append('((A.{name}=B.{name}) OR ((abs(A.{name}-B.{name}))<=('+str(self.abs_tol)+'+('+str(self.rel_tol)+'*abs(A.{name})))))')
+            else:#non-numeric comparison
+                equal_comparisons.append('((A.{name}=B.{name}))')
 
         if self._known_differences:
             new_input = "B.{name}"
@@ -595,6 +605,8 @@ class SparkCompare(object):
             ("# Known Diffs", self._known_differences is not None, 13, True),
             ("# Mismatches", True, 12, True)
         ]
+        if self.match_rates:
+            headers_columns_unequal.append(("Match Rate %",True, 12, True))
         headers_columns_unequal_valid = [h for h in headers_columns_unequal if h[1]]
         padding = 2  # spaces to add to left and right of each column
 
@@ -613,6 +625,9 @@ class SparkCompare(object):
             if num_mismatches or num_known_diffs:
                 output_row = [column_name, compare_column, base_types.get(column_name),
                               compare_types.get(column_name), str(num_matches), str(num_mismatches)]
+                if  self.match_rates:
+                    match_rate = 100*(1-(column_values[MatchType.MISMATCH.value]+0.0)/self.common_row_count+0.0)
+                    output_row.append('{:02.5f}'.format(match_rate))
                 if num_known_diffs is not None:
                     output_row.insert(len(output_row) - 1, str(num_known_diffs))
                 print(format_pattern.format(*output_row), file=myfile)

--- a/datacompy/sparkcompare.py
+++ b/datacompy/sparkcompare.py
@@ -131,6 +131,7 @@ class SparkCompare(object):
         have done some work deduping the input dataframes. If
         ``cache_intermediates=False``, the instantiation of this object is lazy.
     """
+
     def __init__(self, spark_session, base_df, compare_df, join_columns,column_mapping=None,
                  cache_intermediates=False, known_differences=None,rel_tol=0, abs_tol=0,
                  show_all_columns=False,match_rates=False):

--- a/datacompy/sparkcompare.py
+++ b/datacompy/sparkcompare.py
@@ -119,9 +119,9 @@ class SparkCompare(object):
         Relative tolerance between two values.
     show_all_columns : bool, optional
         If true, all columns will be shown in the report including columns
-        with a 100% match rate
+        with a 100% match rate.
     match_rates : bool, optional
-        If true, match rates by column will be shown in the column summary
+        If true, match rates by column will be shown in the column summary.
 
     Returns
     -------

--- a/datacompy/sparkcompare.py
+++ b/datacompy/sparkcompare.py
@@ -483,8 +483,6 @@ class SparkCompare(object):
         compare_dtype = [d[1] for d in self.compare_df.dtypes if d[0] == name][0]
 
         if _is_comparable(base_dtype, compare_dtype):
-
-            #equal_comparisons.append('(A.{name}=B.{name})')
             if (base_dtype in NUMERIC_SPARK_TYPES) and (compare_dtype in NUMERIC_SPARK_TYPES ):#numeric tolerance comparison
                 equal_comparisons.append('((A.{name}=B.{name}) OR ((abs(A.{name}-B.{name}))<=('+str(self.abs_tol)+'+('+str(self.rel_tol)+'*abs(A.{name})))))')
             else:#non-numeric comparison

--- a/datacompy/sparkcompare.py
+++ b/datacompy/sparkcompare.py
@@ -113,6 +113,15 @@ class SparkCompare(object):
             * transformation: A Spark SQL statement to apply to the column
                 in the compare dataset. The string "{input}" will be replaced
                 by the variable in question.
+    abs_tol : float, optional
+        Absolute tolerance between two values.
+    rel_tol : float, optional
+        Relative tolerance between two values.
+    show_all_columns : bool, optional
+        If true, all columns will be shown in the report including columns
+        with a 100% match rate
+    match_rates : bool, optional
+        If true, match rates by column will be shown in the column summary
 
     Returns
     -------
@@ -122,8 +131,9 @@ class SparkCompare(object):
         have done some work deduping the input dataframes. If
         ``cache_intermediates=False``, the instantiation of this object is lazy.
     """
-    def __init__(self, spark_session, base_df, compare_df, join_columns,rel_tol=0, abs_tol=0,column_mapping=None,
-                 cache_intermediates=False, known_differences=None,show_all_columns=False,match_rates=False):
+    def __init__(self, spark_session, base_df, compare_df, join_columns,column_mapping=None,
+                 cache_intermediates=False, known_differences=None,rel_tol=0, abs_tol=0,
+                 show_all_columns=False,match_rates=False):
         self.rel_tol = rel_tol
         self.abs_tol = abs_tol
         if self.rel_tol<0 or self.abs_tol<0:

--- a/tests/test_sparkcompare.py
+++ b/tests/test_sparkcompare.py
@@ -131,7 +131,7 @@ def compare_df3_fixture(spark):
 
     return spark.createDataFrame(mock_data2)
 
-#####NEW dataframe fixture for tolerance
+
 @pytest.fixture(scope='module', name='base_tol')
 def base_tol_fixture(spark):
     tol_data1 = [
@@ -165,6 +165,7 @@ def base_tol_fixture(spark):
 
     return spark.createDataFrame(tol_data1)
 
+
 @pytest.fixture(scope='module', name='compare_abs_tol')
 def compare_tol2_fixture(spark):
     tol_data2 = [
@@ -197,6 +198,7 @@ def compare_tol2_fixture(spark):
     ]
 
     return spark.createDataFrame(tol_data2)
+
 
 @pytest.fixture(scope='module', name='compare_rel_tol')
 def compare_tol3_fixture(spark):
@@ -264,8 +266,6 @@ def compare_tol4_fixture(spark):
     ]
 
     return spark.createDataFrame(tol_data4)
-###############
-
 
 
 @pytest.fixture(scope='module', name='base_td')
@@ -331,15 +331,15 @@ def comparison_abs_tol_fixture(base_tol, compare_abs_tol, spark):
 def comparison_rel_tol_fixture(base_tol, compare_rel_tol, spark):
     return SparkCompare(spark, base_tol, compare_rel_tol, join_columns=['account_identifier'],rel_tol=0.1)
 
+
 @pytest.fixture(scope='module', name='comparison_both_tol')
 def comparison_both_tol_fixture(base_tol, compare_both_tol, spark):
     return SparkCompare(spark, base_tol, compare_both_tol, join_columns=['account_identifier'],rel_tol=0.1,abs_tol=0.01)
 
+
 @pytest.fixture(scope='module', name='comparison_neg_tol')
 def comparison_neg_tol_fixture(base_tol, compare_both_tol, spark):
     return SparkCompare(spark, base_tol, compare_both_tol, join_columns=['account_identifier'],rel_tol=-0.2,abs_tol=0.01)
-
-
 
 
 @pytest.fixture(scope='module', name='comparison_kd1')
@@ -409,7 +409,7 @@ def comparison4_fixture(base_df2, compare_df1, spark):
 def comparison_decimal_fixture(base_decimal, compare_decimal, spark):
     return SparkCompare(spark, base_decimal, compare_decimal, join_columns=['acct'])
 
-############### added tests for tolerances
+
 def test_absolute_tolerances(comparison_abs_tol):
     stdout = six.StringIO()
 

--- a/tests/test_sparkcompare.py
+++ b/tests/test_sparkcompare.py
@@ -131,6 +131,142 @@ def compare_df3_fixture(spark):
 
     return spark.createDataFrame(mock_data2)
 
+#####NEW dataframe fixture for tolerance
+@pytest.fixture(scope='module', name='base_tol')
+def base_tol_fixture(spark):
+    tol_data1 = [
+        Row(account_identifier=10000001234, dollar_amount=123.4, name='Franklin Delano Bluth', float_field=14530.155,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=False),
+        Row(account_identifier=10000001235, dollar_amount=500.0, name='Surely Funke', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=True),
+        Row(account_identifier=10000001236, dollar_amount=-1100.0, name='Nichael Bluth', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=True),
+        Row(account_identifier=10000001237, dollar_amount=0.45, name='Mr. F', float_field=1.0,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=False),
+        Row(account_identifier=10000001238, dollar_amount=1345.0, name='Steve Holt!', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=False),
+        Row(account_identifier=10000001239, dollar_amount=123456.0, name='Blue Man Group', float_field=345.12,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=False),
+        Row(account_identifier=10000001240, dollar_amount=1.1, name='Her?', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=True),
+        Row(account_identifier=10000001241, dollar_amount=0.0, name='Mrs. Featherbottom', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=True),
+        Row(account_identifier=10000001242, dollar_amount=0.0, name='Ice', float_field=345.12,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=False),
+        Row(account_identifier=10000001243, dollar_amount=-10.0, name='Frank Wrench', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=True),
+        Row(account_identifier=10000001244, dollar_amount=None, name='Lucille 2', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=True),
+        Row(account_identifier=10000001245, dollar_amount=0.009999, name='Gene Parmesan', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=True),
+        Row(account_identifier=10000001246, dollar_amount=None, name='Motherboy', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=True)
+    ]
+
+    return spark.createDataFrame(tol_data1)
+
+@pytest.fixture(scope='module', name='compare_abs_tol')
+def compare_tol2_fixture(spark):
+    tol_data2 = [
+        Row(account_identifier=10000001234, dollar_amount=123.4, name='Franklin Delano Bluth', float_field=14530.155,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=False),#full match
+        Row(account_identifier=10000001235, dollar_amount=500.01, name='Surely Funke', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=True),#off by 0.01
+        Row(account_identifier=10000001236, dollar_amount=-1100.01, name='Nichael Bluth', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=True),#off by -0.01
+        Row(account_identifier=10000001237, dollar_amount=0.46000000001, name='Mr. F', float_field=1.0,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=False),#off by 0.01000000001
+        Row(account_identifier=10000001238, dollar_amount=1344.8999999999, name='Steve Holt!', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=False),#off by -0.01000000001
+        Row(account_identifier=10000001239, dollar_amount=123456.0099999999, name='Blue Man Group', float_field=345.12,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=False),#off by 0.00999999999
+        Row(account_identifier=10000001240, dollar_amount=1.090000001, name='Her?', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=True), #off by -0.00999999999
+        Row(account_identifier=10000001241, dollar_amount=0.0, name='Mrs. Featherbottom', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=True),#both zero
+        Row(account_identifier=10000001242, dollar_amount=1.0, name='Ice', float_field=345.12,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=False),#base 0, compare 1
+        Row(account_identifier=10000001243, dollar_amount=0.0, name='Frank Wrench', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=True), #base -10, compare 0
+        Row(account_identifier=10000001244, dollar_amount=-1.0, name='Lucille 2', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=True), #base NULL, compare -1
+        Row(account_identifier=10000001245, dollar_amount=None, name='Gene Parmesan', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=True), #base 0.009999, compare NULL
+        Row(account_identifier=10000001246, dollar_amount=None, name='Motherboy', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=True) #both NULL
+    ]
+
+    return spark.createDataFrame(tol_data2)
+
+@pytest.fixture(scope='module', name='compare_rel_tol')
+def compare_tol3_fixture(spark):
+    tol_data3 = [
+        Row(account_identifier=10000001234, dollar_amount=123.4, name='Franklin Delano Bluth', float_field=14530.155,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=False),#full match   #MATCH
+        Row(account_identifier=10000001235, dollar_amount=550.0, name='Surely Funke', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=True),#off by 10%   #MATCH
+        Row(account_identifier=10000001236, dollar_amount=-1000.0, name='Nichael Bluth', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=True),#off by -10%    #MATCH
+        Row(account_identifier=10000001237, dollar_amount=0.49501, name='Mr. F', float_field=1.0,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=False),#off by greater than 10%
+        Row(account_identifier=10000001238, dollar_amount=1210.001, name='Steve Holt!', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=False),#off by greater than -10%
+        Row(account_identifier=10000001239, dollar_amount=135801.59999, name='Blue Man Group', float_field=345.12,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=False),#off by just under 10%   #MATCH
+        Row(account_identifier=10000001240, dollar_amount=1.000001, name='Her?', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=True), #off by just under -10%   #MATCH
+        Row(account_identifier=10000001241, dollar_amount=0.0, name='Mrs. Featherbottom', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=True),#both zero   #MATCH
+        Row(account_identifier=10000001242, dollar_amount=1.0, name='Ice', float_field=345.12,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=False),#base 0, compare 1
+        Row(account_identifier=10000001243, dollar_amount=0.0, name='Frank Wrench', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=True), #base -10, compare 0
+        Row(account_identifier=10000001244, dollar_amount=-1.0, name='Lucille 2', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=True), #base NULL, compare -1
+        Row(account_identifier=10000001245, dollar_amount=None, name='Gene Parmesan', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=True), #base 0.009999, compare NULL
+        Row(account_identifier=10000001246, dollar_amount=None, name='Motherboy', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=True) #both NULL  #MATCH
+    ]
+
+    return spark.createDataFrame(tol_data3)
+
+
+@pytest.fixture(scope='module', name='compare_both_tol')
+def compare_tol4_fixture(spark):
+    tol_data4 = [
+        Row(account_identifier=10000001234, dollar_amount=123.4, name='Franklin Delano Bluth', float_field=14530.155,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=False),#full match
+        Row(account_identifier=10000001235, dollar_amount=550.01, name='Surely Funke', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=True),#off by 10% and +0.01
+        Row(account_identifier=10000001236, dollar_amount=-1000.01, name='Nichael Bluth', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=True),#off by -10% and -0.01
+        Row(account_identifier=10000001237, dollar_amount=0.505000000001, name='Mr. F', float_field=1.0,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=False),#off by greater than 10% and +0.01
+        Row(account_identifier=10000001238, dollar_amount=1209.98999, name='Steve Holt!', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=False),#off by greater than -10% and -0.01
+        Row(account_identifier=10000001239, dollar_amount=135801.609999, name='Blue Man Group', float_field=345.12,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=False),#off by just under 10% and just under +0.01
+        Row(account_identifier=10000001240, dollar_amount=0.99000001, name='Her?', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=True), #off by just under -10% and just under -0.01
+        Row(account_identifier=10000001241, dollar_amount=0.0, name='Mrs. Featherbottom', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=True),#both zero
+        Row(account_identifier=10000001242, dollar_amount=1.0, name='Ice', float_field=345.12,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=False),#base 0, compare 1
+        Row(account_identifier=10000001243, dollar_amount=0.0, name='Frank Wrench', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=True), #base -10, compare 0
+        Row(account_identifier=10000001244, dollar_amount=-1.0, name='Lucille 2', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=True), #base NULL, compare -1
+        Row(account_identifier=10000001245, dollar_amount=None, name='Gene Parmesan', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=True), #base 0.009999, compare NULL
+        Row(account_identifier=10000001246, dollar_amount=None, name='Motherboy', float_field=None,
+            date_field=datetime.date(2017, 1, 1), accnt_purge=True) #both NULL
+    ]
+
+    return spark.createDataFrame(tol_data4)
+###############
+
+
 
 @pytest.fixture(scope='module', name='base_td')
 def base_td_fixture(spark):
@@ -184,6 +320,26 @@ def compare_decimal_fixture(spark):
     ]
 
     return spark.createDataFrame(mock_data)
+
+
+@pytest.fixture(scope='module', name='comparison_abs_tol')
+def comparison_abs_tol_fixture(base_tol, compare_abs_tol, spark):
+    return SparkCompare(spark, base_tol, compare_abs_tol, join_columns=['account_identifier'],abs_tol=0.01)
+
+
+@pytest.fixture(scope='module', name='comparison_rel_tol')
+def comparison_rel_tol_fixture(base_tol, compare_rel_tol, spark):
+    return SparkCompare(spark, base_tol, compare_rel_tol, join_columns=['account_identifier'],rel_tol=0.1)
+
+@pytest.fixture(scope='module', name='comparison_both_tol')
+def comparison_both_tol_fixture(base_tol, compare_both_tol, spark):
+    return SparkCompare(spark, base_tol, compare_both_tol, join_columns=['account_identifier'],rel_tol=0.1,abs_tol=0.01)
+
+@pytest.fixture(scope='module', name='comparison_neg_tol')
+def comparison_neg_tol_fixture(base_tol, compare_both_tol, spark):
+    return SparkCompare(spark, base_tol, compare_both_tol, join_columns=['account_identifier'],rel_tol=-0.2,abs_tol=0.01)
+
+
 
 
 @pytest.fixture(scope='module', name='comparison_kd1')
@@ -253,6 +409,47 @@ def comparison4_fixture(base_df2, compare_df1, spark):
 def comparison_decimal_fixture(base_decimal, compare_decimal, spark):
     return SparkCompare(spark, base_decimal, compare_decimal, join_columns=['acct'])
 
+############### added tests for tolerances
+def test_absolute_tolerances(comparison_abs_tol):
+    stdout = six.StringIO()
+
+    comparison_abs_tol.report(file=stdout)
+    stdout.seek(0)
+    assert '****** Row Comparison ******' in stdout.getvalue()
+    assert 'Number of rows with some columns unequal: 6' in stdout.getvalue()
+    assert 'Number of rows with all columns equal: 7' in stdout.getvalue()
+    assert 'Number of columns compared with some values unequal: 1' in stdout.getvalue()
+    assert 'Number of columns compared with all values equal: 4' in stdout.getvalue()
+
+def test_relative_tolerances(comparison_rel_tol):
+    stdout = six.StringIO()
+
+    comparison_rel_tol.report(file=stdout)
+    stdout.seek(0)
+    assert '****** Row Comparison ******' in stdout.getvalue()
+    assert 'Number of rows with some columns unequal: 6' in stdout.getvalue()
+    assert 'Number of rows with all columns equal: 7' in stdout.getvalue()
+    assert 'Number of columns compared with some values unequal: 1' in stdout.getvalue()
+    assert 'Number of columns compared with all values equal: 4' in stdout.getvalue()
+
+
+def test_both_tolerances(comparison_both_tol):
+    stdout = six.StringIO()
+
+    comparison_both_tol.report(file=stdout)
+    stdout.seek(0)
+    assert '****** Row Comparison ******' in stdout.getvalue()
+    assert 'Number of rows with some columns unequal: 6' in stdout.getvalue()
+    assert 'Number of rows with all columns equal: 7' in stdout.getvalue()
+    assert 'Number of columns compared with some values unequal: 1' in stdout.getvalue()
+    assert 'Number of columns compared with all values equal: 4' in stdout.getvalue()
+
+
+def test_negative_tolerances(comparison_neg_tol):
+    #stdout = six.StringIO()
+    with pytest.raises(ValueError, message="Please enter positive valued tolerances"):
+        comparison_neg_tol.report()#file=stdout)
+        pass
 
 def test_decimal_comparisons():
     true_decimals = ["decimal", "decimal()", "decimal(20, 10)"]


### PR DESCRIPTION
A couple of new features useful for "close enough" data validation have been added.

For this, four new arguments have been added to the sparkCompare object instantiation function:
1) abs_tol allows for absolute match tolerances for numeric values.
2) rel_tol allows for relative match tolerances for numeric values.
3) show_all_columns will show all columns regardless of their match rates(by default, only columns with at least one match rate is shown).
4) match_rates will show a column's match rate as a proportion of matches to total rows for all columns.

Four new tests have also been added to test the tolerance functionality:
1) test_absolute_tolerances tests the absolute tolerances argument using negative values, edge cases and combinations of null values
2) test_relative_tolerances tests the relative tolerances argument using negative values, edge cases and combinations of null values
3) test_both_tolerances tests both tolerances arguments being used simultaneously using negative values, edge cases and combinations of null values.
4) test_negative_tolerances tests whether an error is thrown when a negative tolerance is provided.(it should throw a ValueError with the message "Please enter positive valued tolerances")