### PR TITLE
Removing cap on pandas version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,12 +113,6 @@ Things that are happening behind the scenes
 
 - You can turn on logging to see more detailed logs.
 
-Note on Pandas versions
------------------------
-
-Due to some changes in the Pandas API, we have a range of versions of Pandas that we've tried to
-test on, found in the ``requirements.txt`` file.  Versions of Pandas outside of that range may well
-work, but it's buyer beware.
 
 .. _spark-detail:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 enum34>=1.1.6;python_version<"3.4"
-pandas>=0.19.0,<=0.23.3
+pandas>=0.19.0
 numpy>=1.11.3
 six>=1.10

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import sys
 CURR_DIR = os.path.abspath(os.path.dirname(__file__))
 INSTALL_REQUIRES = [
     'enum34>=1.1.6;python_version<"3.4"',
-    "pandas>=0.19.0,<=0.23.3",
+    "pandas>=0.19.0",
     "numpy>=1.11.3",
     "six>=1.10",
 ]


### PR DESCRIPTION
Flip-flopping on this because I think it's the exception where a version of Pandas wouldn't work, and I don't want this package to be holding a user back.