### PR TITLE
Add datacompy[spark] pip install option

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,5 +3,5 @@ repos:
     rev: stable
     hooks:
     - id: black
-      language_version: python3.6
+      language_version: python3.7
       types: [python]

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
 python:
   - "3.5"
   - "3.6"
+  - "3.7"
 before_install:
   - mkdir -p /opt
   - wget -q -O /opt/spark.tgz https://archive.apache.org/dist/spark/spark-2.4.3/spark-2.4.3-bin-hadoop2.7.tgz

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 jdk: openjdk8
-dist: trusty
+dist: xenial
 cache:
   pip: true
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,11 @@ before_install:
   - rm /opt/spark.tgz
   - export SPARK_HOME=/opt/spark-2.4.3-bin-hadoop2.7
   - export PATH=$PATH:/opt/spark-2.4.3-bin-hadoop2.7/bin
+  - export PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
+  - export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
 install:
   - pip install -r test-requirements.txt
   - pip install pyspark==2.4.3
   - pip install pytest-spark==0.4.5
 script:
-  - jdk_switcher use openjdk8
   - python -m pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,5 @@ install:
   - pip install pyspark==2.4.3
   - pip install pytest-spark==0.4.5
 script:
+  - jdk_switcher use openjdk8
   - python -m pytest

--- a/datacompy/__init__.py
+++ b/datacompy/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Capital One Services, LLC
+# Copyright 2020 Capital One Services, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/datacompy/_version.py
+++ b/datacompy/_version.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Capital One Services, LLC
+# Copyright 2020 Capital One Services, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/datacompy/core.py
+++ b/datacompy/core.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Capital One Services, LLC
+# Copyright 2020 Capital One Services, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/datacompy/core.py
+++ b/datacompy/core.py
@@ -21,11 +21,11 @@ PROC COMPARE in SAS - i.e. human-readable reporting on the difference between
 two dataframes.
 """
 
-import os
 import logging
-from datetime import datetime
-import pandas as pd
+import os
+
 import numpy as np
+import pandas as pd
 
 LOG = logging.getLogger(__name__)
 

--- a/datacompy/sparkcompare.py
+++ b/datacompy/sparkcompare.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Capital One Services, LLC
+# Copyright 2020 Capital One Services, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/datacompy/sparkcompare.py
+++ b/datacompy/sparkcompare.py
@@ -306,9 +306,8 @@ class SparkCompare:
                 'base_or_compare must be BASE or COMPARE, but was "{}"'.format(base_or_compare)
             )
 
-        if (
-            not columns
-        ):  # If there are no columns only in this dataframe, don't display this section
+        # If there are no columns only in this dataframe, don't display this section
+        if not columns:
             return
 
         max_length = max([len(col) for col in columns] + [11])
@@ -522,9 +521,8 @@ class SparkCompare:
 
         # For each column, create a single tuple. This tuple's values correspond to the number of times
         # each match type appears in that column
-        match_data = match_dataframe.agg(*[helper(col) for col in self.columns_compared]).collect()[
-            0
-        ]
+        match_data = match_dataframe.agg(*[helper(col) for col in self.columns_compared]).collect()
+        match_data = match_data[0]
 
         for c in self.columns_compared:
             self.columns_match_dict[c] = match_data[c]

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,16 @@
 from setuptools import setup, find_packages
 import os
-from io import open as iopen
 
 CURR_DIR = os.path.abspath(os.path.dirname(__file__))
-INSTALL_REQUIRES = ["pandas>=0.19.0,!=0.23.*", "numpy>=1.11.3"]
-with iopen(os.path.join(CURR_DIR, "README.rst"), encoding="utf-8") as file_open:
+
+with open(os.path.join(CURR_DIR, "README.rst"), encoding="utf-8") as file_open:
     LONG_DESCRIPTION = file_open.read()
+
+with open("requirements.txt", "r") as requirements_file:
+    raw_requirements = requirements_file.read().strip().split("\n")
+
+INSTALL_REQUIRES = [line for line in raw_requirements if not (line.startswith("#") or line == "")]
+
 
 exec(open("datacompy/_version.py").read())
 
@@ -18,6 +23,7 @@ setup(
     license="Apache-2.0",
     packages=find_packages(),
     install_requires=INSTALL_REQUIRES,
+    extras_require={"spark": ["pyspark>=2.2.0"]},
     package_data={"": ["templates/*"]},
     zip_safe=False,
 )

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Capital One Services, LLC
+# Copyright 2020 Capital One Services, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "datacompy"
-copyright = "2017, Capital One"
+copyright = "2020, Capital One"
 author = "Ian Robertson, Dan Coates, Usman Azhar"
 
 # The version info for the project you're documenting, acts as replacement for

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Capital One Services, LLC
+# Copyright 2020 Capital One Services, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -16,18 +16,20 @@
 """
 Testing out the datacompy functionality
 """
-from datetime import datetime
-from decimal import Decimal
-import pytest
-from pytest import raises
-import datacompy
-import pandas as pd
-from pandas.util.testing import assert_series_equal
-import numpy as np
+import io
 import logging
 import sys
-import io
+from datetime import datetime
+from decimal import Decimal
 from unittest import mock
+
+import numpy as np
+import pandas as pd
+import pytest
+from pandas.util.testing import assert_series_equal
+from pytest import raises
+
+import datacompy
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 

--- a/tests/test_sparkcompare.py
+++ b/tests/test_sparkcompare.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Capital One Services, LLC
+# Copyright 2020 Capital One Services, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_sparkcompare.py
+++ b/tests/test_sparkcompare.py
@@ -1748,7 +1748,7 @@ def test_rows_both_all_returns_all_rows_in_both_dataframes_for_differently_named
     )
 
     assert comparison3.rows_both_all.count() == 5
-    assert expected_df.unionAll(comparison3.rows_both_all).distinct().count() == 5
+    assert expected_df.union(comparison3.rows_both_all).distinct().count() == 5
 
 
 def test_columns_with_unequal_values_text_is_aligned(comparison4):

--- a/tests/test_sparkcompare.py
+++ b/tests/test_sparkcompare.py
@@ -1188,7 +1188,7 @@ def test_column_comparison_outputs_all_columns_equal_for_identical_dataframes(co
 
 
 def test_column_comparison_outputs_number_of_columns_with_differences_for_differently_named_columns(
-    comparison3
+    comparison3,
 ):
     stdout = io.StringIO()
 
@@ -1200,7 +1200,7 @@ def test_column_comparison_outputs_number_of_columns_with_differences_for_differ
 
 
 def test_column_comparison_outputs_number_of_columns_with_differences_for_known_diffs(
-    comparison_kd1
+    comparison_kd1,
 ):
     stdout = io.StringIO()
 
@@ -1219,7 +1219,7 @@ def test_column_comparison_outputs_number_of_columns_with_differences_for_known_
 
 
 def test_column_comparison_outputs_number_of_columns_with_differences_for_custom_known_diffs(
-    comparison_kd2
+    comparison_kd2,
 ):
     stdout = io.StringIO()
 

--- a/tests/test_sparkcompare.py
+++ b/tests/test_sparkcompare.py
@@ -1383,7 +1383,7 @@ def test_rows_both_mismatch_returns_a_dataframe_with_rows_where_variables_mismat
     )
 
     assert comparison1.rows_both_mismatch.count() == 3
-    assert expected_df.unionAll(comparison1.rows_both_mismatch).distinct().count() == 3
+    assert expected_df.union(comparison1.rows_both_mismatch).distinct().count() == 3
 
 
 def test_rows_both_mismatch_only_includes_rows_with_true_mismatches_when_known_diffs_are_present(
@@ -1411,7 +1411,7 @@ def test_rows_both_mismatch_only_includes_rows_with_true_mismatches_when_known_d
     )
 
     assert comparison_kd1.rows_both_mismatch.count() == 1
-    assert expected_df.unionAll(comparison_kd1.rows_both_mismatch).distinct().count() == 1
+    assert expected_df.union(comparison_kd1.rows_both_mismatch).distinct().count() == 1
 
 
 def test_rows_both_all_returns_a_dataframe_with_all_rows_in_both_dataframes(spark, comparison1):
@@ -1477,7 +1477,7 @@ def test_rows_both_all_returns_a_dataframe_with_all_rows_in_both_dataframes(spar
     )
 
     assert comparison1.rows_both_all.count() == 4
-    assert expected_df.unionAll(comparison1.rows_both_all).distinct().count() == 4
+    assert expected_df.union(comparison1.rows_both_all).distinct().count() == 4
 
 
 def test_rows_both_all_shows_known_diffs_flag_and_known_diffs_count_as_matches(
@@ -1569,7 +1569,7 @@ def test_rows_both_all_shows_known_diffs_flag_and_known_diffs_count_as_matches(
     )
 
     assert comparison_kd1.rows_both_all.count() == 5
-    assert expected_df.unionAll(comparison_kd1.rows_both_all).distinct().count() == 5
+    assert expected_df.union(comparison_kd1.rows_both_all).distinct().count() == 5
 
 
 def test_rows_both_all_returns_a_dataframe_with_all_rows_in_identical_dataframes(
@@ -1656,7 +1656,7 @@ def test_rows_both_all_returns_a_dataframe_with_all_rows_in_identical_dataframes
     )
 
     assert comparison2.rows_both_all.count() == 5
-    assert expected_df.unionAll(comparison2.rows_both_all).distinct().count() == 5
+    assert expected_df.union(comparison2.rows_both_all).distinct().count() == 5
 
 
 def test_rows_both_all_returns_all_rows_in_both_dataframes_for_differently_named_columns(


### PR DESCRIPTION
This change allows a user to run `pip install datacompy[spark]` and install datacompy along with its prerequisite for Spark usage (pyspark). Right now, `pip install datacompy` comes with requirements needed for pandas comparisons, but not Spark. That is probably the correct choice to not inconvenience pandas users with a heavy Spark dependency, but forces Spark users to manually account for the dependency. This change intends to be a reasonable compromise of giving users the choice of a one-step installation for datacompy with Spark if desired.

I also included a few housekeeping changes that were easy to make as I ran through the code:
* Update copyright year to present
* Sort imports per best practices
* Run pre-commit black and Travis on Python 3.7*
* Avoid deprecated `unionAll` method in SparkCompare tests
* Eliminate Python 2.7 compatibility code in setup.py
* Pull package requirements from requirements.txt in setup.py to avoid the possibility of the two becoming misaligned
* Minor black-compatible formatting changes in a couple of places

\*I'm not sure if this will cause any CI failures, but the only way to know is to try :)