### PR TITLE
Fixes #59

### DIFF
--- a/datacompy/core.py
+++ b/datacompy/core.py
@@ -231,12 +231,11 @@ class Compare:
             params = {"on": self.join_columns}
 
         if ignore_spaces:
-            self.df1[self.join_columns] = self.df1[self.join_columns].apply(
-                lambda x: x.str.strip() if x.dtype.kind == "O" else x
-            )
-            self.df2[self.join_columns] = self.df2[self.join_columns].apply(
-                lambda x: x.str.strip() if x.dtype.kind == "O" else x
-            )
+            for column in self.join_columns:
+                if self.df1[column].dtype.kind == "O":
+                    self.df1[column] = self.df1[column].str.strip()
+                if self.df2[column].dtype.kind == "O":
+                    self.df2[column] = self.df2[column].str.strip()
 
         outer_join = self.df1.merge(
             self.df2, how="outer", suffixes=("_df1", "_df2"), indicator=True, **params

--- a/datacompy/core.py
+++ b/datacompy/core.py
@@ -61,7 +61,8 @@ class Compare:
     df2_name : str, optional
         A string name for the second dataframe
     ignore_spaces : bool, optional
-        Flag to strip whitespace (including newlines) from string columns
+        Flag to strip whitespace (including newlines) from string columns (including any join
+        columns)
     ignore_case : bool, optional
         Flag to ignore the case of string columns
 
@@ -228,6 +229,14 @@ class Compare:
             params = {"left_index": True, "right_index": True}
         else:
             params = {"on": self.join_columns}
+
+        if ignore_spaces:
+            self.df1[self.join_columns] = self.df1[self.join_columns].apply(
+                lambda x: x.str.strip() if x.dtype.kind == "O" else x
+            )
+            self.df2[self.join_columns] = self.df2[self.join_columns].apply(
+                lambda x: x.str.strip() if x.dtype.kind == "O" else x
+            )
 
         outer_join = self.df1.merge(
             self.df2, how="outer", suffixes=("_df1", "_df2"), indicator=True, **params

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -816,6 +816,41 @@ def test_index_with_joins_with_ignore_case():
     assert compare.intersect_rows_match()
 
 
+def test_strings_with_ignore_spaces_and_join_columns():
+    df1 = pd.DataFrame([{"a": "hi", "b": "A"}, {"a": "bye", "b": "A"}])
+    df2 = pd.DataFrame([{"a": " hi ", "b": "A"}, {"a": " bye ", "b": "A"}])
+    compare = datacompy.Compare(df1, df2, "a", ignore_spaces=False)
+    assert not compare.matches()
+    assert compare.all_columns_match()
+    assert not compare.all_rows_overlap()
+    assert compare.count_matching_rows() == 0
+
+    compare = datacompy.Compare(df1, df2, "a", ignore_spaces=True)
+    assert compare.matches()
+    assert compare.all_columns_match()
+    assert compare.all_rows_overlap()
+    assert compare.intersect_rows_match()
+    assert compare.count_matching_rows() == 2
+
+
+def test_integers_with_ignore_spaces_and_join_columns():
+    df1 = pd.DataFrame([{"a": 1, "b": "A"}, {"a": 2, "b": "A"}])
+    df2 = pd.DataFrame([{"a": 1, "b": "A"}, {"a": 2, "b": "A"}])
+    compare = datacompy.Compare(df1, df2, "a", ignore_spaces=False)
+    assert compare.matches()
+    assert compare.all_columns_match()
+    assert compare.all_rows_overlap()
+    assert compare.intersect_rows_match()
+    assert compare.count_matching_rows() == 2
+
+    compare = datacompy.Compare(df1, df2, "a", ignore_spaces=True)
+    assert compare.matches()
+    assert compare.all_columns_match()
+    assert compare.all_rows_overlap()
+    assert compare.intersect_rows_match()
+    assert compare.count_matching_rows() == 2
+
+
 MAX_DIFF_DF = pd.DataFrame(
     {
         "base": [1, 1, 1, 1, 1],


### PR DESCRIPTION
@jborchma This fixes issues #59 
Just want your thoughts on this. It is a pretty simple fix described below:

Under `_dataframe_merge` we check if `ignore_spaces` is `true`, and apply the `strip` on the `join_colmuns` if it is a `O` dtype object. This is done for `df1` and `df2`

When some calls: `datacompy.Compare(df1, df2, "a", ignore_spaces=False)`
It will ignore spaces essentially on all string columns including the join ones.
