### PR TITLE
py2 note

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -2,6 +2,19 @@
 Installation
 ============
 
+.. note::
+
+    Moving forward ``datacompy`` will not support Python 2. Please make sure you are using Python 3.5+
+
+
+PyPI (basic)
+------------
+
+::
+
+    pip install datacompy
+
+
 A Conda environment or virtual environment is highly recommended:
 
 conda (installs dependencies from Conda)


### PR DESCRIPTION
Wanted to have a note about no longer supporting Python 2, and also made a tweak to include `pip install datacompy` in the install section (which is what most people will use)