### PR TITLE
all mismatches

### DIFF
--- a/datacompy/core.py
+++ b/datacompy/core.py
@@ -434,8 +434,8 @@ class Compare:
         return to_return
 
     def all_mismatch(self):
-        """All mismatches to a file which contains all columns (with ``_match``), and df1 and df2 versions of
-        those columns.
+        """All rows with any columns that have a mismatch. Returns all df1 and df2 versions of the columns and join
+        columns.
 
         Returns
         -------

--- a/datacompy/core.py
+++ b/datacompy/core.py
@@ -24,6 +24,7 @@ two dataframes.
 import logging
 import os
 
+
 import numpy as np
 import pandas as pd
 
@@ -431,6 +432,25 @@ class Compare:
                 column + " (" + self.df2_name + ")",
             ]
         return to_return
+
+    def all_mismatch(self):
+        """All mismatches to a file which contains all columns (with ``_match``), and df1 and df2 versions of
+        those columns.
+
+        Returns
+        -------
+        Pandas.DataFrame
+            All rows of the intersection dataframe, containing any columns, that don't match.
+        """
+        match_list = []
+        return_list = []
+        for col in self.intersect_rows.columns:
+            if col.endswith("_match"):
+                match_list.append(col)
+                return_list.extend([col[:-6] + "_df1", col[:-6] + "_df2"])
+
+        mm_bool = self.intersect_rows[match_list].all(axis="columns")
+        return self.intersect_rows[~mm_bool][self.join_columns + return_list]
 
     def report(self, sample_count=10):
         """Returns a string representation of a report.  The representation can

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -851,6 +851,76 @@ def test_integers_with_ignore_spaces_and_join_columns():
     assert compare.count_matching_rows() == 2
 
 
+def test_sample_mismatch():
+    data1 = """acct_id,dollar_amt,name,float_fld,date_fld
+    10000001234,123.45,George Maharis,14530.1555,2017-01-01
+    10000001235,0.45,Michael Bluth,1,2017-01-01
+    10000001236,1345,George Bluth,,2017-01-01
+    10000001237,123456,Bob Loblaw,345.12,2017-01-01
+    10000001239,1.05,Lucille Bluth,,2017-01-01
+    10000001240,123.45,George Maharis,14530.1555,2017-01-02
+    """
+
+    data2 = """acct_id,dollar_amt,name,float_fld,date_fld
+    10000001234,123.4,George Michael Bluth,14530.155,
+    10000001235,0.45,Michael Bluth,,
+    10000001236,1345,George Bluth,1,
+    10000001237,123456,Robert Loblaw,345.12,
+    10000001238,1.05,Loose Seal Bluth,111,
+    10000001240,123.45,George Maharis,14530.1555,2017-01-02
+    """
+    df1 = pd.read_csv(io.StringIO(data1), sep=",")
+    df2 = pd.read_csv(io.StringIO(data2), sep=",")
+    compare = datacompy.Compare(df1, df2, "acct_id")
+
+    output = compare.sample_mismatch(column="name", sample_count=1)
+    assert output.shape[0] == 1
+    assert (output.name_df1 != output.name_df2).all()
+
+    output = compare.sample_mismatch(column="name", sample_count=2)
+    assert output.shape[0] == 2
+    assert (output.name_df1 != output.name_df2).all()
+
+    output = compare.sample_mismatch(column="name", sample_count=3)
+    assert output.shape[0] == 2
+    assert (output.name_df1 != output.name_df2).all()
+
+
+def test_all_mismatch():
+    data1 = """acct_id,dollar_amt,name,float_fld,date_fld
+    10000001234,123.45,George Maharis,14530.1555,2017-01-01
+    10000001235,0.45,Michael Bluth,1,2017-01-01
+    10000001236,1345,George Bluth,,2017-01-01
+    10000001237,123456,Bob Loblaw,345.12,2017-01-01
+    10000001239,1.05,Lucille Bluth,,2017-01-01
+    10000001240,123.45,George Maharis,14530.1555,2017-01-02
+    """
+
+    data2 = """acct_id,dollar_amt,name,float_fld,date_fld
+    10000001234,123.4,George Michael Bluth,14530.155,
+    10000001235,0.45,Michael Bluth,,
+    10000001236,1345,George Bluth,1,
+    10000001237,123456,Robert Loblaw,345.12,
+    10000001238,1.05,Loose Seal Bluth,111,
+    10000001240,123.45,George Maharis,14530.1555,2017-01-02
+    """
+    df1 = pd.read_csv(io.StringIO(data1), sep=",")
+    df2 = pd.read_csv(io.StringIO(data2), sep=",")
+    compare = datacompy.Compare(df1, df2, "acct_id")
+
+    output = compare.all_mismatch()
+    assert output.shape[0] == 4
+
+    assert (output.name_df1 != output.name_df2).values.sum() == 2
+    assert (~(output.name_df1 != output.name_df2)).values.sum() == 2
+
+    assert (output.dollar_amt_df1 != output.dollar_amt_df2).values.sum() == 1
+    assert (~(output.dollar_amt_df1 != output.dollar_amt_df2)).values.sum() == 3
+
+    assert (output.float_fld_df1 != output.float_fld_df2).values.sum() == 3
+    assert (~(output.float_fld_df1 != output.float_fld_df2)).values.sum() == 1
+
+
 MAX_DIFF_DF = pd.DataFrame(
     {
         "base": [1, 1, 1, 1, 1],


### PR DESCRIPTION
Partially relates back to #43

Expands on `sample_mismatch` to provide a new function called `all_mismatch`. This will provide all rows which mismatch back as a dataframe so users can export, query, or analyze if there are a lot of them. It keeps the join keys and all columns where a "match" was run.

I left out the export part from the original request since from a df you can easily do that in the format you like.