### PR TITLE
Lower casing columns and casting as string

### DIFF
--- a/datacompy/core.py
+++ b/datacompy/core.py
@@ -105,6 +105,7 @@ class Compare:
             self.on_index = False
 
         self._any_dupes = False
+        self.lower = lower
         self.df1 = df1
         self.df2 = df2
         self.df1_name = df1_name
@@ -113,7 +114,6 @@ class Compare:
         self.rel_tol = rel_tol
         self.df1_unq_rows = self.df2_unq_rows = self.intersect_rows = None
         self.column_stats = []
-        self.lower = lower
         self._compare(ignore_spaces, ignore_case)
 
     @property

--- a/datacompy/core.py
+++ b/datacompy/core.py
@@ -92,20 +92,20 @@ class Compare:
         lower=True,
     ):
 
+        self.lower = lower
         if on_index and join_columns is not None:
             raise Exception("Only provide on_index or join_columns")
         elif on_index:
             self.on_index = True
             self.join_columns = []
-        elif isinstance(join_columns, str):
-            self.join_columns = [join_columns.lower()]
+        elif isinstance(join_columns, (str, int, float)):
+            self.join_columns = [str(join_columns).lower() if self.lower else str(join_columns)]
             self.on_index = False
         else:
-            self.join_columns = [col.lower() for col in join_columns]
+            self.join_columns = [str(col).lower() if self.lower else str(col) for col in join_columns]
             self.on_index = False
 
         self._any_dupes = False
-        self.lower = lower
         self.df1 = df1
         self.df2 = df2
         self.df1_name = df1_name

--- a/datacompy/core.py
+++ b/datacompy/core.py
@@ -99,10 +99,15 @@ class Compare:
             self.on_index = True
             self.join_columns = []
         elif isinstance(join_columns, (str, int, float)):
-            self.join_columns = [str(join_columns).lower() if self.cast_column_names_lower else str(join_columns)]
+            self.join_columns = [
+                str(join_columns).lower() if self.cast_column_names_lower else str(join_columns)
+            ]
             self.on_index = False
         else:
-            self.join_columns = [str(col).lower() if self.cast_column_names_lower else str(col) for col in join_columns]
+            self.join_columns = [
+                str(col).lower() if self.cast_column_names_lower else str(col)
+                for col in join_columns
+            ]
             self.on_index = False
 
         self._any_dupes = False

--- a/datacompy/core.py
+++ b/datacompy/core.py
@@ -66,7 +66,7 @@ class Compare:
         columns)
     ignore_case : bool, optional
         Flag to ignore the case of string columns
-    lower: bool, optional
+    cast_column_names_lower: bool, optional
         Boolean indicator that controls of column names will be cast into lower case
 
     Attributes
@@ -89,20 +89,20 @@ class Compare:
         df2_name="df2",
         ignore_spaces=False,
         ignore_case=False,
-        lower=True,
+        cast_column_names_lower=True,
     ):
 
-        self.lower = lower
+        self.cast_column_names_lower = cast_column_names_lower
         if on_index and join_columns is not None:
             raise Exception("Only provide on_index or join_columns")
         elif on_index:
             self.on_index = True
             self.join_columns = []
         elif isinstance(join_columns, (str, int, float)):
-            self.join_columns = [str(join_columns).lower() if self.lower else str(join_columns)]
+            self.join_columns = [str(join_columns).lower() if self.cast_column_names_lower else str(join_columns)]
             self.on_index = False
         else:
-            self.join_columns = [str(col).lower() if self.lower else str(col) for col in join_columns]
+            self.join_columns = [str(col).lower() if self.cast_column_names_lower else str(col) for col in join_columns]
             self.on_index = False
 
         self._any_dupes = False
@@ -124,7 +124,7 @@ class Compare:
     def df1(self, df1):
         """Check that it is a dataframe and has the join columns"""
         self._df1 = df1
-        self._validate_dataframe("df1", lower=self.lower)
+        self._validate_dataframe("df1", cast_column_names_lower=self.cast_column_names_lower)
 
     @property
     def df2(self):
@@ -134,24 +134,26 @@ class Compare:
     def df2(self, df2):
         """Check that it is a dataframe and has the join columns"""
         self._df2 = df2
-        self._validate_dataframe("df2", lower=self.lower)
+        self._validate_dataframe("df2", cast_column_names_lower=self.cast_column_names_lower)
 
-    def _validate_dataframe(self, index, lower=True):
+    def _validate_dataframe(self, index, cast_column_names_lower=True):
         """Check that it is a dataframe and has the join columns
 
         Parameters
         ----------
         index : str
             The "index" of the dataframe - df1 or df2.
-        lower: bool, optional
+        cast_column_names_lower: bool, optional
             Boolean indicator that controls of column names will be cast into lower case
         """
         dataframe = getattr(self, index)
         if not isinstance(dataframe, pd.DataFrame):
             raise TypeError("{} must be a pandas DataFrame".format(index))
 
-        if lower:
+        if cast_column_names_lower:
             dataframe.columns = [str(col).lower() for col in dataframe.columns]
+        else:
+            dataframe.columns = [str(col) for col in dataframe.columns]
         # Check if join_columns are present in the dataframe
         if not set(self.join_columns).issubset(set(dataframe.columns)):
             raise ValueError("{} must have all columns from join_columns".format(index))

--- a/datacompy/core.py
+++ b/datacompy/core.py
@@ -66,6 +66,8 @@ class Compare:
         columns)
     ignore_case : bool, optional
         Flag to ignore the case of string columns
+    lower: bool, optional
+        Boolean indicator that controls of column names will be cast into lower case
 
     Attributes
     ----------
@@ -87,6 +89,7 @@ class Compare:
         df2_name="df2",
         ignore_spaces=False,
         ignore_case=False,
+        lower=True,
     ):
 
         if on_index and join_columns is not None:
@@ -110,6 +113,7 @@ class Compare:
         self.rel_tol = rel_tol
         self.df1_unq_rows = self.df2_unq_rows = self.intersect_rows = None
         self.column_stats = []
+        self.lower = lower
         self._compare(ignore_spaces, ignore_case)
 
     @property
@@ -120,7 +124,7 @@ class Compare:
     def df1(self, df1):
         """Check that it is a dataframe and has the join columns"""
         self._df1 = df1
-        self._validate_dataframe("df1")
+        self._validate_dataframe("df1", lower=self.lower)
 
     @property
     def df2(self):
@@ -130,21 +134,24 @@ class Compare:
     def df2(self, df2):
         """Check that it is a dataframe and has the join columns"""
         self._df2 = df2
-        self._validate_dataframe("df2")
+        self._validate_dataframe("df2", lower=self.lower)
 
-    def _validate_dataframe(self, index):
+    def _validate_dataframe(self, index, lower=True):
         """Check that it is a dataframe and has the join columns
 
         Parameters
         ----------
         index : str
             The "index" of the dataframe - df1 or df2.
+        lower: bool, optional
+            Boolean indicator that controls of column names will be cast into lower case
         """
         dataframe = getattr(self, index)
         if not isinstance(dataframe, pd.DataFrame):
             raise TypeError("{} must be a pandas DataFrame".format(index))
 
-        dataframe.columns = [col.lower() for col in dataframe.columns]
+        if lower:
+            dataframe.columns = [str(col).lower() for col in dataframe.columns]
         # Check if join_columns are present in the dataframe
         if not set(self.join_columns).issubset(set(dataframe.columns)):
             raise ValueError("{} must have all columns from join_columns".format(index))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1015,3 +1015,25 @@ def test_lower():
     df2 = pd.DataFrame({"a": [1, 2, 3], "B": [0, 1, 2]})
     compare = datacompy.Compare(df1, df2, join_columns=["a"], lower=False)
     assert not compare.matches()
+
+    # test join column
+    # should match
+    df1 = pd.DataFrame({"a": [1, 2, 3], "b": [0, 1, 2]})
+    df2 = pd.DataFrame({"A": [1, 2, 3], "B": [0, 1, 2]})
+    compare = datacompy.Compare(df1, df2, join_columns=["a"])
+    assert compare.matches()
+    # should fail because "a" is not found in df2
+    df1 = pd.DataFrame({"a": [1, 2, 3], "b": [0, 1, 2]})
+    df2 = pd.DataFrame({"A": [1, 2, 3], "B": [0, 1, 2]})
+    expected_message = "df2 must have all columns from join_columns"
+    with raises(ValueError, match=expected_message):
+        compare = datacompy.Compare(df1, df2, join_columns=["a"], lower=False)
+
+
+def test_integer_column_names():
+    """This function tests that integer column names would also work
+    """
+    df1 = pd.DataFrame({1: [1, 2, 3], 2: [0, 1, 2]})
+    df2 = pd.DataFrame({1: [1, 2, 3], 2: [0, 1, 2]})
+    compare = datacompy.Compare(df1, df2, join_columns=[1])
+    assert compare.matches()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1000,3 +1000,18 @@ def test_generate_id_within_group(dataframe, expected):
 def test_generate_id_within_group_valueerror(dataframe, message):
     with raises(ValueError, match=message):
         datacompy.core.generate_id_within_group(dataframe, ["a", "b"])
+
+
+def test_lower():
+    """This function tests the toggle to use lower case for column names or not
+    """
+    # should match
+    df1 = pd.DataFrame({"a": [1, 2, 3], "b": [0, 1, 2]})
+    df2 = pd.DataFrame({"a": [1, 2, 3], "B": [0, 1, 2]})
+    compare = datacompy.Compare(df1, df2, join_columns=["a"])
+    assert compare.matches()
+    # should not match
+    df1 = pd.DataFrame({"a": [1, 2, 3], "b": [0, 1, 2]})
+    df2 = pd.DataFrame({"a": [1, 2, 3], "B": [0, 1, 2]})
+    compare = datacompy.Compare(df1, df2, join_columns=["a"], lower=False)
+    assert not compare.matches()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1013,7 +1013,7 @@ def test_lower():
     # should not match
     df1 = pd.DataFrame({"a": [1, 2, 3], "b": [0, 1, 2]})
     df2 = pd.DataFrame({"a": [1, 2, 3], "B": [0, 1, 2]})
-    compare = datacompy.Compare(df1, df2, join_columns=["a"], lower=False)
+    compare = datacompy.Compare(df1, df2, join_columns=["a"], cast_column_names_lower=False)
     assert not compare.matches()
 
     # test join column
@@ -1027,7 +1027,7 @@ def test_lower():
     df2 = pd.DataFrame({"A": [1, 2, 3], "B": [0, 1, 2]})
     expected_message = "df2 must have all columns from join_columns"
     with raises(ValueError, match=expected_message):
-        compare = datacompy.Compare(df1, df2, join_columns=["a"], lower=False)
+        compare = datacompy.Compare(df1, df2, join_columns=["a"], cast_column_names_lower=False)
 
 
 def test_integer_column_names():


### PR DESCRIPTION
In this PR I am addressing both #68 and #67. I have implemented the following things:

I have added a new attribute called `lower` that will toggle casting the column names to lower. The default is `True`, so nothing should change unless specified.

Further, I have added that column names are cast to strings in the internal dataframes. 

I have also added testing for both features.