### PR TITLE
Suppress "Sample Rows" section in the output report if sample_count=0

### DIFF
--- a/datacompy/core.py
+++ b/datacompy/core.py
@@ -571,14 +571,15 @@ class Compare:
             ].to_string()
             report += "\n\n"
 
-            report += "Sample Rows with Unequal Values\n"
-            report += "-------------------------------\n"
-            report += "\n"
-            for sample in match_sample:
-                report += sample.to_string()
-                report += "\n\n"
+            if sample_count > 0:
+                report += "Sample Rows with Unequal Values\n"
+                report += "-------------------------------\n"
+                report += "\n"
+                for sample in match_sample:
+                    report += sample.to_string()
+                    report += "\n\n"
 
-        if self.df1_unq_rows.shape[0] > 0:
+        if min(sample_count, self.df1_unq_rows.shape[0]) > 0:
             report += "Sample Rows Only in {} (First 10 Columns)\n".format(self.df1_name)
             report += "---------------------------------------{}\n".format("-" * len(self.df1_name))
             report += "\n"
@@ -587,7 +588,7 @@ class Compare:
             report += self.df1_unq_rows.sample(unq_count)[columns].to_string()
             report += "\n\n"
 
-        if self.df2_unq_rows.shape[0] > 0:
+        if min(sample_count, self.df2_unq_rows.shape[0]) > 0:
             report += "Sample Rows Only in {} (First 10 Columns)\n".format(self.df2_name)
             report += "---------------------------------------{}\n".format("-" * len(self.df2_name))
             report += "\n"


### PR DESCRIPTION
Currently, if the sample_count parameter in the report() method is set to 0, the comparison report still prints an empty data frame object, which can be confusing to the end user.  This pull request is for a minor change to the report() method to suppress the "Sample Rows" section of the output report entirely if sample_count = 0.