### PR TITLE
Make column order in reports determinitistic (alphabetical)

### DIFF
--- a/datacompy/core.py
+++ b/datacompy/core.py
@@ -297,7 +297,7 @@ class Compare:
         """
         LOG.debug("Comparing intersection")
         row_cnt = len(self.intersect_rows)
-        for column in self.intersect_columns():
+        for column in sorted(self.intersect_columns()):
             if column in self.join_columns:
                 match_cnt = row_cnt
                 col_match = ""
@@ -369,7 +369,7 @@ class Compare:
             Number of matching rows
         """
         match_columns = []
-        for column in self.intersect_columns():
+        for column in sorted(self.intersect_columns()):
             if column not in self.join_columns:
                 match_columns.append(column + "_match")
         return self.intersect_rows[match_columns].all(axis=1).sum()

--- a/tests/test_sparkcompare.py
+++ b/tests/test_sparkcompare.py
@@ -45,7 +45,7 @@ CACHE_INTERMEDIATES = True
 # (if we need to use these in other modules, move to conftest.py)
 @pytest.fixture(scope="module", name="spark")
 def spark_fixture():
-    spark = SparkSession.builder.master("local[2]").appName("pytest").getOrCreate()
+    spark = SparkSession.builder.master("local[2]").config("spark.driver.bindAddress", "127.0.0.1").appName("pytest").getOrCreate()
     yield spark
     spark.stop()
 


### PR DESCRIPTION
Sort the column intersection before using them in inspections.

Fixes #81 