### PR TITLE
Use OrderedSet to maintain DataFrame column order through set operations

### DIFF
--- a/datacompy/core.py
+++ b/datacompy/core.py
@@ -28,6 +28,8 @@ import os
 import numpy as np
 import pandas as pd
 
+from ordered_set import OrderedSet
+
 LOG = logging.getLogger(__name__)
 
 
@@ -203,15 +205,15 @@ class Compare:
 
     def df1_unq_columns(self):
         """Get columns that are unique to df1"""
-        return set(self.df1.columns) - set(self.df2.columns)
+        return OrderedSet(self.df1.columns) - OrderedSet(self.df2.columns)
 
     def df2_unq_columns(self):
         """Get columns that are unique to df2"""
-        return set(self.df2.columns) - set(self.df1.columns)
+        return OrderedSet(self.df2.columns) - OrderedSet(self.df1.columns)
 
     def intersect_columns(self):
         """Get columns that are shared between the two dataframes"""
-        return set(self.df1.columns) & set(self.df2.columns)
+        return OrderedSet(self.df1.columns) & OrderedSet(self.df2.columns)
 
     def _dataframe_merge(self, ignore_spaces):
         """Merge df1 to df2 on the join columns, to get df1 - df2, df2 - df1
@@ -297,7 +299,7 @@ class Compare:
         """
         LOG.debug("Comparing intersection")
         row_cnt = len(self.intersect_rows)
-        for column in sorted(self.intersect_columns()):
+        for column in self.intersect_columns():
             if column in self.join_columns:
                 match_cnt = row_cnt
                 col_match = ""
@@ -369,7 +371,7 @@ class Compare:
             Number of matching rows
         """
         match_columns = []
-        for column in sorted(self.intersect_columns()):
+        for column in self.intersect_columns():
             if column not in self.join_columns:
                 match_columns.append(column + "_match")
         return self.intersect_rows[match_columns].all(axis=1).sum()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pandas>=0.25.0
 numpy>=1.11.3
+ordered-set>=4.0.2

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -461,6 +461,27 @@ def test_columns_no_overlap():
     assert compare.intersect_columns() == {"a", "b"}
 
 
+def test_columns_maintain_order_through_set_operations():
+    df1 = pd.DataFrame(
+        [
+            (("A"), (0), (1), (2), (3), (4), (-2)),
+            (("B"), (0), (2), (2), (3), (4), (-3))
+        ],
+        columns=["join", "f", "g", "b", "h", "a", "c"]
+    )
+    df2 = pd.DataFrame(
+        [
+            (("A"), (0), (1), (2), (-1), (4), (-3)),
+            (("B"), (1), (2), (3), (-1), (4), (-2))
+        ],
+        columns=["join", "e", "h", "b", "a", "g", "d"]
+    )
+    compare = datacompy.Compare(df1, df2, ["join"])
+    assert list(compare.df1_unq_columns()) == ["f", "c"]
+    assert list(compare.df2_unq_columns()) == ["e", "d"]
+    assert list(compare.intersect_columns()) == ["join", "g", "b", "h", "a"]
+
+
 def test_10k_rows():
     df1 = pd.DataFrame(np.random.randint(0, 100, size=(10000, 2)), columns=["b", "c"])
     df1.reset_index(inplace=True)


### PR DESCRIPTION
@fdosani @KrishanBhasin 

Fixes #81. Iteration on #107. This aims to maintain the original order when printing out the set of common columns as well as unique columns, both which are based on set operations.