### PR TITLE
adding column count, fixes #115

### DIFF
--- a/datacompy/core.py
+++ b/datacompy/core.py
@@ -24,10 +24,8 @@ two dataframes.
 import logging
 import os
 
-
 import numpy as np
 import pandas as pd
-
 from ordered_set import OrderedSet
 
 LOG = logging.getLogger(__name__)
@@ -102,7 +100,9 @@ class Compare:
             self.join_columns = []
         elif isinstance(join_columns, (str, int, float)):
             self.join_columns = [
-                str(join_columns).lower() if self.cast_column_names_lower else str(join_columns)
+                str(join_columns).lower()
+                if self.cast_column_names_lower
+                else str(join_columns)
             ]
             self.on_index = False
         else:
@@ -131,7 +131,9 @@ class Compare:
     def df1(self, df1):
         """Check that it is a dataframe and has the join columns"""
         self._df1 = df1
-        self._validate_dataframe("df1", cast_column_names_lower=self.cast_column_names_lower)
+        self._validate_dataframe(
+            "df1", cast_column_names_lower=self.cast_column_names_lower
+        )
 
     @property
     def df2(self):
@@ -141,7 +143,9 @@ class Compare:
     def df2(self, df2):
         """Check that it is a dataframe and has the join columns"""
         self._df2 = df2
-        self._validate_dataframe("df2", cast_column_names_lower=self.cast_column_names_lower)
+        self._validate_dataframe(
+            "df2", cast_column_names_lower=self.cast_column_names_lower
+        )
 
     def _validate_dataframe(self, index, cast_column_names_lower=True):
         """Check that it is a dataframe and has the join columns
@@ -172,7 +176,9 @@ class Compare:
             if dataframe.index.duplicated().sum() > 0:
                 self._any_dupes = True
         else:
-            if len(dataframe.drop_duplicates(subset=self.join_columns)) < len(dataframe):
+            if len(dataframe.drop_duplicates(subset=self.join_columns)) < len(
+                dataframe
+            ):
                 self._any_dupes = True
 
     def _compare(self, ignore_spaces, ignore_case):
@@ -187,14 +193,24 @@ class Compare:
             LOG.info("df1 Pandas.DataFrame.equals df2")
         else:
             LOG.info("df1 does not Pandas.DataFrame.equals df2")
-        LOG.info("Number of columns in common: {}".format(len(self.intersect_columns())))
+        LOG.info(
+            "Number of columns in common: {}".format(len(self.intersect_columns()))
+        )
         LOG.debug("Checking column overlap")
         for col in self.df1_unq_columns():
             LOG.info("Column in df1 and not in df2: {}".format(col))
-        LOG.info("Number of columns in df1 and not in df2: {}".format(len(self.df1_unq_columns())))
+        LOG.info(
+            "Number of columns in df1 and not in df2: {}".format(
+                len(self.df1_unq_columns())
+            )
+        )
         for col in self.df2_unq_columns():
             LOG.info("Column in df2 and not in df1: {}".format(col))
-        LOG.info("Number of columns in df2 and not in df1: {}".format(len(self.df2_unq_columns())))
+        LOG.info(
+            "Number of columns in df2 and not in df1: {}".format(
+                len(self.df2_unq_columns())
+            )
+        )
         LOG.debug("Merging dataframes")
         self._dataframe_merge(ignore_spaces)
         self._intersect_compare(ignore_spaces, ignore_case)
@@ -237,8 +253,12 @@ class Compare:
 
             # Create order column for uniqueness of match
             order_column = temp_column_name(self.df1, self.df2)
-            self.df1[order_column] = generate_id_within_group(self.df1, temp_join_columns)
-            self.df2[order_column] = generate_id_within_group(self.df2, temp_join_columns)
+            self.df1[order_column] = generate_id_within_group(
+                self.df1, temp_join_columns
+            )
+            self.df2[order_column] = generate_id_within_group(
+                self.df2, temp_join_columns
+            )
             temp_join_columns.append(order_column)
 
             params = {"on": temp_join_columns}
@@ -273,14 +293,22 @@ class Compare:
         df2_cols = get_merged_columns(self.df2, outer_join, "_df2")
 
         LOG.debug("Selecting df1 unique rows")
-        self.df1_unq_rows = outer_join[outer_join["_merge"] == "left_only"][df1_cols].copy()
+        self.df1_unq_rows = outer_join[outer_join["_merge"] == "left_only"][
+            df1_cols
+        ].copy()
         self.df1_unq_rows.columns = self.df1.columns
 
         LOG.debug("Selecting df2 unique rows")
-        self.df2_unq_rows = outer_join[outer_join["_merge"] == "right_only"][df2_cols].copy()
+        self.df2_unq_rows = outer_join[outer_join["_merge"] == "right_only"][
+            df2_cols
+        ].copy()
         self.df2_unq_rows.columns = self.df2.columns
-        LOG.info("Number of rows in df1 and not in df2: {}".format(len(self.df1_unq_rows)))
-        LOG.info("Number of rows in df2 and not in df1: {}".format(len(self.df2_unq_rows)))
+        LOG.info(
+            "Number of rows in df1 and not in df2: {}".format(len(self.df1_unq_rows))
+        )
+        LOG.info(
+            "Number of rows in df2 and not in df1: {}".format(len(self.df2_unq_rows))
+        )
 
         LOG.debug("Selecting intersecting rows")
         self.intersect_rows = outer_join[outer_join["_merge"] == "both"].copy()
@@ -322,14 +350,19 @@ class Compare:
                     self.intersect_rows[col_1], self.intersect_rows[col_2]
                 )
                 null_diff = (
-                    (self.intersect_rows[col_1].isnull()) ^ (self.intersect_rows[col_2].isnull())
+                    (self.intersect_rows[col_1].isnull())
+                    ^ (self.intersect_rows[col_2].isnull())
                 ).sum()
 
             if row_cnt > 0:
                 match_rate = float(match_cnt) / row_cnt
             else:
                 match_rate = 0
-            LOG.info("{}: {} / {} ({:.2%}) match".format(column, match_cnt, row_cnt, match_rate))
+            LOG.info(
+                "{}: {} / {} ({:.2%}) match".format(
+                    column, match_cnt, row_cnt, match_rate
+                )
+            )
 
             self.column_stats.append(
                 {
@@ -340,7 +373,10 @@ class Compare:
                     "dtype1": str(self.df1[column].dtype),
                     "dtype2": str(self.df2[column].dtype),
                     "all_match": all(
-                        (self.df1[column].dtype == self.df2[column].dtype, row_cnt == match_cnt)
+                        (
+                            self.df1[column].dtype == self.df2[column].dtype,
+                            row_cnt == match_cnt,
+                        )
                     ),
                     "max_diff": max_diff,
                     "null_diff": null_diff,
@@ -468,7 +504,7 @@ class Compare:
         mm_bool = self.intersect_rows[match_list].all(axis="columns")
         return self.intersect_rows[~mm_bool][self.join_columns + return_list]
 
-    def report(self, sample_count=10):
+    def report(self, sample_count=10, column_count=10):
         """Returns a string representation of a report.  The representation can
         then be printed or saved to a file.
 
@@ -476,6 +512,9 @@ class Compare:
         ----------
         sample_count : int, optional
             The number of sample records to return.  Defaults to 10.
+
+        column_count : int, optional
+            The number of columns to display in the sample records output.  Defaults to 10.
 
         Returns
         -------
@@ -551,7 +590,9 @@ class Compare:
                 )
                 if column["unequal_cnt"] > 0:
                     match_sample.append(
-                        self.sample_mismatch(column["column"], sample_count, for_display=True)
+                        self.sample_mismatch(
+                            column["column"], sample_count, for_display=True
+                        )
                     )
 
         if any_mismatch:
@@ -582,19 +623,27 @@ class Compare:
                     report += "\n\n"
 
         if min(sample_count, self.df1_unq_rows.shape[0]) > 0:
-            report += "Sample Rows Only in {} (First 10 Columns)\n".format(self.df1_name)
-            report += "---------------------------------------{}\n".format("-" * len(self.df1_name))
+            report += "Sample Rows Only in {} (First {} Columns)\n".format(
+                self.df1_name, column_count
+            )
+            report += "---------------------------------------{}\n".format(
+                "-" * len(self.df1_name)
+            )
             report += "\n"
-            columns = self.df1_unq_rows.columns[:10]
+            columns = self.df1_unq_rows.columns[:column_count]
             unq_count = min(sample_count, self.df1_unq_rows.shape[0])
             report += self.df1_unq_rows.sample(unq_count)[columns].to_string()
             report += "\n\n"
 
         if min(sample_count, self.df2_unq_rows.shape[0]) > 0:
-            report += "Sample Rows Only in {} (First 10 Columns)\n".format(self.df2_name)
-            report += "---------------------------------------{}\n".format("-" * len(self.df2_name))
+            report += "Sample Rows Only in {} (First {} Columns)\n".format(
+                self.df2_name, column_count
+            )
+            report += "---------------------------------------{}\n".format(
+                "-" * len(self.df2_name)
+            )
             report += "\n"
-            columns = self.df2_unq_rows.columns[:10]
+            columns = self.df2_unq_rows.columns[:column_count]
             unq_count = min(sample_count, self.df2_unq_rows.shape[0])
             report += self.df2_unq_rows.sample(unq_count)[columns].to_string()
             report += "\n\n"
@@ -624,7 +673,9 @@ def render(filename, *fields):
         return file_open.read().format(*fields)
 
 
-def columns_equal(col_1, col_2, rel_tol=0, abs_tol=0, ignore_spaces=False, ignore_case=False):
+def columns_equal(
+    col_1, col_2, rel_tol=0, abs_tol=0, ignore_spaces=False, ignore_case=False
+):
     """Compares two columns from a dataframe, returning a True/False series,
     with the same index as column 1.
 
@@ -658,7 +709,9 @@ def columns_equal(col_1, col_2, rel_tol=0, abs_tol=0, ignore_spaces=False, ignor
         values don't match.
     """
     try:
-        compare = pd.Series(np.isclose(col_1, col_2, rtol=rel_tol, atol=abs_tol, equal_nan=True))
+        compare = pd.Series(
+            np.isclose(col_1, col_2, rtol=rel_tol, atol=abs_tol, equal_nan=True)
+        )
     except TypeError:
         try:
             compare = pd.Series(
@@ -687,7 +740,9 @@ def columns_equal(col_1, col_2, rel_tol=0, abs_tol=0, ignore_spaces=False, ignor
                 if {col_1.dtype.kind, col_2.dtype.kind} == {"M", "O"}:
                     compare = compare_string_and_date_columns(col_1, col_2)
                 else:
-                    compare = pd.Series((col_1 == col_2) | (col_1.isnull() & col_2.isnull()))
+                    compare = pd.Series(
+                        (col_1 == col_2) | (col_1.isnull() & col_2.isnull())
+                    )
             except:
                 # Blanket exception should just return all False
                 compare = pd.Series(False, index=col_1.index)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -173,7 +173,9 @@ def test_date_columns_equal_with_ignore_spaces():
     expect_out = df["expected"]
     assert_series_equal(expect_out, actual_out, check_names=False)
     # and reverse
-    actual_out_rev = datacompy.columns_equal(df.b, df.a, rel_tol=0.2, ignore_spaces=True)
+    actual_out_rev = datacompy.columns_equal(
+        df.b, df.a, rel_tol=0.2, ignore_spaces=True
+    )
     assert_series_equal(expect_out, actual_out_rev, check_names=False)
 
 
@@ -200,13 +202,14 @@ def test_date_columns_equal_with_ignore_spaces_and_case():
     expect_out = df["expected"]
     assert_series_equal(expect_out, actual_out, check_names=False)
     # and reverse
-    actual_out_rev = datacompy.columns_equal(df.b, df.a, rel_tol=0.2, ignore_spaces=True)
+    actual_out_rev = datacompy.columns_equal(
+        df.b, df.a, rel_tol=0.2, ignore_spaces=True
+    )
     assert_series_equal(expect_out, actual_out_rev, check_names=False)
 
 
 def test_date_columns_unequal():
-    """I want datetime fields to match with dates stored as strings
-    """
+    """I want datetime fields to match with dates stored as strings"""
     df = pd.DataFrame([{"a": "2017-01-01", "b": "2017-01-02"}, {"a": "2017-01-01"}])
     df["a_dt"] = pd.to_datetime(df["a"])
     df["b_dt"] = pd.to_datetime(df["b"])
@@ -291,7 +294,11 @@ def test_decimal_columns_equal():
             {"a": Decimal("1"), "b": Decimal("1"), "expected": True},
             {"a": Decimal("1.3"), "b": Decimal("1.3"), "expected": True},
             {"a": Decimal("1.000003"), "b": Decimal("1.000003"), "expected": True},
-            {"a": Decimal("1.000000004"), "b": Decimal("1.000000003"), "expected": False},
+            {
+                "a": Decimal("1.000000004"),
+                "b": Decimal("1.000000003"),
+                "expected": False,
+            },
             {"a": Decimal("1.3"), "b": Decimal("1.2"), "expected": False},
             {"a": np.nan, "b": np.nan, "expected": True},
             {"a": np.nan, "b": Decimal("1"), "expected": False},
@@ -309,7 +316,11 @@ def test_decimal_columns_equal_rel():
             {"a": Decimal("1"), "b": Decimal("1"), "expected": True},
             {"a": Decimal("1.3"), "b": Decimal("1.3"), "expected": True},
             {"a": Decimal("1.000003"), "b": Decimal("1.000003"), "expected": True},
-            {"a": Decimal("1.000000004"), "b": Decimal("1.000000003"), "expected": True},
+            {
+                "a": Decimal("1.000000004"),
+                "b": Decimal("1.000000003"),
+                "expected": True,
+            },
             {"a": Decimal("1.3"), "b": Decimal("1.2"), "expected": False},
             {"a": np.nan, "b": np.nan, "expected": True},
             {"a": np.nan, "b": Decimal("1"), "expected": False},
@@ -383,7 +394,9 @@ def test_mixed_column_with_ignore_spaces_and_case():
             {"a": "hi", "b": "hi ", "expected": True},
         ]
     )
-    actual_out = datacompy.columns_equal(df.a, df.b, ignore_spaces=True, ignore_case=True)
+    actual_out = datacompy.columns_equal(
+        df.a, df.b, ignore_spaces=True, ignore_case=True
+    )
     expect_out = df["expected"]
     assert_series_equal(expect_out, actual_out, check_names=False)
 
@@ -465,16 +478,16 @@ def test_columns_maintain_order_through_set_operations():
     df1 = pd.DataFrame(
         [
             (("A"), (0), (1), (2), (3), (4), (-2)),
-            (("B"), (0), (2), (2), (3), (4), (-3))
+            (("B"), (0), (2), (2), (3), (4), (-3)),
         ],
-        columns=["join", "f", "g", "b", "h", "a", "c"]
+        columns=["join", "f", "g", "b", "h", "a", "c"],
     )
     df2 = pd.DataFrame(
         [
             (("A"), (0), (1), (2), (-1), (4), (-3)),
-            (("B"), (1), (2), (3), (-1), (4), (-2))
+            (("B"), (1), (2), (3), (-1), (4), (-2)),
         ],
-        columns=["join", "e", "h", "b", "a", "g", "d"]
+        columns=["join", "e", "h", "b", "a", "g", "d"],
     )
     compare = datacompy.Compare(df1, df2, ["join"])
     assert list(compare.df1_unq_columns()) == ["f", "c"]
@@ -591,7 +604,9 @@ def test_index_joining_strings_i_guess():
 
 def test_index_joining_non_overlapping():
     df1 = pd.DataFrame([{"a": "hi", "b": 2}, {"a": "bye", "b": 2}])
-    df2 = pd.DataFrame([{"a": "hi", "b": 2}, {"a": "bye", "b": 2}, {"a": "back fo mo", "b": 3}])
+    df2 = pd.DataFrame(
+        [{"a": "hi", "b": 2}, {"a": "bye", "b": 2}, {"a": "back fo mo", "b": 3}]
+    )
     compare = datacompy.Compare(df1, df2, on_index=True)
     assert not compare.matches()
     assert compare.all_columns_match()
@@ -603,22 +618,17 @@ def test_index_joining_non_overlapping():
 
 def test_temp_column_name():
     df1 = pd.DataFrame([{"a": "hi", "b": 2}, {"a": "bye", "b": 2}])
-    df2 = pd.DataFrame([{"a": "hi", "b": 2}, {"a": "bye", "b": 2}, {"a": "back fo mo", "b": 3}])
+    df2 = pd.DataFrame(
+        [{"a": "hi", "b": 2}, {"a": "bye", "b": 2}, {"a": "back fo mo", "b": 3}]
+    )
     actual = datacompy.temp_column_name(df1, df2)
     assert actual == "_temp_0"
 
 
 def test_temp_column_name_one_has():
     df1 = pd.DataFrame([{"_temp_0": "hi", "b": 2}, {"_temp_0": "bye", "b": 2}])
-    df2 = pd.DataFrame([{"a": "hi", "b": 2}, {"a": "bye", "b": 2}, {"a": "back fo mo", "b": 3}])
-    actual = datacompy.temp_column_name(df1, df2)
-    assert actual == "_temp_1"
-
-
-def test_temp_column_name_both_have():
-    df1 = pd.DataFrame([{"_temp_0": "hi", "b": 2}, {"_temp_0": "bye", "b": 2}])
     df2 = pd.DataFrame(
-        [{"_temp_0": "hi", "b": 2}, {"_temp_0": "bye", "b": 2}, {"a": "back fo mo", "b": 3}]
+        [{"a": "hi", "b": 2}, {"a": "bye", "b": 2}, {"a": "back fo mo", "b": 3}]
     )
     actual = datacompy.temp_column_name(df1, df2)
     assert actual == "_temp_1"
@@ -627,7 +637,24 @@ def test_temp_column_name_both_have():
 def test_temp_column_name_both_have():
     df1 = pd.DataFrame([{"_temp_0": "hi", "b": 2}, {"_temp_0": "bye", "b": 2}])
     df2 = pd.DataFrame(
-        [{"_temp_0": "hi", "b": 2}, {"_temp_1": "bye", "b": 2}, {"a": "back fo mo", "b": 3}]
+        [
+            {"_temp_0": "hi", "b": 2},
+            {"_temp_0": "bye", "b": 2},
+            {"a": "back fo mo", "b": 3},
+        ]
+    )
+    actual = datacompy.temp_column_name(df1, df2)
+    assert actual == "_temp_1"
+
+
+def test_temp_column_name_both_have():
+    df1 = pd.DataFrame([{"_temp_0": "hi", "b": 2}, {"_temp_0": "bye", "b": 2}])
+    df2 = pd.DataFrame(
+        [
+            {"_temp_0": "hi", "b": 2},
+            {"_temp_1": "bye", "b": 2},
+            {"a": "back fo mo", "b": 3},
+        ]
     )
     actual = datacompy.temp_column_name(df1, df2)
     assert actual == "_temp_2"
@@ -636,7 +663,11 @@ def test_temp_column_name_both_have():
 def test_temp_column_name_one_already():
     df1 = pd.DataFrame([{"_temp_1": "hi", "b": 2}, {"_temp_1": "bye", "b": 2}])
     df2 = pd.DataFrame(
-        [{"_temp_1": "hi", "b": 2}, {"_temp_1": "bye", "b": 2}, {"a": "back fo mo", "b": 3}]
+        [
+            {"_temp_1": "hi", "b": 2},
+            {"_temp_1": "bye", "b": 2},
+            {"a": "back fo mo", "b": 3},
+        ]
     )
     actual = datacompy.temp_column_name(df1, df2)
     assert actual == "_temp_0"
@@ -705,6 +736,9 @@ def test_simple_dupes_one_field_three_to_two_vals():
     # Just render the report to make sure it renders.
     t = compare.report()
 
+    assert "(First 1 Columns)" in compare.report(column_count=1)
+    assert "(First 2 Columns)" in compare.report(column_count=2)
+
 
 def test_dupes_from_real_data():
     data = """acct_id,acct_sfx_num,trxn_post_dt,trxn_post_seq_num,trxn_amt,trxn_dt,debit_cr_cd,cash_adv_trxn_comn_cntry_cd,mrch_catg_cd,mrch_pstl_cd,visa_mail_phn_cd,visa_rqstd_pmt_svc_cd,mc_pmt_facilitator_idn_num
@@ -733,7 +767,9 @@ def test_dupes_from_real_data():
     compare_acct = datacompy.Compare(df1, df2, join_columns=["acct_id"])
     assert compare_acct.matches()
     compare_unq = datacompy.Compare(
-        df1, df2, join_columns=["acct_id", "acct_sfx_num", "trxn_post_dt", "trxn_post_seq_num"]
+        df1,
+        df2,
+        join_columns=["acct_id", "acct_sfx_num", "trxn_post_dt", "trxn_post_seq_num"],
     )
     assert compare_unq.matches()
     # Just render the report to make sure it renders.
@@ -986,7 +1022,9 @@ def test_dupes_with_nulls():
             "fld_2": ["A", np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
         }
     )
-    df2 = pd.DataFrame({"fld_1": [1, 2, 3, 4, 5], "fld_2": ["A", np.nan, np.nan, np.nan, np.nan]})
+    df2 = pd.DataFrame(
+        {"fld_1": [1, 2, 3, 4, 5], "fld_2": ["A", np.nan, np.nan, np.nan, np.nan]}
+    )
     comp = datacompy.Compare(df1, df2, join_columns=["fld_1", "fld_2"])
     assert comp.subset()
 
@@ -995,18 +1033,31 @@ def test_dupes_with_nulls():
     "dataframe,expected",
     [
         (pd.DataFrame({"a": [1, 2, 3], "b": [1, 2, 3]}), pd.Series([0, 0, 0])),
-        (pd.DataFrame({"a": ["a", "a", "DATACOMPY_NULL"], "b": [1, 1, 2]}), pd.Series([0, 1, 0])),
-        (pd.DataFrame({"a": [-999, 2, 3], "b": [1, 2, 3]}), pd.Series([0, 0, 0])),
-        (pd.DataFrame({"a": [1, np.nan, np.nan], "b": [1, 2, 2]}), pd.Series([0, 0, 1])),
-        (pd.DataFrame({"a": ["1", np.nan, np.nan], "b": ["1", "2", "2"]}), pd.Series([0, 0, 1])),
         (
-            pd.DataFrame({"a": [datetime(2018, 1, 1), np.nan, np.nan], "b": ["1", "2", "2"]}),
+            pd.DataFrame({"a": ["a", "a", "DATACOMPY_NULL"], "b": [1, 1, 2]}),
+            pd.Series([0, 1, 0]),
+        ),
+        (pd.DataFrame({"a": [-999, 2, 3], "b": [1, 2, 3]}), pd.Series([0, 0, 0])),
+        (
+            pd.DataFrame({"a": [1, np.nan, np.nan], "b": [1, 2, 2]}),
+            pd.Series([0, 0, 1]),
+        ),
+        (
+            pd.DataFrame({"a": ["1", np.nan, np.nan], "b": ["1", "2", "2"]}),
+            pd.Series([0, 0, 1]),
+        ),
+        (
+            pd.DataFrame(
+                {"a": [datetime(2018, 1, 1), np.nan, np.nan], "b": ["1", "2", "2"]}
+            ),
             pd.Series([0, 0, 1]),
         ),
     ],
 )
 def test_generate_id_within_group(dataframe, expected):
-    assert (datacompy.core.generate_id_within_group(dataframe, ["a", "b"]) == expected).all()
+    assert (
+        datacompy.core.generate_id_within_group(dataframe, ["a", "b"]) == expected
+    ).all()
 
 
 @pytest.mark.parametrize(
@@ -1024,8 +1075,7 @@ def test_generate_id_within_group_valueerror(dataframe, message):
 
 
 def test_lower():
-    """This function tests the toggle to use lower case for column names or not
-    """
+    """This function tests the toggle to use lower case for column names or not"""
     # should match
     df1 = pd.DataFrame({"a": [1, 2, 3], "b": [0, 1, 2]})
     df2 = pd.DataFrame({"a": [1, 2, 3], "B": [0, 1, 2]})
@@ -1034,7 +1084,9 @@ def test_lower():
     # should not match
     df1 = pd.DataFrame({"a": [1, 2, 3], "b": [0, 1, 2]})
     df2 = pd.DataFrame({"a": [1, 2, 3], "B": [0, 1, 2]})
-    compare = datacompy.Compare(df1, df2, join_columns=["a"], cast_column_names_lower=False)
+    compare = datacompy.Compare(
+        df1, df2, join_columns=["a"], cast_column_names_lower=False
+    )
     assert not compare.matches()
 
     # test join column
@@ -1048,12 +1100,13 @@ def test_lower():
     df2 = pd.DataFrame({"A": [1, 2, 3], "B": [0, 1, 2]})
     expected_message = "df2 must have all columns from join_columns"
     with raises(ValueError, match=expected_message):
-        compare = datacompy.Compare(df1, df2, join_columns=["a"], cast_column_names_lower=False)
+        compare = datacompy.Compare(
+            df1, df2, join_columns=["a"], cast_column_names_lower=False
+        )
 
 
 def test_integer_column_names():
-    """This function tests that integer column names would also work
-    """
+    """This function tests that integer column names would also work"""
     df1 = pd.DataFrame({1: [1, 2, 3], 2: [0, 1, 2]})
     df2 = pd.DataFrame({1: [1, 2, 3], 2: [0, 1, 2]})
     compare = datacompy.Compare(df1, df2, join_columns=[1])


### PR DESCRIPTION
Fixes #115 

Request from user to be able to tweak the number of columns in the sample row report. Right now it was fixed at 10. We can change it with an argument to the `report` method. Changes only for pandas, not Spark.