### PR TITLE
edgetest bump

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,13 +16,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
+        python-version: [3.7, 3.8, 3.9, '3.10']
         spark-version: [3.0.3, 3.1.2, 3.2.0]
         hadoop: [3.2]
         include:
-          - python-version: 3.6
-            spark-version: 2.4.8
-            hadoop: 2.7
           - python-version: 3.7
             spark-version: 2.4.8
             hadoop: 2.7

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ derby.log
 # Sphinx documentation
 docs/_build/
 docs/source/api/
+
+#edgetest
+.edgetest/

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist/
 *.egg-info/
 */__pycache__/
 .idea/
+.vscode/
 *.pyc
 .DS_Store
 .pytest_cache/

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @fdosani @elzzhu
+*       @fdosani @elzzhu @ak-gupta

--- a/datacompy/_version.py
+++ b/datacompy/_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.3"
+__version__ = "0.8.0"

--- a/docs/source/developer_instructions.rst
+++ b/docs/source/developer_instructions.rst
@@ -50,6 +50,35 @@ Requirements of the project should be added to ``requirements.txt``.  Optional r
 documentation, or code quality are added to ``setup.py`` and ``EXTRAS_REQUIRE``
 
 
+
+edgetest
+--------
+
+edgetest is a utility to help keep requirements up to date and ensure a subset of testing requirements still work.
+More on edgetest `here <https://github.com/capitalone/edgetest>`_.
+
+The ``setup.cfg`` has configuration details on how to run edgetest. This process can be automated via GitHub Actions.
+(A future addition, which will come soon).
+
+In order to execute edgetest locally you can run the following after install ``edgetest``:
+
+.. code-block:: bash
+    edgetest -c setup.cfg -r requirements.txt --export
+This should return output like the following and also updating ``requirements.txt``:
+
+.. code-block:: bash
+    =============  ===============  ===================  =================
+    Environment    Passing tests    Upgraded packages    Package version
+    =============  ===============  ===================  =================
+    core           True             boto3                1.21.7
+    core           True             pandas               1.3.5
+    core           True             PyYAML               6.0
+    =============  ===============  ===================  =================
+    No PEP-517 style requirements in setup.cfg to update. Updating requirements.txt
+
+
+
+
 Release Guide
 -------------
 

--- a/docs/source/developer_instructions.rst
+++ b/docs/source/developer_instructions.rst
@@ -63,10 +63,13 @@ The ``setup.cfg`` has configuration details on how to run edgetest. This process
 In order to execute edgetest locally you can run the following after install ``edgetest``:
 
 .. code-block:: bash
+
     edgetest -c setup.cfg -r requirements.txt --export
+
 This should return output like the following and also updating ``requirements.txt``:
 
 .. code-block:: bash
+
     =============  ===============  ===================  =================
     Environment    Passing tests    Upgraded packages    Package version
     =============  ===============  ===================  =================

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+
+spark_options =
+    spark.sql.catalogImplementation: in-memory
+    spark.master: local

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pandas>=0.25.0
-numpy>=1.11.3
-ordered-set>=4.0.2
+pandas<=1.4.1,>=0.25.0
+numpy<=1.22.2,>=1.11.3
+ordered-set<=4.1.0,>=4.0.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,24 @@
 [isort]
-multi_line_output=3
-include_trailing_comma=True
-force_grid_wrap=0
-use_parentheses=True
-line_length=88
+multi_line_output = 3
+include_trailing_comma = True
+force_grid_wrap = 0
+use_parentheses = True
+line_length = 88
+
+[options]
+install_requires = 
+
+[edgetest.envs.core]
+python_version = 3.9
+conda_install = 
+	openjdk=8
+extras = 
+	tests
+	spark
+command = 
+	pytest tests -m 'not integration'
+upgrade = 
+	pandas
+	numpy
+	ordered-set
+

--- a/setup.py
+++ b/setup.py
@@ -22,16 +22,14 @@ exec(open("datacompy/_version.py").read())
 EXTRAS_REQUIRE = {
     "spark": ["pyspark>=2.2.0"],
     "docs": ["sphinx", "sphinx_rtd_theme"],
-    "tests": [
-        "pytest",
-        "pytest-cov",
-    ],
+    "tests": ["pytest", "pytest-cov", "pytest-spark"],
     "qa": [
         "pre-commit",
         "black",
         "isort",
     ],
     "build": ["twine", "wheel"],
+    "edgetest": ["edgetest", "edgetest-conda"],
 }
 
 EXTRAS_REQUIRE["dev"] = (


### PR DESCRIPTION
Adding `edgetest` to `datacompy`:

- updating developer docs
- adding config details to `setup.cfg`
- creating bounds for the `requirements.txt` file
- dropping Python 3.6 testing
- bumping version for release to v0.8.0

Closes #123 
Closes #122 
Closes #124 
