### PR TITLE
Use less restrictive dependency version constraints.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,9 +33,9 @@ zip_safe = False
 include_package_data = True
 packages = find:
 install_requires = 
-	pandas<=1.5.1,>=0.25.0
-	numpy<=1.23.4,>=1.11.3
-	ordered-set<=4.1.0,>=4.0.2
+	pandas<=1.6,>=0.25.0
+	numpy<=1.24,>=1.11.3
+	ordered-set<=5.0,>=4.0.2
 
 [options.package_data]
 * = templates/*


### PR DESCRIPTION
## Changes
We use `datacompy` as a library in the project using `poetry` to lock dependencies. And using the strict upper bounds for minor versions makes it hard to update our dependencies to include bug and security fixes. This PR changes the version constraints to be more permissive. 