### PR TITLE
Add Fugue support (Phase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ docs/source/api/
 
 #edgetest
 .edgetest/
+tmp/

--- a/datacompy/__init__.py
+++ b/datacompy/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2020 Capital One Services, LLC
+# Copyright 2023 Capital One Services, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.0.0"
+__version__ = "0.9.0"
 
 from datacompy.core import *
 from datacompy.fuguecompare import is_match

--- a/datacompy/__init__.py
+++ b/datacompy/__init__.py
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.9.0"
+__version__ = "1.0.0"
 
 from datacompy.core import *
+from datacompy.fuguecompare import is_match
 from datacompy.sparkcompare import NUMERIC_SPARK_TYPES, SparkCompare

--- a/datacompy/fuguecompare.py
+++ b/datacompy/fuguecompare.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2020 Capital One Services, LLC
+# Copyright 2023 Capital One Services, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -77,6 +77,14 @@ def is_match(
         Flag to ignore the case of string columns
     cast_column_names_lower: bool, optional
         Boolean indicator that controls of column names will be cast into lower case
+    parallelism: int, optional
+        An integer representing the amount of parallelism. Entering a value for this
+        will force to use of Fugue over just vanilla Pandas
+
+    Returns
+    -------
+    bool
+        Returns boolean as to if the DataFrames match.
     """
     if (
         isinstance(df1, pd.DataFrame)

--- a/datacompy/fuguecompare.py
+++ b/datacompy/fuguecompare.py
@@ -1,0 +1,189 @@
+#
+# Copyright 2020 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Compare two DataFrames that are supported by Fugue
+"""
+
+import logging
+import pickle
+from typing import Any, Dict, Iterable, List, Optional, Union
+
+import fugue.api as fa
+import pandas as pd
+import pyarrow as pa
+from fugue import AnyDataFrame
+
+from .core import Compare
+
+LOG = logging.getLogger(__name__)
+HASH_COL = "__datacompy__hash__"
+
+
+def is_match(
+    df1: AnyDataFrame,
+    df2: AnyDataFrame,
+    join_columns: Union[str, List[str]],
+    abs_tol: float = 0,
+    rel_tol: float = 0,
+    df1_name: str = "df1",
+    df2_name: str = "df2",
+    ignore_spaces: bool = False,
+    ignore_case: bool = False,
+    cast_column_names_lower: bool = True,
+    parallelism: Optional[int] = None,
+) -> bool:
+    """Check whether two dataframes match.
+
+    Both df1 and df2 should be dataframes containing all of the join_columns,
+    with unique column names. Differences between values are compared to
+    abs_tol + rel_tol * abs(df2['value']).
+
+    Parameters
+    ----------
+    df1 : ``AnyDataFrame``
+        First dataframe to check
+    df2 : ``AnyDataFrame``
+        Second dataframe to check
+    join_columns : list or str, optional
+        Column(s) to join dataframes on.  If a string is passed in, that one
+        column will be used.
+    abs_tol : float, optional
+        Absolute tolerance between two values.
+    rel_tol : float, optional
+        Relative tolerance between two values.
+    df1_name : str, optional
+        A string name for the first dataframe.  This allows the reporting to
+        print out an actual name instead of "df1", and allows human users to
+        more easily track the dataframes.
+    df2_name : str, optional
+        A string name for the second dataframe
+    ignore_spaces : bool, optional
+        Flag to strip whitespace (including newlines) from string columns (including any join
+        columns)
+    ignore_case : bool, optional
+        Flag to ignore the case of string columns
+    cast_column_names_lower: bool, optional
+        Boolean indicator that controls of column names will be cast into lower case
+    """
+    if (
+        isinstance(df1, pd.DataFrame)
+        and isinstance(df2, pd.DataFrame)
+        and parallelism is None  # user did not specify parallelism
+        and fa.get_current_parallelism() == 1  # currently on a local execution engine
+    ):
+        comp = Compare(
+            df1=df1,
+            df2=df2,
+            join_columns=join_columns,
+            abs_tol=abs_tol,
+            rel_tol=rel_tol,
+            df1_name=df1_name,
+            df2_name=df2_name,
+            ignore_spaces=ignore_spaces,
+            ignore_case=ignore_case,
+            cast_column_names_lower=cast_column_names_lower,
+        )
+        return comp.matches()
+
+    tdf1 = fa.as_fugue_df(df1)
+    tdf2 = fa.as_fugue_df(df2)
+
+    if isinstance(join_columns, str):
+        hash_cols = [join_columns]
+    else:
+        hash_cols = join_columns
+    # ensure all cols exist
+    hash_cols = tdf1.schema.extract(hash_cols).names
+
+    if cast_column_names_lower:
+        tdf1 = tdf1.rename(
+            {col: col.lower() for col in tdf1.schema.names if col != col.lower()}
+        )
+        tdf2 = tdf2.rename(
+            {col: col.lower() for col in tdf2.schema.names if col != col.lower()}
+        )
+        hash_cols = [col.lower() for col in hash_cols]
+
+    if tdf1.schema != tdf2.schema:
+        return False
+
+    all_cols = tdf1.schema.names
+    str_cols = set(f.name for f in tdf1.schema.fields if pa.types.is_string(f.type))
+    bucket = (
+        parallelism if parallelism is not None else fa.get_current_parallelism() * 2
+    )
+
+    def _serialize(dfs: Iterable[pd.DataFrame], left: bool) -> Iterable[Dict[str, Any]]:
+        for df in dfs:
+            cols = {}
+            for name in df.columns:
+                col = df[name]
+                if name in str_cols:
+                    if ignore_spaces:
+                        col = col.str.strip()
+                    if ignore_case:
+                        col = col.str.lower()
+                cols[name] = col
+            data = pd.DataFrame(cols)
+            gp = pd.util.hash_pandas_object(df[hash_cols], index=False).mod(bucket)
+            for k, sub in data.groupby(gp, as_index=False, group_keys=False):
+                yield {"key": k, "left": left, "data": pickle.dumps(sub)}
+
+    ser = fa.union(
+        fa.transform(
+            tdf1,
+            _serialize,
+            schema="key:int,left:bool,data:binary",
+            params=dict(left=True),
+        ),
+        fa.transform(
+            tdf2,
+            _serialize,
+            schema="key:int,left:bool,data:binary",
+            params=dict(left=False),
+        ),
+        distinct=False,
+    )
+
+    def _comp(df: List[Dict[str, Any]]) -> List[List[Any]]:
+        df1 = (
+            pd.concat([pickle.loads(r["data"]) for r in df if r["left"]])
+            .sort_values(all_cols)
+            .reset_index(drop=True)
+        )
+        df2 = (
+            pd.concat([pickle.loads(r["data"]) for r in df if not r["left"]])
+            .sort_values(all_cols)
+            .reset_index(drop=True)
+        )
+        comp = Compare(
+            df1=df1,
+            df2=df2,
+            join_columns=join_columns,
+            abs_tol=abs_tol,
+            rel_tol=rel_tol,
+            df1_name=df1_name,
+            df2_name=df2_name,
+            cast_column_names_lower=False,
+        )
+        return [[comp.matches()]]
+
+    matches = fa.as_pandas(
+        fa.transform(
+            ser, _comp, schema="match:bool", partition=dict(by="key", num=bucket)
+        )
+    )
+    return matches.match.all()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,10 @@
 [pytest]
 spark_options =
-    spark.sql.catalogImplementation: in-memory
-    spark.master: local
+  spark.master: local[*]
+  spark.sql.catalogImplementation: in-memory
+  spark.sql.shuffle.partitions: 4
+  spark.default.parallelism: 4
+  spark.executor.cores: 4
+  spark.sql.execution.arrow.pyspark.enabled: true
+  spark.sql.execution.arrow.enabled: false
+  spark.sql.adaptive.enabled: false

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
 	pandas<=1.5.3,>=0.25.0
 	numpy<=1.24.2,>=1.11.3
 	ordered-set<=4.1.0,>=4.0.2
+	fugue>=0.8.1
 
 [options.package_data]
 * = templates/*
@@ -42,6 +43,11 @@ install_requires =
 [options.extras_require]
 spark = 
 	pyspark>=2.2.0
+	fugue[spark]
+dask =
+	fugue[dask]
+ray =
+	fugue[ray]
 docs = 
 	sphinx
 	sphinx_rtd_theme

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,8 +41,11 @@ install_requires =
 * = templates/*
 
 [options.extras_require]
+duckdb =
+	fugue[duckdb]
+polars =
+	fugue[polars]
 spark = 
-	pyspark>=2.2.0
 	fugue[spark]
 dask =
 	fugue[dask]
@@ -72,6 +75,7 @@ dev =
 	pytest
 	pytest-cov
 	pytest-spark
+	fugue[spark,duckdb,polars]
 	pre-commit
 	black
 	isort

--- a/tests/test_fugue.py
+++ b/tests/test_fugue.py
@@ -1,8 +1,27 @@
+#
+# Copyright 2023 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Testing out the fugue is_match functionality
+"""
+
+import duckdb
 import fugue.api as fa
 import numpy as np
 import pandas as pd
 import polars as pl
-import duckdb
 import pytest
 
 from datacompy import is_match

--- a/tests/test_fugue.py
+++ b/tests/test_fugue.py
@@ -1,0 +1,117 @@
+import numpy as np
+import pandas as pd
+import pytest
+import fugue.api as fa
+from datacompy import is_match
+
+
+@pytest.fixture
+def ref_df():
+    np.random.seed(0)
+    return pd.DataFrame(
+        dict(
+            a=np.random.randint(0, 10, 100),
+            b=np.random.rand(100),
+            c=np.random.choice(["aaa", "b_c", "csd"], 100),
+        )
+    )
+
+
+@pytest.fixture
+def shuffle_df(ref_df):
+    return ref_df.sample(frac=1.0)
+
+
+@pytest.fixture
+def float_off_df(shuffle_df):
+    return shuffle_df.assign(b=shuffle_df.b + 0.0001)
+
+
+@pytest.fixture
+def upper_case_df(shuffle_df):
+    return shuffle_df.assign(c=shuffle_df.c.str.upper())
+
+
+@pytest.fixture
+def space_df(shuffle_df):
+    return shuffle_df.assign(c=shuffle_df.c + " ")
+
+
+@pytest.fixture
+def upper_col_df(shuffle_df):
+    return shuffle_df.rename(columns={"a": "A"})
+
+
+def test_is_match_native(
+    ref_df,
+    shuffle_df,
+    float_off_df,
+    upper_case_df,
+    space_df,
+    upper_col_df,
+):
+    # defaults to Compare class
+    assert is_match(ref_df, ref_df.copy(), join_columns="a")
+    assert not is_match(ref_df, shuffle_df, join_columns="a")
+    # Fugue
+    assert is_match(ref_df, shuffle_df, join_columns="a", parallelism=2)
+
+    assert not is_match(ref_df, float_off_df, join_columns="a", parallelism=2)
+    assert not is_match(
+        ref_df, float_off_df, abs_tol=0.00001, join_columns="a", parallelism=2
+    )
+    assert is_match(
+        ref_df, float_off_df, abs_tol=0.001, join_columns="a", parallelism=2
+    )
+    assert is_match(
+        ref_df, float_off_df, abs_tol=0.001, join_columns="a", parallelism=2
+    )
+
+    assert not is_match(ref_df, upper_case_df, join_columns="a", parallelism=2)
+    assert is_match(
+        ref_df, upper_case_df, join_columns="a", ignore_case=True, parallelism=2
+    )
+
+    assert not is_match(ref_df, space_df, join_columns="a", parallelism=2)
+    assert is_match(
+        ref_df, space_df, join_columns="a", ignore_spaces=True, parallelism=2
+    )
+
+    assert is_match(ref_df, upper_col_df, join_columns="a", parallelism=2)
+    assert not is_match(
+        ref_df,
+        upper_col_df,
+        join_columns="a",
+        cast_column_names_lower=False,
+        parallelism=2,
+    )
+
+
+def test_is_match_spark(
+    spark_session,
+    ref_df,
+    shuffle_df,
+    float_off_df,
+    upper_case_df,
+    space_df,
+    upper_col_df,
+):
+    rdf = spark_session.createDataFrame(ref_df)
+
+    assert is_match(rdf, shuffle_df, join_columns="a")
+
+    assert not is_match(rdf, float_off_df, join_columns="a")
+    assert not is_match(rdf, float_off_df, abs_tol=0.00001, join_columns="a")
+    assert is_match(rdf, float_off_df, abs_tol=0.001, join_columns="a")
+    assert is_match(rdf, float_off_df, abs_tol=0.001, join_columns="a")
+
+    assert not is_match(rdf, upper_case_df, join_columns="a")
+    assert is_match(rdf, upper_case_df, join_columns="a", ignore_case=True)
+
+    assert not is_match(rdf, space_df, join_columns="a")
+    assert is_match(rdf, space_df, join_columns="a", ignore_spaces=True)
+
+    assert is_match(rdf, upper_col_df, join_columns="a")
+    assert not is_match(
+        rdf, upper_col_df, join_columns="a", cast_column_names_lower=False
+    )


### PR DESCRIPTION
[Fugue](https://github.com/fugue-project/fugue) is an abstraction for distributed and local computing frameworks such as Spark Dask, Ray, Duckdb and Polars. For datacompy, fugue can elegantly scale the core Compare class to different distributed backends.

Is Phase 1, we only implemented `is_match` function. In Phase 2, we will enable report.

Notice, `is_match` will compare unordered data, meaning that, `df1`, `df2` without the same order can still match. In distributed systems, the concept of order doesn't natively exist, so that is why `is_match` doesn't require orders.

Here are a few examples to use is_match

```python
import fugue.api as fa
from datacompy import is_match

is_match(pdf1, pdf2, join_columns="a")  # defaults to Compare class
is_match(pdf1, pdf2, join_columns="a", parallelism=1)  # force to use Fugue, but the backend is still pandas

is_match(spark_df1, spark_df2, join_columns="a") # compare spark dataframes using spark
is_match(spark_df1, pdf2, join_columns="a") # compare spark dataframe with pandas dataframe using spark
is_match(pdf1, spark_df2, join_columns="a") # compare spark dataframe with pandas dataframe using spark

with fa.engine_context(spark_session):
    is_match(pdf1, pdf2, join_columns="a")  # force to use spark to compare dataframes

is_match(ray_df1, ray_df2, join_columns="a") # compare ray dataset using ray
is_match(ray_df1, pdf2, join_columns="a") # compare ray dataset with pandas dataframe using ray
is_match(pdf1, ray_df2, join_columns="a") # compare ray dataset with pandas dataframe using ray
```