### PR TITLE
Add support for stings with pd.NA

### DIFF
--- a/datacompy/core.py
+++ b/datacompy/core.py
@@ -760,7 +760,7 @@ def columns_equal(
                     compare = compare_string_and_date_columns(col_1, col_2)
                 else:
                     compare = pd.Series(
-                        (col_1 == col_2) | (col_1.isnull() & col_2.isnull())
+                        ((col_1 == col_2).combine_first(col_1.isna() & col_2.isna())) | (col_1.isnull() & col_2.isnull())
                     )
             except:
                 # Blanket exception should just return all False


### PR DESCRIPTION
UPDATE - will need to fix the spark tests - didn't do this locally.

WIP - if this approach is acceptable, I can update the current tests that use strings to run with series of object and string type.

The PR:

- updates core.py to prevent comparisons with `pd.NA` from returning `pd.NA`. The downside of this is that I believe any kinds of missing will match, so it won't be possible to distinguish `pd.NA` and `NaN`, for example.
- adds a test to check behaviour for strings is as expected (and checks it works for objects too)
- updates one of the existing tests with strings to use both dtypes

TODO:

- understand if this approach is acceptable for the package owners
- update the other existing tests with strings to use both object and string dtypes
- add some tests to cover the behaviour for matching different kinds of missing data, e.g. pd.NA and nan