### PR TITLE
adding in unq_columns and intersect_columns for Fugue

### DIFF
--- a/datacompy/__init__.py
+++ b/datacompy/__init__.py
@@ -16,5 +16,5 @@
 __version__ = "0.10.2"
 
 from datacompy.core import *
-from datacompy.fugue import is_match, report, unq_columns, intersect_columns
+from datacompy.fugue import intersect_columns, is_match, report, unq_columns
 from datacompy.spark import NUMERIC_SPARK_TYPES, SparkCompare

--- a/datacompy/__init__.py
+++ b/datacompy/__init__.py
@@ -16,5 +16,5 @@
 __version__ = "0.10.2"
 
 from datacompy.core import *
-from datacompy.fugue import is_match, report, unq_columns
+from datacompy.fugue import is_match, report, unq_columns, intersect_columns
 from datacompy.spark import NUMERIC_SPARK_TYPES, SparkCompare

--- a/datacompy/__init__.py
+++ b/datacompy/__init__.py
@@ -16,5 +16,5 @@
 __version__ = "0.10.2"
 
 from datacompy.core import *
-from datacompy.fugue import is_match, report
+from datacompy.fugue import is_match, report, unq_columns
 from datacompy.spark import NUMERIC_SPARK_TYPES, SparkCompare

--- a/datacompy/fugue.py
+++ b/datacompy/fugue.py
@@ -50,9 +50,9 @@ def unq_columns(df1: AnyDataFrame, df2: AnyDataFrame):
     OrderedSet
         Set of columns that are unique to df1
     """
-    tdf1 = fa.as_fugue_df(df1)
-    tdf2 = fa.as_fugue_df(df2)
-    return OrderedSet(tdf1.columns) - OrderedSet(tdf2.columns)
+    col1 = fa.get_column_names(df1)
+    col2 = fa.get_column_names(df2)
+    return OrderedSet(col1) - OrderedSet(col2)
 
 
 def is_match(

--- a/datacompy/fugue.py
+++ b/datacompy/fugue.py
@@ -55,6 +55,27 @@ def unq_columns(df1: AnyDataFrame, df2: AnyDataFrame):
     return OrderedSet(col1) - OrderedSet(col2)
 
 
+def intersect_columns(df1: AnyDataFrame, df2: AnyDataFrame):
+    """Get columns that are shared between the two dataframes
+
+    Parameters
+    ----------
+    df1 : ``AnyDataFrame``
+        First dataframe to check
+
+    df2 : ``AnyDataFrame``
+        Second dataframe to check
+
+    Returns
+    -------
+    OrderedSet
+        Set of that are shared between the two dataframes
+    """
+    col1 = fa.get_column_names(df1)
+    col2 = fa.get_column_names(df2)
+    return OrderedSet(col1) & OrderedSet(col2)
+
+
 def is_match(
     df1: AnyDataFrame,
     df2: AnyDataFrame,

--- a/datacompy/fugue.py
+++ b/datacompy/fugue.py
@@ -26,11 +26,33 @@ import fugue.api as fa
 import pandas as pd
 import pyarrow as pa
 from fugue import AnyDataFrame
+from ordered_set import OrderedSet
 
 from .core import Compare, render
 
 LOG = logging.getLogger(__name__)
 HASH_COL = "__datacompy__hash__"
+
+
+def unq_columns(df1: AnyDataFrame, df2: AnyDataFrame):
+    """Get columns that are unique to df1
+
+    Parameters
+    ----------
+    df1 : ``AnyDataFrame``
+        First dataframe to check
+
+    df2 : ``AnyDataFrame``
+        Second dataframe to check
+
+    Returns
+    -------
+    OrderedSet
+        Set of columns that are unique to df1
+    """
+    tdf1 = fa.as_fugue_df(df1)
+    tdf2 = fa.as_fugue_df(df2)
+    return OrderedSet(tdf1.columns) - OrderedSet(tdf2.columns)
 
 
 def is_match(

--- a/tests/test_fugue.py
+++ b/tests/test_fugue.py
@@ -24,9 +24,10 @@ import numpy as np
 import pandas as pd
 import polars as pl
 import pytest
+from ordered_set import OrderedSet
 from pytest import raises
 
-from datacompy import Compare, is_match, report
+from datacompy import Compare, is_match, report, unq_columns
 
 
 @pytest.fixture
@@ -271,3 +272,67 @@ def test_report_spark(spark_session, simple_diff_df1, simple_diff_df2):
     comp = Compare(simple_diff_df1, simple_diff_df2, join_columns="aa")
     a = report(df1, df2, ["aa"])
     assert a == comp.report()
+
+
+def test_unique_columns_native(ref_df):
+    df1 = ref_df
+    df2 = ref_df.copy().drop(columns=["c"])
+    df3 = ref_df.copy().drop(columns=["a", "b"])
+
+    assert unq_columns(df1, df1.copy()) == OrderedSet()
+    assert unq_columns(df1, df2) == OrderedSet(["c"])
+    assert unq_columns(df1, df3) == OrderedSet(["a", "b"])
+    assert unq_columns(df1.copy(), df1) == OrderedSet()
+    assert unq_columns(df3, df2) == OrderedSet(["c"])
+
+
+def test_unique_columns_spark(spark_session, ref_df):
+    df1 = ref_df
+    df2 = ref_df.copy().drop(columns=["c"])
+    df3 = ref_df.copy().drop(columns=["a", "b"])
+
+    sdf1 = spark_session.createDataFrame(df1)
+    sdf1_copy = spark_session.createDataFrame(df1.copy())
+    sdf2 = spark_session.createDataFrame(df2)
+    sdf3 = spark_session.createDataFrame(df3)
+
+    assert unq_columns(sdf1, sdf1_copy) == OrderedSet()
+    assert unq_columns(sdf1, sdf2) == OrderedSet(["c"])
+    assert unq_columns(sdf1, sdf3) == OrderedSet(["a", "b"])
+    assert unq_columns(sdf1_copy, sdf1) == OrderedSet()
+    assert unq_columns(sdf3, sdf2) == OrderedSet(["c"])
+
+
+def test_unique_columns_polars(ref_df):
+    df1 = ref_df
+    df2 = ref_df.copy().drop(columns=["c"])
+    df3 = ref_df.copy().drop(columns=["a", "b"])
+
+    pdf1 = pl.from_pandas(df1)
+    pdf1_copy = pl.from_pandas(df1.copy())
+    pdf2 = pl.from_pandas(df2)
+    pdf3 = pl.from_pandas(df3)
+
+    assert unq_columns(pdf1, pdf1_copy) == OrderedSet()
+    assert unq_columns(pdf1, pdf2) == OrderedSet(["c"])
+    assert unq_columns(pdf1, pdf3) == OrderedSet(["a", "b"])
+    assert unq_columns(pdf1_copy, pdf1) == OrderedSet()
+    assert unq_columns(pdf3, pdf2) == OrderedSet(["c"])
+
+
+def test_unique_columns_duckdb(ref_df):
+    df1 = ref_df
+    df2 = ref_df.copy().drop(columns=["c"])
+    df3 = ref_df.copy().drop(columns=["a", "b"])
+
+    with duckdb.connect():
+        ddf1 = duckdb.from_df(df1)
+        ddf1_copy = duckdb.from_df(df1.copy())
+        ddf2 = duckdb.from_df(df2)
+        ddf3 = duckdb.from_df(df3)
+
+        assert unq_columns(ddf1, ddf1_copy) == OrderedSet()
+        assert unq_columns(ddf1, ddf2) == OrderedSet(["c"])
+        assert unq_columns(ddf1, ddf3) == OrderedSet(["a", "b"])
+        assert unq_columns(ddf1_copy, ddf1) == OrderedSet()
+        assert unq_columns(ddf3, ddf2) == OrderedSet(["c"])

--- a/tests/test_fugue.py
+++ b/tests/test_fugue.py
@@ -291,15 +291,15 @@ def test_unique_columns_spark(spark_session, ref_df):
     df2 = ref_df.copy().drop(columns=["c"])
     df3 = ref_df.copy().drop(columns=["a", "b"])
 
+    df1.iteritems = df1.items  # pandas 2 compatibility
+    df1_copy.iteritems = df1_copy.items  # pandas 2 compatibility
+    df2.iteritems = df2.items  # pandas 2 compatibility
+    df3.iteritems = df3.items  # pandas 2 compatibility
+
     sdf1 = spark_session.createDataFrame(df1)
     sdf1_copy = spark_session.createDataFrame(df1.copy())
     sdf2 = spark_session.createDataFrame(df2)
     sdf3 = spark_session.createDataFrame(df3)
-
-    sdf1.iteritems = sdf1.items  # pandas 2 compatibility
-    sdf1_copy.iteritems = sdf1_copy.items  # pandas 2 compatibility
-    sdf2.iteritems = sdf2.items  # pandas 2 compatibility
-    sdf3.iteritems = sdf3.items  # pandas 2 compatibility
 
     assert unq_columns(sdf1, sdf1_copy) == OrderedSet()
     assert unq_columns(sdf1, sdf2) == OrderedSet(["c"])

--- a/tests/test_fugue.py
+++ b/tests/test_fugue.py
@@ -27,7 +27,7 @@ import pytest
 from ordered_set import OrderedSet
 from pytest import raises
 
-from datacompy import Compare, is_match, report, unq_columns
+from datacompy import Compare, is_match, report, unq_columns, intersect_columns
 
 
 @pytest.fixture
@@ -342,3 +342,75 @@ def test_unique_columns_duckdb(ref_df):
         assert unq_columns(ddf1, ddf3) == OrderedSet(["a", "b"])
         assert unq_columns(ddf1_copy, ddf1) == OrderedSet()
         assert unq_columns(ddf3, ddf2) == OrderedSet(["c"])
+
+
+
+
+def test_intersect_columns_native(ref_df):
+    df1 = ref_df
+    df2 = ref_df.copy().drop(columns=["c"])
+    df3 = ref_df.copy().drop(columns=["a", "b"])
+
+    assert intersect_columns(df1, df1.copy()) == OrderedSet(["a", "b", "c"])
+    assert intersect_columns(df1, df2) == OrderedSet(["a", "b"])
+    assert intersect_columns(df1, df3) == OrderedSet(["c"])
+    assert intersect_columns(df1.copy(), df1) == OrderedSet(["a", "b", "c"])
+    assert intersect_columns(df3, df2) == OrderedSet()
+
+
+def test_intersect_columns_spark(spark_session, ref_df):
+    df1 = ref_df
+    df1_copy = ref_df.copy()
+    df2 = ref_df.copy().drop(columns=["c"])
+    df3 = ref_df.copy().drop(columns=["a", "b"])
+
+    df1.iteritems = df1.items  # pandas 2 compatibility
+    df1_copy.iteritems = df1_copy.items  # pandas 2 compatibility
+    df2.iteritems = df2.items  # pandas 2 compatibility
+    df3.iteritems = df3.items  # pandas 2 compatibility
+
+    sdf1 = spark_session.createDataFrame(df1)
+    sdf1_copy = spark_session.createDataFrame(df1_copy)
+    sdf2 = spark_session.createDataFrame(df2)
+    sdf3 = spark_session.createDataFrame(df3)
+
+    assert intersect_columns(sdf1, sdf1_copy) == OrderedSet(["a", "b", "c"])
+    assert intersect_columns(sdf1, sdf2) == OrderedSet(["a", "b"])
+    assert intersect_columns(sdf1, sdf3) == OrderedSet(["c"])
+    assert intersect_columns(sdf1_copy, sdf1) == OrderedSet(["a", "b", "c"])
+    assert intersect_columns(sdf3, sdf2) == OrderedSet()
+
+
+def test_intersect_columns_polars(ref_df):
+    df1 = ref_df
+    df2 = ref_df.copy().drop(columns=["c"])
+    df3 = ref_df.copy().drop(columns=["a", "b"])
+
+    pdf1 = pl.from_pandas(df1)
+    pdf1_copy = pl.from_pandas(df1.copy())
+    pdf2 = pl.from_pandas(df2)
+    pdf3 = pl.from_pandas(df3)
+
+    assert intersect_columns(pdf1, pdf1_copy) == OrderedSet(["a", "b", "c"])
+    assert intersect_columns(pdf1, pdf2) == OrderedSet(["a", "b"])
+    assert intersect_columns(pdf1, pdf3) == OrderedSet(["c"])
+    assert intersect_columns(pdf1_copy, pdf1) == OrderedSet(["a", "b", "c"])
+    assert intersect_columns(pdf3, pdf2) == OrderedSet()
+
+
+def test_intersect_columns_duckdb(ref_df):
+    df1 = ref_df
+    df2 = ref_df.copy().drop(columns=["c"])
+    df3 = ref_df.copy().drop(columns=["a", "b"])
+
+    with duckdb.connect():
+        ddf1 = duckdb.from_df(df1)
+        ddf1_copy = duckdb.from_df(df1.copy())
+        ddf2 = duckdb.from_df(df2)
+        ddf3 = duckdb.from_df(df3)
+
+        assert intersect_columns(ddf1, ddf1_copy) == OrderedSet(["a", "b", "c"])
+        assert intersect_columns(ddf1, ddf2) == OrderedSet(["a", "b"])
+        assert intersect_columns(ddf1, ddf3) == OrderedSet(["c"])
+        assert intersect_columns(ddf1_copy, ddf1) == OrderedSet(["a", "b", "c"])
+        assert intersect_columns(ddf3, ddf2) == OrderedSet()

--- a/tests/test_fugue.py
+++ b/tests/test_fugue.py
@@ -296,6 +296,11 @@ def test_unique_columns_spark(spark_session, ref_df):
     sdf2 = spark_session.createDataFrame(df2)
     sdf3 = spark_session.createDataFrame(df3)
 
+    sdf1.iteritems = sdf1.items  # pandas 2 compatibility
+    sdf1_copy.iteritems = sdf1_copy.items  # pandas 2 compatibility
+    sdf2.iteritems = sdf2.items  # pandas 2 compatibility
+    sdf3.iteritems = sdf3.items  # pandas 2 compatibility
+
     assert unq_columns(sdf1, sdf1_copy) == OrderedSet()
     assert unq_columns(sdf1, sdf2) == OrderedSet(["c"])
     assert unq_columns(sdf1, sdf3) == OrderedSet(["a", "b"])

--- a/tests/test_fugue.py
+++ b/tests/test_fugue.py
@@ -288,6 +288,7 @@ def test_unique_columns_native(ref_df):
 
 def test_unique_columns_spark(spark_session, ref_df):
     df1 = ref_df
+    df1_copy = ref_df.copy()
     df2 = ref_df.copy().drop(columns=["c"])
     df3 = ref_df.copy().drop(columns=["a", "b"])
 
@@ -297,7 +298,7 @@ def test_unique_columns_spark(spark_session, ref_df):
     df3.iteritems = df3.items  # pandas 2 compatibility
 
     sdf1 = spark_session.createDataFrame(df1)
-    sdf1_copy = spark_session.createDataFrame(df1.copy())
+    sdf1_copy = spark_session.createDataFrame(df1_copy)
     sdf2 = spark_session.createDataFrame(df2)
     sdf3 = spark_session.createDataFrame(df3)
 

--- a/tests/test_fugue.py
+++ b/tests/test_fugue.py
@@ -27,7 +27,7 @@ import pytest
 from ordered_set import OrderedSet
 from pytest import raises
 
-from datacompy import Compare, is_match, report, unq_columns, intersect_columns
+from datacompy import Compare, intersect_columns, is_match, report, unq_columns
 
 
 @pytest.fixture
@@ -342,8 +342,6 @@ def test_unique_columns_duckdb(ref_df):
         assert unq_columns(ddf1, ddf3) == OrderedSet(["a", "b"])
         assert unq_columns(ddf1_copy, ddf1) == OrderedSet()
         assert unq_columns(ddf3, ddf2) == OrderedSet(["c"])
-
-
 
 
 def test_intersect_columns_native(ref_df):


### PR DESCRIPTION
Adding in `unq_columns` for the Fugue module. Equivalent of the:
- df1_unq_columns
- and df2_unq_columns

Fairly simple function which mirrors the `core` version. Main difference is that I used `as_fugue_df` to conver the inputs to ensure uniformity and compatability between different frameworks. @goodwanghan does this make sense? Just want to confirm my thought process here.