### PR TITLE
set spark shuffle partitions to 1 to speed up unit tests

### DIFF
--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -51,6 +51,7 @@ def spark_fixture():
         .appName("pytest")
         .getOrCreate()
     )
+    spark.conf.set("spark.sql.shuffle.partitions", 1)
     yield spark
     spark.stop()
 


### PR DESCRIPTION
fixes https://github.com/capitalone/datacompy/issues/223