### PR TITLE
python 3.11 support

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -21,9 +21,13 @@ jobs:
       matrix:
         python-version: [3.8, 3.9, '3.10', '3.11']
         spark-version: [3.1.3, 3.2.4, 3.3.4, 3.4.2, 3.5.0]
-        exclude:
-          - python-version: ['3.10', '3.11']
-            spark-version: [3.1.3, 3.2.4, 3.3.4]
+#        exclude:
+#          - python-version: '3.11'
+#            spark-version: 3.1.3
+#          - python-version: '3.11'
+#            spark-version: 3.2.4
+#          - python-version: '3.11'
+#            spark-version: 3.3.4
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}
       SPARK_VERSION: ${{ matrix.spark-version }}

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -21,6 +21,9 @@ jobs:
       matrix:
         python-version: [3.8, 3.9, '3.10', '3.11']
         spark-version: [3.1.3, 3.2.4, 3.3.4, 3.4.2, 3.5.0]
+        exclude:
+          - python-version: ['3.10', '3.11']
+            spark-version: [3.1.3, 3.2.4, 3.3.4]
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}
       SPARK_VERSION: ${{ matrix.spark-version }}

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
+        python-version: [3.8, 3.9, '3.10', '3.11']
         spark-version: [3.1.3, 3.2.4, 3.3.4, 3.4.2, 3.5.0]
         exclude:
           - python-version: '3.11'
@@ -27,12 +27,6 @@ jobs:
           - python-version: '3.11'
             spark-version: 3.2.4
           - python-version: '3.11'
-            spark-version: 3.3.4
-          - python-version: '3.12'
-            spark-version: 3.1.3
-          - python-version: '3.12'
-            spark-version: 3.2.4
-          - python-version: '3.12'
             spark-version: 3.3.4
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}
@@ -68,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
+        python-version: [3.8, 3.9, '3.10', '3.11']
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}
 
@@ -94,7 +88,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
+        python-version: [3.8, 3.9, '3.10', '3.11']
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}
 

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -21,13 +21,13 @@ jobs:
       matrix:
         python-version: [3.8, 3.9, '3.10', '3.11']
         spark-version: [3.1.3, 3.2.4, 3.3.4, 3.4.2, 3.5.0]
-#        exclude:
-#          - python-version: '3.11'
-#            spark-version: 3.1.3
-#          - python-version: '3.11'
-#            spark-version: 3.2.4
-#          - python-version: '3.11'
-#            spark-version: 3.3.4
+        exclude:
+          - python-version: '3.11'
+            spark-version: 3.1.3
+          - python-version: '3.11'
+            spark-version: 3.2.4
+          - python-version: '3.11'
+            spark-version: 3.3.4
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}
       SPARK_VERSION: ${{ matrix.spark-version }}

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.8, 3.9, '3.10', '3.11']
-        spark-version: [3.1.3, 3.2.3, 3.3.1, 3.4.0, 3.5.0]
+        spark-version: [3.1.3, 3.2.4, 3.3.4, 3.4.2, 3.5.0]
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}
       SPARK_VERSION: ${{ matrix.spark-version }}

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11']
+        python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
         spark-version: [3.1.3, 3.2.4, 3.3.4, 3.4.2, 3.5.0]
         exclude:
           - python-version: '3.11'
@@ -27,6 +27,12 @@ jobs:
           - python-version: '3.11'
             spark-version: 3.2.4
           - python-version: '3.11'
+            spark-version: 3.3.4
+          - python-version: '3.12'
+            spark-version: 3.1.3
+          - python-version: '3.12'
+            spark-version: 3.2.4
+          - python-version: '3.12'
             spark-version: 3.3.4
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}
@@ -62,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11']
+        python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}
 
@@ -88,7 +94,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11']
+        python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}
 

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10', '3.11']
         spark-version: [3.1.3, 3.2.3, 3.3.1, 3.4.0, 3.5.0]
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10', '3.11']
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}
 
@@ -81,7 +81,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10', '3.11']
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,22 @@ pip install datacompy[ray]
 
 ```
 
+### In-scope Spark versions
+Different versions of Spark play nicely with only certain versions of Python below is a matrix of what we test with
+
+|             | Spark 3.1.3  | Spark 3.2.3 | Spark 3.3.4 | Spark 3.4.4 | Spark 3.5.0 |
+|-------------|--------------|-------------|-------------|-------------|-------------|
+| Python 3.8  | ✅           | ✅           | ✅           | ✅          | ✅          |
+| Python 3.9  | ✅           | ✅           | ✅           | ✅          | ✅          |
+| Python 3.10 | ✅           | ✅           | ✅           | ✅          | ✅          |
+| Python 3.11 | ❌           | ❌           | ❌           | ✅          | ✅          |
+| Python 3.12 | ❌           | ❌           | ❌           | ❌          | ❌          |
+
+
+:::{note}
+At the current time Python ``3.12`` is not supported by Spark and also Ray within Fugue.
+:::
+
 ## Supported backends
 
 - Pandas: ([See documentation](https://capitalone.github.io/datacompy/pandas_usage.html))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ tests-spark = [
     "pytest",
     "pytest-cov",
     "pytest-spark",
-    "fugue[spark]",
+    "spark",
 ]
 qa = [
     "pre-commit",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,8 +62,11 @@ python-tag = "py3"
 
 [project.optional-dependencies]
 duckdb = ["fugue[duckdb]"]
-polars = ["fugue[polars]"]
-spark = ["fugue[spark]"]
+polars = ["polars"]
+spark = [
+    "pyspark>=3.1.1; python_version < '3.11'",
+    "pyspark>=3.4; python_version >= '3.11'",
+]
 dask = ["fugue[dask]"]
 ray = ["fugue[ray]"]
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+
 ]
 
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,6 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-
 ]
 
 dynamic = ["version"]


### PR DESCRIPTION
This was in ref: #262. I've added in 3.11 support but it seems like Spark and Ray (Fugue) are not compatible with 3.12  as of yet. 😢 

Otherwise I've just made some minor tweaks and added a matrix to the `README`