### PR TITLE
Move pandas upper bound to 2.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ maintainers = [
 ]
 license = {text = "Apache Software License"}
 dependencies = [
-    "pandas<=2.0.2,>=0.25.0",
+    "pandas<=2.2.0,>=0.25.0",
     "numpy<=1.26.0,>=1.22.0",
     "ordered-set<=4.1.0,>=4.0.2",
     "fugue<=0.8.7,>=0.8.7",


### PR DESCRIPTION
Move pandas upper bound to latest release (2.2.0 as of today).