### PR TITLE
edgetest sparkfix

### DIFF
--- a/.github/workflows/edgetest.yml
+++ b/.github/workflows/edgetest.yml
@@ -11,12 +11,35 @@ jobs:
     runs-on: ubuntu-latest
     name: running edgetest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: edgetest-sparkfix
-      - id: run-edgetest
-        uses: edgetest-dev/run-edgetest-action@v1.4
+      
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
         with:
-          edgetest-flags: '-c pyproject.toml --export'
-          base-branch: 'edgetest-sparkfix'
-          skip-pr: 'false'
+          python-version: '3.10'
+      
+      - name: Setup Java JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+
+      - name: Install edgetest
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install edgetest edgetest-conda
+      
+      - name: Run edgetest
+        run: |
+          edgetest -c pyproject.toml --export
+
+
+
+      # - id: run-edgetest
+      #   uses: edgetest-dev/run-edgetest-action@v1.4
+      #   with:
+      #     edgetest-flags: '-c pyproject.toml --export'
+      #     base-branch: 'edgetest-sparkfix'
+      #     skip-pr: 'false'

--- a/.github/workflows/edgetest.yml
+++ b/.github/workflows/edgetest.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: running edgetest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: 'edgetest-sparkfix'
       - id: run-edgetest
@@ -20,4 +20,4 @@ jobs:
           edgetest-flags: '-c pyproject.toml --export'
           base-branch: 'edgetest-sparkfix'
           skip-pr: 'false'
-          python-version: "3.10"
+          python-version: '3.10'

--- a/.github/workflows/edgetest.yml
+++ b/.github/workflows/edgetest.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: edgetest-sparkfix
+          ref: develop
       
       - name: Set up Python 3.10
         uses: conda-incubator/setup-miniconda@v2
@@ -40,11 +40,16 @@ jobs:
         run: |
           edgetest -c pyproject.toml --export
 
-
-
-      # - id: run-edgetest
-      #   uses: edgetest-dev/run-edgetest-action@v1.4
-      #   with:
-      #     edgetest-flags: '-c pyproject.toml --export'
-      #     base-branch: 'edgetest-sparkfix'
-      #     skip-pr: 'false'
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          branch: edgetest-patch
+          base: develop
+          delete-branch: true
+          title: Changes by run-edgetest action
+          commit-message: '[edgetest] automated change'
+          body: Automated changes by [run-edgetest-action](https://github.com/edgetest-dev/run-edgetest-action) GitHub action
+          add-paths: |
+            requirements.txt
+            setup.cfg
+            pyproject.toml

--- a/.github/workflows/edgetest.yml
+++ b/.github/workflows/edgetest.yml
@@ -20,4 +20,4 @@ jobs:
           edgetest-flags: '-c pyproject.toml --export'
           base-branch: 'develop'
           skip-pr: 'false'
-          python-version: 3.10
+          python-version: "3.10"

--- a/.github/workflows/edgetest.yml
+++ b/.github/workflows/edgetest.yml
@@ -18,6 +18,6 @@ jobs:
         uses: edgetest-dev/run-edgetest-action@v1.4
         with:
           edgetest-flags: '-c pyproject.toml --export'
-          base-branch: 'develop'
+          base-branch: 'edgetest-sparkfix'
           skip-pr: 'false'
           python-version: "3.10"

--- a/.github/workflows/edgetest.yml
+++ b/.github/workflows/edgetest.yml
@@ -24,4 +24,4 @@ jobs:
       - name: DEBUG
         shell: bash -l {0}
         run: |
-          pip list
+          /home/runner/work/datacompy/datacompy/.edgetest/core/bin/pip list

--- a/.github/workflows/edgetest.yml
+++ b/.github/workflows/edgetest.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install edgetest edgetest-conda
+          python -m pip install .[dev]
       
       - name: Run edgetest
         run: |

--- a/.github/workflows/edgetest.yml
+++ b/.github/workflows/edgetest.yml
@@ -20,3 +20,4 @@ jobs:
           edgetest-flags: '-c pyproject.toml --export'
           base-branch: 'develop'
           skip-pr: 'false'
+          python-version: 3.10

--- a/.github/workflows/edgetest.yml
+++ b/.github/workflows/edgetest.yml
@@ -21,3 +21,7 @@ jobs:
           base-branch: 'edgetest-sparkfix'
           skip-pr: 'false'
           python-version: '3.10'
+      - name: DEBUG
+        shell: bash -l {0}
+        run: |
+          pip list

--- a/.github/workflows/edgetest.yml
+++ b/.github/workflows/edgetest.yml
@@ -16,9 +16,11 @@ jobs:
           ref: edgetest-sparkfix
       
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: conda-incubator/setup-miniconda@v2
         with:
+          auto-update-conda: true
           python-version: '3.10'
+          channels: conda-forge
       
       - name: Setup Java JDK
         uses: actions/setup-java@v3

--- a/.github/workflows/edgetest.yml
+++ b/.github/workflows/edgetest.yml
@@ -11,18 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     name: running edgetest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2
         with:
-          ref: 'edgetest-sparkfix'
+          ref: edgetest-sparkfix
       - id: run-edgetest
         uses: edgetest-dev/run-edgetest-action@v1.4
         with:
           edgetest-flags: '-c pyproject.toml --export'
           base-branch: 'edgetest-sparkfix'
           skip-pr: 'false'
-          python-version: '3.10'
-      - name: DEBUG
-        shell: bash -l {0}
-        run: |
-          echo $PYSPARK_PYTHON
-          echo $PYSPARK_DRIVER_PYTHON

--- a/.github/workflows/edgetest.yml
+++ b/.github/workflows/edgetest.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: develop
+          ref: 'edgetest-sparkfix'
       - id: run-edgetest
         uses: edgetest-dev/run-edgetest-action@v1.4
         with:

--- a/.github/workflows/edgetest.yml
+++ b/.github/workflows/edgetest.yml
@@ -29,12 +29,14 @@ jobs:
           distribution: 'adopt'
 
       - name: Install edgetest
+        shell: bash -el {0}
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install edgetest edgetest-conda
+          conda install pip
+          conda install edgetest edgetest-conda
           python -m pip install .[dev]
       
       - name: Run edgetest
+        shell: bash -el {0}
         run: |
           edgetest -c pyproject.toml --export
 

--- a/.github/workflows/edgetest.yml
+++ b/.github/workflows/edgetest.yml
@@ -24,4 +24,5 @@ jobs:
       - name: DEBUG
         shell: bash -l {0}
         run: |
-          /home/runner/work/datacompy/datacompy/.edgetest/core/bin/pip list
+          echo $PYSPARK_PYTHON
+          echo $PYSPARK_DRIVER_PYTHON

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,9 +131,8 @@ ignore_missing_imports = true
 
 [edgetest.envs.core]
 python_version = "3.10"
-conda_install = ["openjdk=8"]
+conda_install = ["openjdk=8", "pyspark==3.4.1"]
 extras = ["dev"]
-deps = ["pyspark==3.4.2"]
 command = "pytest tests -m 'not integration'"
 upgrade = [
     "pandas",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,8 +131,9 @@ ignore_missing_imports = true
 
 [edgetest.envs.core]
 python_version = "3.10"
-conda_install = ["openjdk=8", "pyspark==3.4.1", "cloudpickle"]
+conda_install = ["openjdk=8", "pyspark==3.4.1"]
 extras = ["dev"]
+deps = ["cloudpickle"]
 command = "pytest tests -m 'not integration'"
 upgrade = [
     "pandas",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ module = "pyarrow"
 ignore_missing_imports = true
 
 [edgetest.envs.core]
-python_version = "3.10"
+python_version = "3.11"
 conda_install = ["openjdk=8"]
 extras = ["dev"]
 command = "pytest tests -m 'not integration'"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,8 +130,8 @@ module = "pyarrow"
 ignore_missing_imports = true
 
 [edgetest.envs.core]
-python_version = "3.11"
-conda_install = ["openjdk=8"]
+python_version = "3.9"
+conda_install = ["openjdk=8", "pandas"]
 extras = ["dev"]
 command = "pytest tests -m 'not integration'"
 upgrade = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,7 @@ ignore_missing_imports = true
 
 [edgetest.envs.core]
 python_version = "3.10"
-conda_install = ["openjdk=8", "pandas"]
+conda_install = ["openjdk=8"]
 extras = ["dev"]
 command = "pytest tests -m 'not integration'"
 upgrade = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,9 +131,8 @@ ignore_missing_imports = true
 
 [edgetest.envs.core]
 python_version = "3.10"
-conda_install = ["openjdk=8", "pyspark==3.4.1"]
+conda_install = ["openjdk=8"]
 extras = ["dev"]
-deps = ["cloudpickle"]
 command = "pytest tests -m 'not integration'"
 upgrade = [
     "pandas",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,7 @@ ignore_missing_imports = true
 
 [edgetest.envs.core]
 python_version = "3.10"
-conda_install = ["openjdk=8", "pyspark==3.4.1"]
+conda_install = ["openjdk=8", "pyspark==3.4.1", "cloudpickle"]
 extras = ["dev"]
 command = "pytest tests -m 'not integration'"
 upgrade = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ module = "pyarrow"
 ignore_missing_imports = true
 
 [edgetest.envs.core]
-python_version = "3.9"
+python_version = "3.10"
 conda_install = ["openjdk=8", "pandas"]
 extras = ["dev"]
 command = "pytest tests -m 'not integration'"

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,5 +6,4 @@ spark_options =
   spark.default.parallelism: 4
   spark.executor.cores: 4
   spark.sql.execution.arrow.pyspark.enabled: true
-  spark.sql.execution.arrow.enabled: false
   spark.sql.adaptive.enabled: false

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,7 +4,7 @@ spark_options =
   spark.sql.catalogImplementation: in-memory
   spark.sql.shuffle.partitions: 4
   spark.default.parallelism: 4
+  spark.executor.cores: 4
   spark.sql.execution.arrow.pyspark.enabled: true
+  spark.sql.execution.arrow.enabled: false
   spark.sql.adaptive.enabled: false
-  spark.pyspark.driver.python: /home/runner/work/datacompy/datacompy/.edgetest/core/bin/python
-  spark.pyspark.python: /home/runner/work/datacompy/datacompy/.edgetest/core/bin/python

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,3 +6,5 @@ spark_options =
   spark.default.parallelism: 4
   spark.sql.execution.arrow.pyspark.enabled: true
   spark.sql.adaptive.enabled: false
+  spark.pyspark.driver.python: /home/runner/work/datacompy/datacompy/.edgetest/core/bin/python
+  spark.pyspark.python: /home/runner/work/datacompy/datacompy/.edgetest/core/bin/python

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,7 +4,5 @@ spark_options =
   spark.sql.catalogImplementation: in-memory
   spark.sql.shuffle.partitions: 4
   spark.default.parallelism: 4
-  spark.executor.cores: 4
   spark.sql.execution.arrow.pyspark.enabled: true
-  spark.sql.execution.arrow.enabled: false
   spark.sql.adaptive.enabled: false


### PR DESCRIPTION
Fixes #267 

After a bunch of tinkering, I kind of just changed course here and drop the `edgetest` action. It was picking up the wrong env (which I'm too tired to dig into at the moment). I got it working by embedding the logic directly into the action.

- `python` Bumped up versions to 3.10
- `actions/checkout` is now `v3`
- added call to `peter-evans/create-pull-request` for automating PR.

`edgetest` is back and working now: https://github.com/capitalone/datacompy/pull/268/files