### PR TITLE
Move numpy upper bound to 1.26.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ maintainers = [
 license = {text = "Apache Software License"}
 dependencies = [
     "pandas<=2.2.0,>=0.25.0",
-    "numpy<=1.26.0,>=1.22.0",
+    "numpy<=1.26.4,>=1.22.0",
     "ordered-set<=4.1.0,>=4.0.2",
     "fugue<=0.8.7,>=0.8.7",
 ]


### PR DESCRIPTION
Move numpy upper bound to latest release (1.26.4 as of today).