### PR TITLE
bug fix when all columns match but no rows match

### DIFF
--- a/datacompy/__init__.py
+++ b/datacompy/__init__.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.11.0"
+__version__ = "0.11.1"
 
 from datacompy.core import *
 from datacompy.fugue import (

--- a/datacompy/spark.py
+++ b/datacompy/spark.py
@@ -722,18 +722,30 @@ class SparkCompare:
             for key in self.columns_match_dict
             if self.columns_match_dict[key][MatchType.MISMATCH.value]
         }
-        columns_fully_matching = {
-            key: self.columns_match_dict[key]
-            for key in self.columns_match_dict
-            if sum(self.columns_match_dict[key])
-            == self.columns_match_dict[key][MatchType.MATCH.value]
-        }
-        columns_with_any_diffs = {
-            key: self.columns_match_dict[key]
-            for key in self.columns_match_dict
-            if sum(self.columns_match_dict[key])
-            != self.columns_match_dict[key][MatchType.MATCH.value]
-        }
+
+        # corner case: when all columns match but no rows match
+        # issue: #276
+        try:
+            columns_fully_matching = {
+                key: self.columns_match_dict[key]
+                for key in self.columns_match_dict
+                if sum(self.columns_match_dict[key])
+                == self.columns_match_dict[key][MatchType.MATCH.value]
+            }
+        except TypeError:
+            columns_fully_matching = {}
+
+        try:
+            columns_with_any_diffs = {
+                key: self.columns_match_dict[key]
+                for key in self.columns_match_dict
+                if sum(self.columns_match_dict[key])
+                != self.columns_match_dict[key][MatchType.MATCH.value]
+            }
+        except TypeError:
+            columns_with_any_diffs = {}
+        #
+
         base_types = {x[0]: x[1] for x in self.base_df.dtypes}
         compare_types = {x[0]: x[1] for x in self.compare_df.dtypes}
 


### PR DESCRIPTION
Fixes #276 

@SimonBFrank would you mind pulling down this branch and seeing if it fixes your issue. Long story short, there are no results and the subsequent dictionary with values which get displayed out is not able to generate because of `None` values.

More of a hack since we will be deprecating this legacy Spark implementation (#275)  for a much more readable and logically similar to Pandas version. Just catching the `TypeError` for this situation and putting out `{}` for `columns_with_any_diffs` and `columns_fully_matching`