### PR TITLE
Update pandas support to 2.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ maintainers = [
   { name="Faisal Dosani", email="faisal.dosani@capitalone.com" }
 ]
 license = {text = "Apache Software License"}
-dependencies = ["pandas<=2.2.1,>=0.25.0", "numpy<=1.26.4,>=1.22.0", "ordered-set<=4.1.0,>=4.0.2", "fugue<=0.8.7,>=0.8.7"]
+dependencies = ["pandas<=2.2.2,>=0.25.0", "numpy<=1.26.4,>=1.22.0", "ordered-set<=4.1.0,>=4.0.2", "fugue<=0.8.7,>=0.8.7"]
 requires-python = ">=3.9.0"
 classifiers = [
     "Intended Audience :: Developers",


### PR DESCRIPTION
It looks like your edgetest automation job is failing on polars tests but declaring failures for all possible libraries to upgrade, so the automation isn't bumping pandas support even though it seems likely that datacompy supports the relatively minor changes/bugfixes in this patch release.