### PR TITLE
Release v0.12.0

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -19,11 +19,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11']
-        spark-version: [3.1.3, 3.2.4, 3.3.4, 3.4.2, 3.5.0]
+        python-version: [3.9, '3.10', '3.11']
+        spark-version: [3.2.4, 3.3.4, 3.4.2, 3.5.1]
+        pandas-version: [2.2.1, 1.5.3]
         exclude:
-          - python-version: '3.11'
-            spark-version: 3.1.3
           - python-version: '3.11'
             spark-version: 3.2.4
           - python-version: '3.11'
@@ -51,6 +50,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install pytest pytest-spark pypandoc
         python -m pip install pyspark==${{ matrix.spark-version }}
+        python -m pip install pandas==${{ matrix.pandas-version }}
         python -m pip install .[dev]
     - name: Test with pytest
       run: |
@@ -62,7 +62,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11']
+        python-version: [3.9, '3.10', '3.11']
+
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}
 
@@ -88,7 +89,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11']
+        python-version: [3.9, '3.10', '3.11']
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}
 

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         python-version: [3.9, '3.10', '3.11']
         spark-version: [3.2.4, 3.3.4, 3.4.2, 3.5.1]
-        pandas-version: [2.2.1, 1.5.3]
+        pandas-version: [2.2.2, 1.5.3]
         exclude:
           - python-version: '3.11'
             spark-version: 3.2.4

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,3 +4,4 @@
 - Mark Zhou
 - Ian Whitestone
 - Faisal Dosani
+- Lorenzo Mercado

--- a/README.md
+++ b/README.md
@@ -38,16 +38,44 @@ pip install datacompy[ray]
 
 ```
 
-### In-scope Spark versions
-Different versions of Spark play nicely with only certain versions of Python below is a matrix of what we test with
+### Legacy Spark Deprecation
 
-|             | Spark 3.1.3  | Spark 3.2.3 | Spark 3.3.4 | Spark 3.4.2 | Spark 3.5.0 |
-|-------------|--------------|-------------|-------------|-------------|-------------|
-| Python 3.8  | ✅           | ✅           | ✅           | ✅          | ✅          |
-| Python 3.9  | ✅           | ✅           | ✅           | ✅          | ✅          |
-| Python 3.10 | ✅           | ✅           | ✅           | ✅          | ✅          |
-| Python 3.11 | ❌           | ❌           | ❌           | ✅          | ✅          |
-| Python 3.12 | ❌           | ❌           | ❌           | ❌          | ❌          |
+#### Starting with version 0.12.0
+
+The original ``SparkCompare`` implementation differs from all the other native implementations. To align the API better, and keep behaviour consistent we are deprecating ``SparkCompare`` into a new module ``LegacySparkCompare``
+
+If you wish to use the old SparkCompare moving forward you can
+
+```python
+import datacompy.legacy.LegacySparkCompare
+``` 
+
+#### Supported versions and dependncies
+
+Different versions of Spark, Pandas, and Python interact differently. Below is a matrix of what we test with. 
+With the move to Pandas on Spark API and compatability issues with Pandas 2+ we will for the mean time note support Pandas 2 
+with the Pandas on Spark implementation. Spark plans to support Pandas 2 in [Spark 4](https://issues.apache.org/jira/browse/SPARK-44101)
+
+With version ``0.12.0``:
+- Not support Pandas ``2.0.0`` For the native Spark implemention
+- Spark ``3.1`` support will be dropped
+- Python ``3.8`` support is dropped
+
+
+|             | Spark 3.2.4 | Spark 3.3.4 | Spark 3.4.2 | Spark 3.5.1 |
+|-------------|-------------|-------------|-------------|-------------|
+| Python 3.9  | ✅           | ✅           | ✅           | ✅           |
+| Python 3.10 | ✅           | ✅           | ✅           | ✅           |
+| Python 3.11 | ❌           | ❌           | ✅           | ✅           |
+| Python 3.12 | ❌           | ❌           | ❌           | ❌           |
+
+
+|               | Pandas < 1.5.3 | Pandas >=2.0.0 |
+|---------------|----------------|----------------|
+| Native Pandas | ✅              | ✅              |
+| Native Spark  | ✅              | ❌              |
+| Fugue         | ✅              | ✅              |
+
 
 
 > [!NOTE]
@@ -56,7 +84,7 @@ Different versions of Spark play nicely with only certain versions of Python bel
 ## Supported backends
 
 - Pandas: ([See documentation](https://capitalone.github.io/datacompy/pandas_usage.html))
-- Spark: ([See documentation](https://capitalone.github.io/datacompy/spark_usage.html))
+- Spark (Pandas on Spark API): ([See documentation](https://capitalone.github.io/datacompy/spark_usage.html))
 - Polars (Experimental): ([See documentation](https://capitalone.github.io/datacompy/polars_usage.html))
 - Fugue is a Python library that provides a unified interface for data processing on Pandas, DuckDB, Polars, Arrow,
   Spark, Dask, Ray, and many other backends. DataComPy integrates with Fugue to provide a simple way to compare data

--- a/datacompy/__init__.py
+++ b/datacompy/__init__.py
@@ -19,6 +19,7 @@ from datacompy.core import *
 from datacompy.fugue import (
     all_columns_match,
     all_rows_overlap,
+    count_matching_rows,
     intersect_columns,
     is_match,
     report,

--- a/datacompy/__init__.py
+++ b/datacompy/__init__.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.11.3"
+__version__ = "0.12.0"
 
 from datacompy.core import *
 from datacompy.fugue import (
@@ -25,4 +25,4 @@ from datacompy.fugue import (
     unq_columns,
 )
 from datacompy.polars import PolarsCompare
-from datacompy.spark import NUMERIC_SPARK_TYPES, SparkCompare
+from datacompy.spark import SparkCompare

--- a/datacompy/fugue.py
+++ b/datacompy/fugue.py
@@ -291,6 +291,101 @@ def all_rows_overlap(
     return all(overlap)
 
 
+def count_matching_rows(
+    df1: AnyDataFrame,
+    df2: AnyDataFrame,
+    join_columns: Union[str, List[str]],
+    abs_tol: float = 0,
+    rel_tol: float = 0,
+    df1_name: str = "df1",
+    df2_name: str = "df2",
+    ignore_spaces: bool = False,
+    ignore_case: bool = False,
+    cast_column_names_lower: bool = True,
+    parallelism: Optional[int] = None,
+    strict_schema: bool = False,
+) -> int:
+    """Count the number of rows match (on overlapping fields)
+
+    Parameters
+    ----------
+    df1 : ``AnyDataFrame``
+        First dataframe to check
+    df2 : ``AnyDataFrame``
+        Second dataframe to check
+    join_columns : list or str, optional
+        Column(s) to join dataframes on.  If a string is passed in, that one
+        column will be used.
+    abs_tol : float, optional
+        Absolute tolerance between two values.
+    rel_tol : float, optional
+        Relative tolerance between two values.
+    df1_name : str, optional
+        A string name for the first dataframe.  This allows the reporting to
+        print out an actual name instead of "df1", and allows human users to
+        more easily track the dataframes.
+    df2_name : str, optional
+        A string name for the second dataframe
+    ignore_spaces : bool, optional
+        Flag to strip whitespace (including newlines) from string columns (including any join
+        columns)
+    ignore_case : bool, optional
+        Flag to ignore the case of string columns
+    cast_column_names_lower: bool, optional
+        Boolean indicator that controls of column names will be cast into lower case
+    parallelism: int, optional
+        An integer representing the amount of parallelism. Entering a value for this
+        will force to use of Fugue over just vanilla Pandas
+    strict_schema: bool, optional
+        The schema must match exactly if set to ``True``. This includes the names and types. Allows for a fast fail.
+
+    Returns
+    -------
+    int
+        Number of matching rows
+    """
+    if (
+        isinstance(df1, pd.DataFrame)
+        and isinstance(df2, pd.DataFrame)
+        and parallelism is None  # user did not specify parallelism
+        and fa.get_current_parallelism() == 1  # currently on a local execution engine
+    ):
+        comp = Compare(
+            df1=df1,
+            df2=df2,
+            join_columns=join_columns,
+            abs_tol=abs_tol,
+            rel_tol=rel_tol,
+            df1_name=df1_name,
+            df2_name=df2_name,
+            ignore_spaces=ignore_spaces,
+            ignore_case=ignore_case,
+            cast_column_names_lower=cast_column_names_lower,
+        )
+        return comp.count_matching_rows()
+
+    try:
+        count_matching_rows = _distributed_compare(
+            df1=df1,
+            df2=df2,
+            join_columns=join_columns,
+            return_obj_func=lambda comp: comp.count_matching_rows(),
+            abs_tol=abs_tol,
+            rel_tol=rel_tol,
+            df1_name=df1_name,
+            df2_name=df2_name,
+            ignore_spaces=ignore_spaces,
+            ignore_case=ignore_case,
+            cast_column_names_lower=cast_column_names_lower,
+            parallelism=parallelism,
+            strict_schema=strict_schema,
+        )
+    except _StrictSchemaError:
+        return False
+
+    return sum(count_matching_rows)
+
+
 def report(
     df1: AnyDataFrame,
     df2: AnyDataFrame,
@@ -460,7 +555,6 @@ def report(
     any_mismatch = len(match_sample) > 0
 
     # Column Matching
-    cnt_intersect = shape0("intersect_rows_shape")
     rpt += render(
         "column_comparison.txt",
         len([col for col in column_stats if col["unequal_cnt"] > 0]),

--- a/datacompy/legacy.py
+++ b/datacompy/legacy.py
@@ -1,0 +1,928 @@
+#
+# Copyright 2024 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from enum import Enum
+from itertools import chain
+from typing import Any, Dict, List, Optional, Set, TextIO, Tuple, Union
+from warnings import warn
+
+try:
+    import pyspark
+    from pyspark.sql import functions as F
+except ImportError:
+    pass  # Let non-Spark people at least enjoy the loveliness of the pandas datacompy functionality
+
+
+warn(
+    f"The module {__name__} is deprecated. In future versions LegacySparkCompare will be completely removed.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+
+class MatchType(Enum):
+    MISMATCH, MATCH, KNOWN_DIFFERENCE = range(3)
+
+
+# Used for checking equality with decimal(X, Y) types. Otherwise treated as the string "decimal".
+def decimal_comparator() -> str:
+    class DecimalComparator(str):
+        def __eq__(self, other: str) -> bool:  # type: ignore[override]
+            return len(other) >= 7 and other[0:7] == "decimal"
+
+    return DecimalComparator("decimal")
+
+
+NUMERIC_SPARK_TYPES = [
+    "tinyint",
+    "smallint",
+    "int",
+    "bigint",
+    "float",
+    "double",
+    decimal_comparator(),
+]
+
+
+def _is_comparable(type1: str, type2: str) -> bool:
+    """Checks if two Spark data types can be safely compared.
+    Two data types are considered comparable if any of the following apply:
+        1. Both data types are the same
+        2. Both data types are numeric
+
+    Parameters
+    ----------
+    type1 : str
+        A string representation of a Spark data type
+    type2 : str
+        A string representation of a Spark data type
+
+    Returns
+    -------
+    bool
+        True if both data types are comparable
+    """
+
+    return type1 == type2 or (
+        type1 in NUMERIC_SPARK_TYPES and type2 in NUMERIC_SPARK_TYPES
+    )
+
+
+class LegacySparkCompare:
+    """Comparison class used to compare two Spark Dataframes.
+
+    Extends the ``Compare`` functionality to the wide world of Spark and
+    out-of-memory data.
+
+    Parameters
+    ----------
+    spark_session : ``pyspark.sql.SparkSession``
+        A ``SparkSession`` to be used to execute Spark commands in the
+        comparison.
+    base_df : ``pyspark.sql.DataFrame``
+        The dataframe to serve as a basis for comparison. While you will
+        ultimately get the same results comparing A to B as you will comparing
+        B to A, by convention ``base_df`` should be the canonical, gold
+        standard reference dataframe in the comparison.
+    compare_df : ``pyspark.sql.DataFrame``
+        The dataframe to be compared against ``base_df``.
+    join_columns : list
+        A list of columns comprising the join key(s) of the two dataframes.
+        If the column names are the same in the two dataframes, the names of
+        the columns can be given as strings. If the names differ, the
+        ``join_columns`` list should include tuples of the form
+        (base_column_name, compare_column_name).
+    column_mapping : list[tuple], optional
+        If columns to be compared have different names in the base and compare
+        dataframes, a list should be provided in ``columns_mapping`` consisting
+        of tuples of the form (base_column_name, compare_column_name) for each
+        set of differently-named columns to be compared against each other.
+    cache_intermediates : bool, optional
+        Whether or not ``SparkCompare`` will cache intermediate dataframes
+        (such as the deduplicated version of dataframes, or the joined
+        comparison). This will take a large amount of cache, proportional to
+        the size of your dataframes, but will significantly speed up
+        performance, as multiple steps will not have to recompute
+        transformations. False by default.
+    known_differences : list[dict], optional
+        A list of dictionaries that define transformations to apply to the
+        compare dataframe to match values when there are known differences
+        between base and compare. The dictionaries should contain:
+
+            * name: A name that describes the transformation
+            * types: The types that the transformation should be applied to.
+                This prevents certain transformations from being applied to
+                types that don't make sense and would cause exceptions.
+            * transformation: A Spark SQL statement to apply to the column
+                in the compare dataset. The string "{input}" will be replaced
+                by the variable in question.
+    abs_tol : float, optional
+        Absolute tolerance between two values.
+    rel_tol : float, optional
+        Relative tolerance between two values.
+    show_all_columns : bool, optional
+        If true, all columns will be shown in the report including columns
+        with a 100% match rate.
+    match_rates : bool, optional
+        If true, match rates by column will be shown in the column summary.
+
+    Returns
+    -------
+    SparkCompare
+        Instance of a ``SparkCompare`` object, ready to do some comparin'.
+        Note that if ``cache_intermediates=True``, this instance will already
+        have done some work deduping the input dataframes. If
+        ``cache_intermediates=False``, the instantiation of this object is lazy.
+    """
+
+    def __init__(
+        self,
+        spark_session: "pyspark.sql.SparkSession",
+        base_df: "pyspark.sql.DataFrame",
+        compare_df: "pyspark.sql.DataFrame",
+        join_columns: List[Union[str, Tuple[str, str]]],
+        column_mapping: Optional[List[Tuple[str, str]]] = None,
+        cache_intermediates: bool = False,
+        known_differences: Optional[List[Dict[str, Any]]] = None,
+        rel_tol: float = 0,
+        abs_tol: float = 0,
+        show_all_columns: bool = False,
+        match_rates: bool = False,
+    ):
+        self.rel_tol = rel_tol
+        self.abs_tol = abs_tol
+        if self.rel_tol < 0 or self.abs_tol < 0:
+            raise ValueError("Please enter positive valued tolerances")
+        self.show_all_columns = show_all_columns
+        self.match_rates = match_rates
+
+        self._original_base_df = base_df
+        self._original_compare_df = compare_df
+        self.cache_intermediates = cache_intermediates
+
+        self.join_columns = self._tuplizer(input_list=join_columns)
+        self._join_column_names = [name[0] for name in self.join_columns]
+
+        self._known_differences = known_differences
+
+        if column_mapping:
+            for mapping in column_mapping:
+                compare_df = compare_df.withColumnRenamed(mapping[1], mapping[0])
+            self.column_mapping = dict(column_mapping)
+        else:
+            self.column_mapping = {}
+
+        for mapping in self.join_columns:
+            if mapping[1] != mapping[0]:
+                compare_df = compare_df.withColumnRenamed(mapping[1], mapping[0])
+
+        self.spark = spark_session
+        self.base_unq_rows = self.compare_unq_rows = None
+        self._base_row_count: Optional[int] = None
+        self._compare_row_count: Optional[int] = None
+        self._common_row_count: Optional[int] = None
+        self._joined_dataframe: Optional["pyspark.sql.DataFrame"] = None
+        self._rows_only_base: Optional["pyspark.sql.DataFrame"] = None
+        self._rows_only_compare: Optional["pyspark.sql.DataFrame"] = None
+        self._all_matched_rows: Optional["pyspark.sql.DataFrame"] = None
+        self._all_rows_mismatched: Optional["pyspark.sql.DataFrame"] = None
+        self.columns_match_dict: Dict[str, Any] = {}
+
+        # drop the duplicates before actual comparison made.
+        self.base_df = base_df.dropDuplicates(self._join_column_names)
+        self.compare_df = compare_df.dropDuplicates(self._join_column_names)
+
+        if cache_intermediates:
+            self.base_df.cache()
+            self._base_row_count = self.base_df.count()
+            self.compare_df.cache()
+            self._compare_row_count = self.compare_df.count()
+
+    def _tuplizer(
+        self, input_list: List[Union[str, Tuple[str, str]]]
+    ) -> List[Tuple[str, str]]:
+        join_columns: List[Tuple[str, str]] = []
+        for val in input_list:
+            if isinstance(val, str):
+                join_columns.append((val, val))
+            else:
+                join_columns.append(val)
+
+        return join_columns
+
+    @property
+    def columns_in_both(self) -> Set[str]:
+        """set[str]: Get columns in both dataframes"""
+        return set(self.base_df.columns) & set(self.compare_df.columns)
+
+    @property
+    def columns_compared(self) -> List[str]:
+        """list[str]: Get columns to be compared in both dataframes (all
+        columns in both excluding the join key(s)"""
+        return [
+            column
+            for column in list(self.columns_in_both)
+            if column not in self._join_column_names
+        ]
+
+    @property
+    def columns_only_base(self) -> Set[str]:
+        """set[str]: Get columns that are unique to the base dataframe"""
+        return set(self.base_df.columns) - set(self.compare_df.columns)
+
+    @property
+    def columns_only_compare(self) -> Set[str]:
+        """set[str]: Get columns that are unique to the compare dataframe"""
+        return set(self.compare_df.columns) - set(self.base_df.columns)
+
+    @property
+    def base_row_count(self) -> int:
+        """int: Get the count of rows in the de-duped base dataframe"""
+        if self._base_row_count is None:
+            self._base_row_count = self.base_df.count()
+
+        return self._base_row_count
+
+    @property
+    def compare_row_count(self) -> int:
+        """int: Get the count of rows in the de-duped compare dataframe"""
+        if self._compare_row_count is None:
+            self._compare_row_count = self.compare_df.count()
+
+        return self._compare_row_count
+
+    @property
+    def common_row_count(self) -> int:
+        """int: Get the count of rows in common between base and compare dataframes"""
+        if self._common_row_count is None:
+            common_rows = self._get_or_create_joined_dataframe()
+            self._common_row_count = common_rows.count()
+
+        return self._common_row_count
+
+    def _get_unq_base_rows(self) -> "pyspark.sql.DataFrame":
+        """Get the rows only from base data frame"""
+        return self.base_df.select(self._join_column_names).subtract(
+            self.compare_df.select(self._join_column_names)
+        )
+
+    def _get_compare_rows(self) -> "pyspark.sql.DataFrame":
+        """Get the rows only from compare data frame"""
+        return self.compare_df.select(self._join_column_names).subtract(
+            self.base_df.select(self._join_column_names)
+        )
+
+    def _print_columns_summary(self, myfile: TextIO) -> None:
+        """Prints the column summary details"""
+        print("\n****** Column Summary ******", file=myfile)
+        print(
+            f"Number of columns in common with matching schemas: {len(self._columns_with_matching_schema())}",
+            file=myfile,
+        )
+        print(
+            f"Number of columns in common with schema differences: {len(self._columns_with_schemadiff())}",
+            file=myfile,
+        )
+        print(
+            f"Number of columns in base but not compare: {len(self.columns_only_base)}",
+            file=myfile,
+        )
+        print(
+            f"Number of columns in compare but not base: {len(self.columns_only_compare)}",
+            file=myfile,
+        )
+
+    def _print_only_columns(self, base_or_compare: str, myfile: TextIO) -> None:
+        """Prints the columns and data types only in either the base or compare datasets"""
+
+        if base_or_compare.upper() == "BASE":
+            columns = self.columns_only_base
+            df = self.base_df
+        elif base_or_compare.upper() == "COMPARE":
+            columns = self.columns_only_compare
+            df = self.compare_df
+        else:
+            raise ValueError(
+                f'base_or_compare must be BASE or COMPARE, but was "{base_or_compare}"'
+            )
+
+        # If there are no columns only in this dataframe, don't display this section
+        if not columns:
+            return
+
+        max_length = max([len(col) for col in columns] + [11])
+        format_pattern = f"{{:{max_length}s}}"
+
+        print(f"\n****** Columns In {base_or_compare.title()} Only ******", file=myfile)
+        print((format_pattern + "  Dtype").format("Column Name"), file=myfile)
+        print("-" * max_length + "  -------------", file=myfile)
+
+        for column in columns:
+            col_type = df.select(column).dtypes[0][1]
+            print((format_pattern + "  {:13s}").format(column, col_type), file=myfile)
+
+    def _columns_with_matching_schema(self) -> Dict[str, str]:
+        """This function will identify the columns which has matching schema"""
+        col_schema_match = {}
+        base_columns_dict = dict(self.base_df.dtypes)
+        compare_columns_dict = dict(self.compare_df.dtypes)
+
+        for base_row, base_type in base_columns_dict.items():
+            if base_row in compare_columns_dict:
+                compare_column_type = compare_columns_dict.get(base_row)
+                if compare_column_type is not None and base_type in compare_column_type:
+                    col_schema_match[base_row] = compare_column_type
+
+        return col_schema_match
+
+    def _columns_with_schemadiff(self) -> Dict[str, Dict[str, str]]:
+        """This function will identify the columns which has different schema"""
+        col_schema_diff = {}
+        base_columns_dict = dict(self.base_df.dtypes)
+        compare_columns_dict = dict(self.compare_df.dtypes)
+
+        for base_row, base_type in base_columns_dict.items():
+            if base_row in compare_columns_dict:
+                compare_column_type = compare_columns_dict.get(base_row)
+                if (
+                    compare_column_type is not None
+                    and base_type not in compare_column_type
+                ):
+                    col_schema_diff[base_row] = dict(
+                        base_type=base_type,
+                        compare_type=compare_column_type,
+                    )
+        return col_schema_diff
+
+    @property
+    def rows_both_mismatch(self) -> Optional["pyspark.sql.DataFrame"]:
+        """pyspark.sql.DataFrame: Returns all rows in both dataframes that have mismatches"""
+        if self._all_rows_mismatched is None:
+            self._merge_dataframes()
+
+        return self._all_rows_mismatched
+
+    @property
+    def rows_both_all(self) -> Optional["pyspark.sql.DataFrame"]:
+        """pyspark.sql.DataFrame: Returns all rows in both dataframes"""
+        if self._all_matched_rows is None:
+            self._merge_dataframes()
+
+        return self._all_matched_rows
+
+    @property
+    def rows_only_base(self) -> "pyspark.sql.DataFrame":
+        """pyspark.sql.DataFrame: Returns rows only in the base dataframe"""
+        if not self._rows_only_base:
+            base_rows = self._get_unq_base_rows()
+            base_rows.createOrReplaceTempView("baseRows")
+            self.base_df.createOrReplaceTempView("baseTable")
+            join_condition = " AND ".join(
+                [
+                    "A.`" + name + "`<=>B.`" + name + "`"
+                    for name in self._join_column_names
+                ]
+            )
+            sql_query = "select A.* from baseTable as A, baseRows as B where {}".format(
+                join_condition
+            )
+            self._rows_only_base = self.spark.sql(sql_query)
+
+            if self.cache_intermediates:
+                self._rows_only_base.cache().count()
+
+        return self._rows_only_base
+
+    @property
+    def rows_only_compare(self) -> Optional["pyspark.sql.DataFrame"]:
+        """pyspark.sql.DataFrame: Returns rows only in the compare dataframe"""
+        if not self._rows_only_compare:
+            compare_rows = self._get_compare_rows()
+            compare_rows.createOrReplaceTempView("compareRows")
+            self.compare_df.createOrReplaceTempView("compareTable")
+            where_condition = " AND ".join(
+                [
+                    "A.`" + name + "`<=>B.`" + name + "`"
+                    for name in self._join_column_names
+                ]
+            )
+            sql_query = (
+                "select A.* from compareTable as A, compareRows as B where {}".format(
+                    where_condition
+                )
+            )
+            self._rows_only_compare = self.spark.sql(sql_query)
+
+            if self.cache_intermediates:
+                self._rows_only_compare.cache().count()
+
+        return self._rows_only_compare
+
+    def _generate_select_statement(self, match_data: bool = True) -> str:
+        """This function is to generate the select statement to be used later in the query."""
+        base_only = list(set(self.base_df.columns) - set(self.compare_df.columns))
+        compare_only = list(set(self.compare_df.columns) - set(self.base_df.columns))
+        sorted_list = sorted(list(chain(base_only, compare_only, self.columns_in_both)))
+        select_statement = ""
+
+        for column_name in sorted_list:
+            if column_name in self.columns_compared:
+                if match_data:
+                    select_statement = select_statement + ",".join(
+                        [self._create_case_statement(name=column_name)]
+                    )
+                else:
+                    select_statement = select_statement + ",".join(
+                        [self._create_select_statement(name=column_name)]
+                    )
+            elif column_name in base_only:
+                select_statement = select_statement + ",".join(
+                    ["A.`" + column_name + "`"]
+                )
+
+            elif column_name in compare_only:
+                if match_data:
+                    select_statement = select_statement + ",".join(
+                        ["B.`" + column_name + "`"]
+                    )
+                else:
+                    select_statement = select_statement + ",".join(
+                        ["A.`" + column_name + "`"]
+                    )
+            elif column_name in self._join_column_names:
+                select_statement = select_statement + ",".join(
+                    ["A.`" + column_name + "`"]
+                )
+
+            if column_name != sorted_list[-1]:
+                select_statement = select_statement + " , "
+
+        return select_statement
+
+    def _merge_dataframes(self) -> None:
+        """Merges the two dataframes and creates self._all_matched_rows and self._all_rows_mismatched."""
+        full_joined_dataframe = self._get_or_create_joined_dataframe()
+        full_joined_dataframe.createOrReplaceTempView("full_matched_table")
+
+        select_statement = self._generate_select_statement(False)
+        select_query = """SELECT {} FROM full_matched_table A""".format(
+            select_statement
+        )
+        self._all_matched_rows = self.spark.sql(select_query).orderBy(
+            self._join_column_names  # type: ignore[arg-type]
+        )
+        self._all_matched_rows.createOrReplaceTempView("matched_table")
+
+        where_cond = " OR ".join(
+            ["A.`" + name + "_match`= False" for name in self.columns_compared]
+        )
+        mismatch_query = """SELECT * FROM matched_table A WHERE {}""".format(where_cond)
+        self._all_rows_mismatched = self.spark.sql(mismatch_query).orderBy(
+            self._join_column_names  # type: ignore[arg-type]
+        )
+
+    def _get_or_create_joined_dataframe(self) -> "pyspark.sql.DataFrame":
+        if self._joined_dataframe is None:
+            join_condition = " AND ".join(
+                [
+                    "A.`" + name + "`<=>B.`" + name + "`"
+                    for name in self._join_column_names
+                ]
+            )
+            select_statement = self._generate_select_statement(match_data=True)
+
+            self.base_df.createOrReplaceTempView("base_table")
+            self.compare_df.createOrReplaceTempView("compare_table")
+
+            join_query = r"""
+                   SELECT {}
+                   FROM base_table A
+                   JOIN compare_table B
+                   ON {}""".format(
+                select_statement, join_condition
+            )
+
+            self._joined_dataframe = self.spark.sql(join_query)
+            if self.cache_intermediates:
+                self._joined_dataframe.cache()
+                self._common_row_count = self._joined_dataframe.count()
+
+        return self._joined_dataframe
+
+    def _print_num_of_rows_with_column_equality(self, myfile: TextIO) -> None:
+        # match_dataframe contains columns from both dataframes with flag to indicate if columns matched
+        match_dataframe = self._get_or_create_joined_dataframe().select(
+            *self.columns_compared
+        )
+        match_dataframe.createOrReplaceTempView("matched_df")
+
+        where_cond = " AND ".join(
+            [
+                "A.`" + name + "`=" + str(MatchType.MATCH.value)
+                for name in self.columns_compared
+            ]
+        )
+        match_query = (
+            r"""SELECT count(*) AS row_count FROM matched_df A WHERE {}""".format(
+                where_cond
+            )
+        )
+        all_rows_matched = self.spark.sql(match_query)
+        all_rows_matched_head = all_rows_matched.head()
+        matched_rows = (
+            all_rows_matched_head[0] if all_rows_matched_head is not None else 0
+        )
+
+        print("\n****** Row Comparison ******", file=myfile)
+        print(
+            f"Number of rows with some columns unequal: {self.common_row_count - matched_rows}",
+            file=myfile,
+        )
+        print(f"Number of rows with all columns equal: {matched_rows}", file=myfile)
+
+    def _populate_columns_match_dict(self) -> None:
+        """
+        side effects:
+            columns_match_dict assigned to { column -> match_type_counts }
+                where:
+                    column (string): Name of a column that exists in both the base and comparison columns
+                    match_type_counts (list of int with size = len(MatchType)): The number of each match type seen for this column (in order of the MatchType enum values)
+
+        returns: None
+        """
+
+        match_dataframe = self._get_or_create_joined_dataframe().select(
+            *self.columns_compared
+        )
+
+        def helper(c: str) -> "pyspark.sql.Column":
+            # Create a predicate for each match type, comparing column values to the match type value
+            predicates = [F.col(c) == k.value for k in MatchType]
+            # Create a tuple(number of match types found for each match type in this column)
+            return F.struct(
+                [F.lit(F.sum(pred.cast("integer"))) for pred in predicates]
+            ).alias(c)
+
+        # For each column, create a single tuple. This tuple's values correspond to the number of times
+        # each match type appears in that column
+        match_data_agg = match_dataframe.agg(
+            *[helper(col) for col in self.columns_compared]
+        ).collect()
+        match_data = match_data_agg[0]
+
+        for c in self.columns_compared:
+            self.columns_match_dict[c] = match_data[c]
+
+    def _create_select_statement(self, name: str) -> str:
+        if self._known_differences:
+            match_type_comparison = ""
+            for k in MatchType:
+                match_type_comparison += (
+                    " WHEN (A.`{name}`={match_value}) THEN '{match_name}'".format(
+                        name=name, match_value=str(k.value), match_name=k.name
+                    )
+                )
+            return "A.`{name}_base`, A.`{name}_compare`, (CASE WHEN (A.`{name}`={match_failure}) THEN False ELSE True END) AS `{name}_match`, (CASE {match_type_comparison} ELSE 'UNDEFINED' END) AS `{name}_match_type` ".format(
+                name=name,
+                match_failure=MatchType.MISMATCH.value,
+                match_type_comparison=match_type_comparison,
+            )
+        else:
+            return "A.`{name}_base`, A.`{name}_compare`, CASE WHEN (A.`{name}`={match_failure})  THEN False ELSE True END AS `{name}_match` ".format(
+                name=name, match_failure=MatchType.MISMATCH.value
+            )
+
+    def _create_case_statement(self, name: str) -> str:
+        equal_comparisons = ["(A.`{name}` IS NULL AND B.`{name}` IS NULL)"]
+        known_diff_comparisons = ["(FALSE)"]
+
+        base_dtype = [d[1] for d in self.base_df.dtypes if d[0] == name][0]
+        compare_dtype = [d[1] for d in self.compare_df.dtypes if d[0] == name][0]
+
+        if _is_comparable(base_dtype, compare_dtype):
+            if (base_dtype in NUMERIC_SPARK_TYPES) and (
+                compare_dtype in NUMERIC_SPARK_TYPES
+            ):  # numeric tolerance comparison
+                equal_comparisons.append(
+                    "((A.`{name}`=B.`{name}`) OR ((abs(A.`{name}`-B.`{name}`))<=("
+                    + str(self.abs_tol)
+                    + "+("
+                    + str(self.rel_tol)
+                    + "*abs(A.`{name}`)))))"
+                )
+            else:  # non-numeric comparison
+                equal_comparisons.append("((A.`{name}`=B.`{name}`))")
+
+        if self._known_differences:
+            new_input = "B.`{name}`"
+            for kd in self._known_differences:
+                if compare_dtype in kd["types"]:
+                    if "flags" in kd and "nullcheck" in kd["flags"]:
+                        known_diff_comparisons.append(
+                            "(("
+                            + kd["transformation"].format(new_input, input=new_input)
+                            + ") is null AND A.`{name}` is null)"
+                        )
+                    else:
+                        known_diff_comparisons.append(
+                            "(("
+                            + kd["transformation"].format(new_input, input=new_input)
+                            + ") = A.`{name}`)"
+                        )
+
+        case_string = (
+            "( CASE WHEN ("
+            + " OR ".join(equal_comparisons)
+            + ") THEN {match_success} WHEN ("
+            + " OR ".join(known_diff_comparisons)
+            + ") THEN {match_known_difference} ELSE {match_failure} END) "
+            + "AS `{name}`, A.`{name}` AS `{name}_base`, B.`{name}` AS `{name}_compare`"
+        )
+
+        return case_string.format(
+            name=name,
+            match_success=MatchType.MATCH.value,
+            match_known_difference=MatchType.KNOWN_DIFFERENCE.value,
+            match_failure=MatchType.MISMATCH.value,
+        )
+
+    def _print_row_summary(self, myfile: TextIO) -> None:
+        base_df_cnt = self.base_df.count()
+        compare_df_cnt = self.compare_df.count()
+        base_df_with_dup_cnt = self._original_base_df.count()
+        compare_df_with_dup_cnt = self._original_compare_df.count()
+
+        print("\n****** Row Summary ******", file=myfile)
+        print(f"Number of rows in common: {self.common_row_count}", file=myfile)
+        print(
+            f"Number of rows in base but not compare: {base_df_cnt - self.common_row_count}",
+            file=myfile,
+        )
+        print(
+            f"Number of rows in compare but not base: {compare_df_cnt - self.common_row_count}",
+            file=myfile,
+        )
+        print(
+            f"Number of duplicate rows found in base: {base_df_with_dup_cnt - base_df_cnt}",
+            file=myfile,
+        )
+        print(
+            f"Number of duplicate rows found in compare: {compare_df_with_dup_cnt - compare_df_cnt}",
+            file=myfile,
+        )
+
+    def _print_schema_diff_details(self, myfile: TextIO) -> None:
+        schema_diff_dict = self._columns_with_schemadiff()
+
+        if not schema_diff_dict:  # If there are no differences, don't print the section
+            return
+
+        # For columns with mismatches, what are the longest base and compare column name lengths (with minimums)?
+        base_name_max = max([len(key) for key in schema_diff_dict] + [16])
+        compare_name_max = max(
+            [len(self._base_to_compare_name(key)) for key in schema_diff_dict] + [19]
+        )
+
+        format_pattern = "{{:{base}s}}  {{:{compare}s}}".format(
+            base=base_name_max, compare=compare_name_max
+        )
+
+        print("\n****** Schema Differences ******", file=myfile)
+        print(
+            (format_pattern + "  Base Dtype     Compare Dtype").format(
+                "Base Column Name", "Compare Column Name"
+            ),
+            file=myfile,
+        )
+        print(
+            "-" * base_name_max
+            + "  "
+            + "-" * compare_name_max
+            + "  -------------  -------------",
+            file=myfile,
+        )
+
+        for base_column, types in schema_diff_dict.items():
+            compare_column = self._base_to_compare_name(base_column)
+
+            print(
+                (format_pattern + "  {:13s}  {:13s}").format(
+                    base_column,
+                    compare_column,
+                    types["base_type"],
+                    types["compare_type"],
+                ),
+                file=myfile,
+            )
+
+    def _base_to_compare_name(self, base_name: str) -> str:
+        """Translates a column name in the base dataframe to its counterpart in the
+        compare dataframe, if they are different."""
+
+        if base_name in self.column_mapping:
+            return self.column_mapping[base_name]
+        else:
+            for name in self.join_columns:
+                if base_name == name[0]:
+                    return name[1]
+            return base_name
+
+    def _print_row_matches_by_column(self, myfile: TextIO) -> None:
+        self._populate_columns_match_dict()
+        columns_with_mismatches = {
+            key: self.columns_match_dict[key]
+            for key in self.columns_match_dict
+            if self.columns_match_dict[key][MatchType.MISMATCH.value]
+        }
+
+        # corner case: when all columns match but no rows match
+        # issue: #276
+        try:
+            columns_fully_matching = {
+                key: self.columns_match_dict[key]
+                for key in self.columns_match_dict
+                if sum(self.columns_match_dict[key])
+                == self.columns_match_dict[key][MatchType.MATCH.value]
+            }
+        except TypeError:
+            columns_fully_matching = {}
+
+        try:
+            columns_with_any_diffs = {
+                key: self.columns_match_dict[key]
+                for key in self.columns_match_dict
+                if sum(self.columns_match_dict[key])
+                != self.columns_match_dict[key][MatchType.MATCH.value]
+            }
+        except TypeError:
+            columns_with_any_diffs = {}
+        #
+
+        base_types = {x[0]: x[1] for x in self.base_df.dtypes}
+        compare_types = {x[0]: x[1] for x in self.compare_df.dtypes}
+
+        print("\n****** Column Comparison ******", file=myfile)
+
+        if self._known_differences:
+            print(
+                f"Number of columns compared with unexpected differences in some values: {len(columns_with_mismatches)}",
+                file=myfile,
+            )
+            print(
+                f"Number of columns compared with all values equal but known differences found: {len(self.columns_compared) - len(columns_with_mismatches) - len(columns_fully_matching)}",
+                file=myfile,
+            )
+            print(
+                f"Number of columns compared with all values completely equal: {len(columns_fully_matching)}",
+                file=myfile,
+            )
+        else:
+            print(
+                f"Number of columns compared with some values unequal: {len(columns_with_mismatches)}",
+                file=myfile,
+            )
+            print(
+                f"Number of columns compared with all values equal: {len(columns_fully_matching)}",
+                file=myfile,
+            )
+
+        # If all columns matched, don't print columns with unequal values
+        if (not self.show_all_columns) and (
+            len(columns_fully_matching) == len(self.columns_compared)
+        ):
+            return
+
+        # if show_all_columns is set, set column name length maximum to max of ALL columns(with minimum)
+        if self.show_all_columns:
+            base_name_max = max([len(key) for key in self.columns_match_dict] + [16])
+            compare_name_max = max(
+                [
+                    len(self._base_to_compare_name(key))
+                    for key in self.columns_match_dict
+                ]
+                + [19]
+            )
+
+        # For columns with any differences, what are the longest base and compare column name lengths (with minimums)?
+        else:
+            base_name_max = max([len(key) for key in columns_with_any_diffs] + [16])
+            compare_name_max = max(
+                [len(self._base_to_compare_name(key)) for key in columns_with_any_diffs]
+                + [19]
+            )
+
+        """ list of (header, condition, width, align)
+                where
+                    header (String) : output header for a column
+                    condition (Bool): true if this header should be displayed
+                    width (Int)     : width of the column
+                    align (Bool)    : true if right-aligned
+        """
+        headers_columns_unequal = [
+            ("Base Column Name", True, base_name_max, False),
+            ("Compare Column Name", True, compare_name_max, False),
+            ("Base Dtype   ", True, 13, False),
+            ("Compare Dtype", True, 13, False),
+            ("# Matches", True, 9, True),
+            ("# Known Diffs", self._known_differences is not None, 13, True),
+            ("# Mismatches", True, 12, True),
+        ]
+        if self.match_rates:
+            headers_columns_unequal.append(("Match Rate %", True, 12, True))
+        headers_columns_unequal_valid = [h for h in headers_columns_unequal if h[1]]
+        padding = 2  # spaces to add to left and right of each column
+
+        if self.show_all_columns:
+            print("\n****** Columns with Equal/Unequal Values ******", file=myfile)
+        else:
+            print("\n****** Columns with Unequal Values ******", file=myfile)
+
+        format_pattern = (" " * padding).join(
+            [
+                ("{:" + (">" if h[3] else "") + str(h[2]) + "}")
+                for h in headers_columns_unequal_valid
+            ]
+        )
+        print(
+            format_pattern.format(*[h[0] for h in headers_columns_unequal_valid]),
+            file=myfile,
+        )
+        print(
+            format_pattern.format(
+                *["-" * len(h[0]) for h in headers_columns_unequal_valid]
+            ),
+            file=myfile,
+        )
+
+        for column_name, column_values in sorted(
+            self.columns_match_dict.items(), key=lambda i: i[0]
+        ):
+            num_matches = column_values[MatchType.MATCH.value]
+            num_known_diffs = (
+                None
+                if self._known_differences is None
+                else column_values[MatchType.KNOWN_DIFFERENCE.value]
+            )
+            num_mismatches = column_values[MatchType.MISMATCH.value]
+            compare_column = self._base_to_compare_name(column_name)
+
+            if num_mismatches or num_known_diffs or self.show_all_columns:
+                output_row = [
+                    column_name,
+                    compare_column,
+                    base_types.get(column_name),
+                    compare_types.get(column_name),
+                    str(num_matches),
+                    str(num_mismatches),
+                ]
+                if self.match_rates:
+                    match_rate = 100 * (
+                        1
+                        - (column_values[MatchType.MISMATCH.value] + 0.0)
+                        / self.common_row_count
+                        + 0.0
+                    )
+                    output_row.append("{:02.5f}".format(match_rate))
+                if num_known_diffs is not None:
+                    output_row.insert(len(output_row) - 1, str(num_known_diffs))
+                print(format_pattern.format(*output_row), file=myfile)
+
+    # noinspection PyUnresolvedReferences
+    def report(self, file: TextIO = sys.stdout) -> None:
+        """Creates a comparison report and prints it to the file specified
+        (stdout by default).
+
+        Parameters
+        ----------
+        file : ``file``, optional
+            A filehandle to write the report to. By default, this is
+            sys.stdout, printing the report to stdout. You can also redirect
+            this to an output file, as in the example.
+
+        Examples
+        --------
+        >>> with open('my_report.txt', 'w') as report_file:
+        ...     comparison.report(file=report_file)
+        """
+
+        self._print_columns_summary(file)
+        self._print_schema_diff_details(file)
+        self._print_only_columns("BASE", file)
+        self._print_only_columns("COMPARE", file)
+        self._print_row_summary(file)
+        self._merge_dataframes()
+        self._print_num_of_rows_with_column_equality(file)
+        self._print_row_matches_by_column(file)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,7 +10,7 @@ Contents
 
     Installation <install>
     Pandas Usage <pandas_usage>
-    Spark Usage <spark_usage>
+    Spark (Pandas on Spark) Usage <spark_usage>
     Polars Usage <polars_usage>
     Fugue Usage <fugue_usage>
     Developer Instructions <developer_instructions>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ maintainers = [
 ]
 license = {text = "Apache Software License"}
 dependencies = ["pandas<=2.2.1,>=0.25.0", "numpy<=1.26.4,>=1.22.0", "ordered-set<=4.1.0,>=4.0.2", "fugue<=0.8.7,>=0.8.7"]
-requires-python = ">=3.8.0"
+requires-python = ">=3.9.0"
 classifiers = [
     "Intended Audience :: Developers",
     "Natural Language :: English",
@@ -20,7 +20,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ maintainers = [
   { name="Faisal Dosani", email="faisal.dosani@capitalone.com" }
 ]
 license = {text = "Apache Software License"}
-dependencies = ["pandas<=2.2.1,>=0.25.0", "numpy<=1.26.4,>=1.22.0", "ordered-set<=4.1.0,>=4.0.2", "fugue<=0.8.7,>=0.8.7"]
+dependencies = ["pandas<=2.2.2,>=0.25.0", "numpy<=1.26.4,>=1.22.0", "ordered-set<=4.1.0,>=4.0.2", "fugue<=0.8.7,>=0.8.7"]
 requires-python = ">=3.9.0"
 classifiers = [
     "Intended Audience :: Developers",

--- a/tests/test_fugue/conftest.py
+++ b/tests/test_fugue/conftest.py
@@ -1,6 +1,6 @@
-import pytest
 import numpy as np
 import pandas as pd
+import pytest
 
 
 @pytest.fixture
@@ -24,7 +24,8 @@ def ref_df():
             c=np.random.choice(["aaa", "b_c", "csd"], 100),
         )
     )
-    return [df1, df1_copy, df2, df3, df4]
+    df5 = df1.sample(frac=0.1)
+    return [df1, df1_copy, df2, df3, df4, df5]
 
 
 @pytest.fixture
@@ -87,3 +88,16 @@ def large_diff_df2():
     np.random.seed(0)
     data = np.random.randint(6, 11, size=10000)
     return pd.DataFrame({"x": data, "y": np.array([9] * 10000)}).convert_dtypes()
+
+
+@pytest.fixture
+def count_matching_rows_df():
+    np.random.seed(0)
+    df1 = pd.DataFrame(
+        dict(
+            a=np.arange(0, 100),
+            b=np.arange(0, 100),
+        )
+    )
+    df2 = df1.sample(frac=0.1)
+    return [df1, df2]

--- a/tests/test_fugue/test_duckdb.py
+++ b/tests/test_fugue/test_duckdb.py
@@ -20,6 +20,7 @@ from pytest import raises
 from datacompy import (
     all_columns_match,
     all_rows_overlap,
+    count_matching_rows,
     intersect_columns,
     is_match,
     unq_columns,
@@ -137,4 +138,41 @@ def test_all_rows_overlap_duckdb(
             duckdb.sql("SELECT 'a' AS a, 'b' AS b"),
             duckdb.sql("SELECT 'a' AS a, 'b' AS b"),
             join_columns="a",
+        )
+
+
+def test_count_matching_rows_duckdb(count_matching_rows_df):
+    with duckdb.connect():
+        df1 = duckdb.from_df(count_matching_rows_df[0])
+        df1_copy = duckdb.from_df(count_matching_rows_df[0])
+        df2 = duckdb.from_df(count_matching_rows_df[1])
+
+        assert (
+            count_matching_rows(
+                df1,
+                df1_copy,
+                join_columns="a",
+            )
+            == 100
+        )
+        assert count_matching_rows(df1, df2, join_columns="a") == 10
+        # Fugue
+
+        assert (
+            count_matching_rows(
+                df1,
+                df1_copy,
+                join_columns="a",
+                parallelism=2,
+            )
+            == 100
+        )
+        assert (
+            count_matching_rows(
+                df1,
+                df2,
+                join_columns="a",
+                parallelism=2,
+            )
+            == 10
         )

--- a/tests/test_fugue/test_fugue_pandas.py
+++ b/tests/test_fugue/test_fugue_pandas.py
@@ -24,6 +24,7 @@ from datacompy import (
     Compare,
     all_columns_match,
     all_rows_overlap,
+    count_matching_rows,
     intersect_columns,
     is_match,
     report,
@@ -144,7 +145,6 @@ def test_report_pandas(
 
 def test_unique_columns_native(ref_df):
     df1 = ref_df[0]
-    df1_copy = ref_df[1]
     df2 = ref_df[2]
     df3 = ref_df[3]
 
@@ -192,3 +192,41 @@ def test_all_rows_overlap_native(
     # Fugue
     assert all_rows_overlap(ref_df[0], shuffle_df, join_columns="a", parallelism=2)
     assert not all_rows_overlap(ref_df[0], ref_df[4], join_columns="a", parallelism=2)
+
+
+def test_count_matching_rows_native(count_matching_rows_df):
+    # defaults to Compare class
+    assert (
+        count_matching_rows(
+            count_matching_rows_df[0],
+            count_matching_rows_df[0].copy(),
+            join_columns="a",
+        )
+        == 100
+    )
+    assert (
+        count_matching_rows(
+            count_matching_rows_df[0], count_matching_rows_df[1], join_columns="a"
+        )
+        == 10
+    )
+    # Fugue
+
+    assert (
+        count_matching_rows(
+            count_matching_rows_df[0],
+            count_matching_rows_df[0].copy(),
+            join_columns="a",
+            parallelism=2,
+        )
+        == 100
+    )
+    assert (
+        count_matching_rows(
+            count_matching_rows_df[0],
+            count_matching_rows_df[1],
+            join_columns="a",
+            parallelism=2,
+        )
+        == 10
+    )

--- a/tests/test_fugue/test_fugue_polars.py
+++ b/tests/test_fugue/test_fugue_polars.py
@@ -20,6 +20,7 @@ from pytest import raises
 from datacompy import (
     all_columns_match,
     all_rows_overlap,
+    count_matching_rows,
     intersect_columns,
     is_match,
     unq_columns,
@@ -122,3 +123,37 @@ def test_all_rows_overlap_polars(
     assert all_rows_overlap(rdf, rdf_copy, join_columns="a")
     assert all_rows_overlap(rdf, sdf, join_columns="a")
     assert not all_rows_overlap(rdf, rdf4, join_columns="a")
+
+
+def test_count_matching_rows_polars(count_matching_rows_df):
+    df1 = pl.from_pandas(count_matching_rows_df[0])
+    df2 = pl.from_pandas(count_matching_rows_df[1])
+    assert (
+        count_matching_rows(
+            df1,
+            df1.clone(),
+            join_columns="a",
+        )
+        == 100
+    )
+    assert count_matching_rows(df1, df2, join_columns="a") == 10
+    # Fugue
+
+    assert (
+        count_matching_rows(
+            df1,
+            df1.clone(),
+            join_columns="a",
+            parallelism=2,
+        )
+        == 100
+    )
+    assert (
+        count_matching_rows(
+            df1,
+            df2,
+            join_columns="a",
+            parallelism=2,
+        )
+        == 10
+    )

--- a/tests/test_legacy_spark.py
+++ b/tests/test_legacy_spark.py
@@ -1,0 +1,2109 @@
+#
+# Copyright 2024 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+import io
+import logging
+import re
+from decimal import Decimal
+
+import pytest
+
+pytest.importorskip("pyspark")
+
+from pyspark.sql import Row  # noqa: E402
+from pyspark.sql.types import (  # noqa: E402
+    DateType,
+    DecimalType,
+    DoubleType,
+    LongType,
+    StringType,
+    StructField,
+    StructType,
+)
+
+from datacompy.legacy import (  # noqa: E402
+    NUMERIC_SPARK_TYPES,
+    LegacySparkCompare,
+    _is_comparable,
+)
+
+# Turn off py4j debug messages for all tests in this module
+logging.getLogger("py4j").setLevel(logging.INFO)
+
+CACHE_INTERMEDIATES = True
+
+
+@pytest.fixture(scope="module", name="base_df1")
+def base_df1_fixture(spark_session):
+    mock_data = [
+        Row(
+            acct=10000001234,
+            dollar_amt=123,
+            name="George Maharis",
+            float_fld=14530.1555,
+            date_fld=datetime.date(2017, 1, 1),
+        ),
+        Row(
+            acct=10000001235,
+            dollar_amt=0,
+            name="Michael Bluth",
+            float_fld=1.0,
+            date_fld=datetime.date(2017, 1, 1),
+        ),
+        Row(
+            acct=10000001236,
+            dollar_amt=1345,
+            name="George Bluth",
+            float_fld=None,
+            date_fld=datetime.date(2017, 1, 1),
+        ),
+        Row(
+            acct=10000001237,
+            dollar_amt=123456,
+            name="Bob Loblaw",
+            float_fld=345.12,
+            date_fld=datetime.date(2017, 1, 1),
+        ),
+        Row(
+            acct=10000001239,
+            dollar_amt=1,
+            name="Lucille Bluth",
+            float_fld=None,
+            date_fld=datetime.date(2017, 1, 1),
+        ),
+    ]
+
+    return spark_session.createDataFrame(mock_data)
+
+
+@pytest.fixture(scope="module", name="base_df2")
+def base_df2_fixture(spark_session):
+    mock_data = [
+        Row(
+            acct=10000001234,
+            dollar_amt=123,
+            super_duper_big_long_name="George Maharis",
+            float_fld=14530.1555,
+            date_fld=datetime.date(2017, 1, 1),
+        ),
+        Row(
+            acct=10000001235,
+            dollar_amt=0,
+            super_duper_big_long_name="Michael Bluth",
+            float_fld=1.0,
+            date_fld=datetime.date(2017, 1, 1),
+        ),
+        Row(
+            acct=10000001236,
+            dollar_amt=1345,
+            super_duper_big_long_name="George Bluth",
+            float_fld=None,
+            date_fld=datetime.date(2017, 1, 1),
+        ),
+        Row(
+            acct=10000001237,
+            dollar_amt=123456,
+            super_duper_big_long_name="Bob Loblaw",
+            float_fld=345.12,
+            date_fld=datetime.date(2017, 1, 1),
+        ),
+        Row(
+            acct=10000001239,
+            dollar_amt=1,
+            super_duper_big_long_name="Lucille Bluth",
+            float_fld=None,
+            date_fld=datetime.date(2017, 1, 1),
+        ),
+    ]
+
+    return spark_session.createDataFrame(mock_data)
+
+
+@pytest.fixture(scope="module", name="compare_df1")
+def compare_df1_fixture(spark_session):
+    mock_data2 = [
+        Row(
+            acct=10000001234,
+            dollar_amt=123.4,
+            name="George Michael Bluth",
+            float_fld=14530.155,
+            accnt_purge=False,
+        ),
+        Row(
+            acct=10000001235,
+            dollar_amt=0.45,
+            name="Michael Bluth",
+            float_fld=None,
+            accnt_purge=False,
+        ),
+        Row(
+            acct=10000001236,
+            dollar_amt=1345.0,
+            name="George Bluth",
+            float_fld=1.0,
+            accnt_purge=False,
+        ),
+        Row(
+            acct=10000001237,
+            dollar_amt=123456.0,
+            name="Bob Loblaw",
+            float_fld=345.12,
+            accnt_purge=False,
+        ),
+        Row(
+            acct=10000001238,
+            dollar_amt=1.05,
+            name="Loose Seal Bluth",
+            float_fld=111.0,
+            accnt_purge=True,
+        ),
+        Row(
+            acct=10000001238,
+            dollar_amt=1.05,
+            name="Loose Seal Bluth",
+            float_fld=111.0,
+            accnt_purge=True,
+        ),
+    ]
+
+    return spark_session.createDataFrame(mock_data2)
+
+
+@pytest.fixture(scope="module", name="compare_df2")
+def compare_df2_fixture(spark_session):
+    mock_data = [
+        Row(
+            acct=10000001234,
+            dollar_amt=123,
+            name="George Maharis",
+            float_fld=14530.1555,
+            date_fld=datetime.date(2017, 1, 1),
+        ),
+        Row(
+            acct=10000001235,
+            dollar_amt=0,
+            name="Michael Bluth",
+            float_fld=1.0,
+            date_fld=datetime.date(2017, 1, 1),
+        ),
+        Row(
+            acct=10000001236,
+            dollar_amt=1345,
+            name="George Bluth",
+            float_fld=None,
+            date_fld=datetime.date(2017, 1, 1),
+        ),
+        Row(
+            acct=10000001237,
+            dollar_amt=123456,
+            name="Bob Loblaw",
+            float_fld=345.12,
+            date_fld=datetime.date(2017, 1, 1),
+        ),
+        Row(
+            acct=10000001239,
+            dollar_amt=1,
+            name="Lucille Bluth",
+            float_fld=None,
+            date_fld=datetime.date(2017, 1, 1),
+        ),
+    ]
+
+    return spark_session.createDataFrame(mock_data)
+
+
+@pytest.fixture(scope="module", name="compare_df3")
+def compare_df3_fixture(spark_session):
+    mock_data2 = [
+        Row(
+            account_identifier=10000001234,
+            dollar_amount=123.4,
+            name="George Michael Bluth",
+            float_field=14530.155,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=False,
+        ),
+        Row(
+            account_identifier=10000001235,
+            dollar_amount=0.45,
+            name="Michael Bluth",
+            float_field=1.0,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=False,
+        ),
+        Row(
+            account_identifier=10000001236,
+            dollar_amount=1345.0,
+            name="George Bluth",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=False,
+        ),
+        Row(
+            account_identifier=10000001237,
+            dollar_amount=123456.0,
+            name="Bob Loblaw",
+            float_field=345.12,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=False,
+        ),
+        Row(
+            account_identifier=10000001239,
+            dollar_amount=1.05,
+            name="Lucille Bluth",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=True,
+        ),
+    ]
+
+    return spark_session.createDataFrame(mock_data2)
+
+
+@pytest.fixture(scope="module", name="base_tol")
+def base_tol_fixture(spark_session):
+    tol_data1 = [
+        Row(
+            account_identifier=10000001234,
+            dollar_amount=123.4,
+            name="Franklin Delano Bluth",
+            float_field=14530.155,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=False,
+        ),
+        Row(
+            account_identifier=10000001235,
+            dollar_amount=500.0,
+            name="Surely Funke",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=True,
+        ),
+        Row(
+            account_identifier=10000001236,
+            dollar_amount=-1100.0,
+            name="Nichael Bluth",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=True,
+        ),
+        Row(
+            account_identifier=10000001237,
+            dollar_amount=0.45,
+            name="Mr. F",
+            float_field=1.0,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=False,
+        ),
+        Row(
+            account_identifier=10000001238,
+            dollar_amount=1345.0,
+            name="Steve Holt!",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=False,
+        ),
+        Row(
+            account_identifier=10000001239,
+            dollar_amount=123456.0,
+            name="Blue Man Group",
+            float_field=345.12,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=False,
+        ),
+        Row(
+            account_identifier=10000001240,
+            dollar_amount=1.1,
+            name="Her?",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=True,
+        ),
+        Row(
+            account_identifier=10000001241,
+            dollar_amount=0.0,
+            name="Mrs. Featherbottom",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=True,
+        ),
+        Row(
+            account_identifier=10000001242,
+            dollar_amount=0.0,
+            name="Ice",
+            float_field=345.12,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=False,
+        ),
+        Row(
+            account_identifier=10000001243,
+            dollar_amount=-10.0,
+            name="Frank Wrench",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=True,
+        ),
+        Row(
+            account_identifier=10000001244,
+            dollar_amount=None,
+            name="Lucille 2",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=True,
+        ),
+        Row(
+            account_identifier=10000001245,
+            dollar_amount=0.009999,
+            name="Gene Parmesan",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=True,
+        ),
+        Row(
+            account_identifier=10000001246,
+            dollar_amount=None,
+            name="Motherboy",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=True,
+        ),
+    ]
+
+    return spark_session.createDataFrame(tol_data1)
+
+
+@pytest.fixture(scope="module", name="compare_abs_tol")
+def compare_tol2_fixture(spark_session):
+    tol_data2 = [
+        Row(
+            account_identifier=10000001234,
+            dollar_amount=123.4,
+            name="Franklin Delano Bluth",
+            float_field=14530.155,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=False,
+        ),  # full match
+        Row(
+            account_identifier=10000001235,
+            dollar_amount=500.01,
+            name="Surely Funke",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=True,
+        ),  # off by 0.01
+        Row(
+            account_identifier=10000001236,
+            dollar_amount=-1100.01,
+            name="Nichael Bluth",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=True,
+        ),  # off by -0.01
+        Row(
+            account_identifier=10000001237,
+            dollar_amount=0.46000000001,
+            name="Mr. F",
+            float_field=1.0,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=False,
+        ),  # off by 0.01000000001
+        Row(
+            account_identifier=10000001238,
+            dollar_amount=1344.8999999999,
+            name="Steve Holt!",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=False,
+        ),  # off by -0.01000000001
+        Row(
+            account_identifier=10000001239,
+            dollar_amount=123456.0099999999,
+            name="Blue Man Group",
+            float_field=345.12,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=False,
+        ),  # off by 0.00999999999
+        Row(
+            account_identifier=10000001240,
+            dollar_amount=1.090000001,
+            name="Her?",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=True,
+        ),  # off by -0.00999999999
+        Row(
+            account_identifier=10000001241,
+            dollar_amount=0.0,
+            name="Mrs. Featherbottom",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=True,
+        ),  # both zero
+        Row(
+            account_identifier=10000001242,
+            dollar_amount=1.0,
+            name="Ice",
+            float_field=345.12,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=False,
+        ),  # base 0, compare 1
+        Row(
+            account_identifier=10000001243,
+            dollar_amount=0.0,
+            name="Frank Wrench",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=True,
+        ),  # base -10, compare 0
+        Row(
+            account_identifier=10000001244,
+            dollar_amount=-1.0,
+            name="Lucille 2",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=True,
+        ),  # base NULL, compare -1
+        Row(
+            account_identifier=10000001245,
+            dollar_amount=None,
+            name="Gene Parmesan",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=True,
+        ),  # base 0.009999, compare NULL
+        Row(
+            account_identifier=10000001246,
+            dollar_amount=None,
+            name="Motherboy",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=True,
+        ),  # both NULL
+    ]
+
+    return spark_session.createDataFrame(tol_data2)
+
+
+@pytest.fixture(scope="module", name="compare_rel_tol")
+def compare_tol3_fixture(spark_session):
+    tol_data3 = [
+        Row(
+            account_identifier=10000001234,
+            dollar_amount=123.4,
+            name="Franklin Delano Bluth",
+            float_field=14530.155,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=False,
+        ),  # full match   #MATCH
+        Row(
+            account_identifier=10000001235,
+            dollar_amount=550.0,
+            name="Surely Funke",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=True,
+        ),  # off by 10%   #MATCH
+        Row(
+            account_identifier=10000001236,
+            dollar_amount=-1000.0,
+            name="Nichael Bluth",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=True,
+        ),  # off by -10%    #MATCH
+        Row(
+            account_identifier=10000001237,
+            dollar_amount=0.49501,
+            name="Mr. F",
+            float_field=1.0,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=False,
+        ),  # off by greater than 10%
+        Row(
+            account_identifier=10000001238,
+            dollar_amount=1210.001,
+            name="Steve Holt!",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=False,
+        ),  # off by greater than -10%
+        Row(
+            account_identifier=10000001239,
+            dollar_amount=135801.59999,
+            name="Blue Man Group",
+            float_field=345.12,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=False,
+        ),  # off by just under 10%   #MATCH
+        Row(
+            account_identifier=10000001240,
+            dollar_amount=1.000001,
+            name="Her?",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=True,
+        ),  # off by just under -10%   #MATCH
+        Row(
+            account_identifier=10000001241,
+            dollar_amount=0.0,
+            name="Mrs. Featherbottom",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=True,
+        ),  # both zero   #MATCH
+        Row(
+            account_identifier=10000001242,
+            dollar_amount=1.0,
+            name="Ice",
+            float_field=345.12,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=False,
+        ),  # base 0, compare 1
+        Row(
+            account_identifier=10000001243,
+            dollar_amount=0.0,
+            name="Frank Wrench",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=True,
+        ),  # base -10, compare 0
+        Row(
+            account_identifier=10000001244,
+            dollar_amount=-1.0,
+            name="Lucille 2",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=True,
+        ),  # base NULL, compare -1
+        Row(
+            account_identifier=10000001245,
+            dollar_amount=None,
+            name="Gene Parmesan",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=True,
+        ),  # base 0.009999, compare NULL
+        Row(
+            account_identifier=10000001246,
+            dollar_amount=None,
+            name="Motherboy",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=True,
+        ),  # both NULL  #MATCH
+    ]
+
+    return spark_session.createDataFrame(tol_data3)
+
+
+@pytest.fixture(scope="module", name="compare_both_tol")
+def compare_tol4_fixture(spark_session):
+    tol_data4 = [
+        Row(
+            account_identifier=10000001234,
+            dollar_amount=123.4,
+            name="Franklin Delano Bluth",
+            float_field=14530.155,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=False,
+        ),  # full match
+        Row(
+            account_identifier=10000001235,
+            dollar_amount=550.01,
+            name="Surely Funke",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=True,
+        ),  # off by 10% and +0.01
+        Row(
+            account_identifier=10000001236,
+            dollar_amount=-1000.01,
+            name="Nichael Bluth",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=True,
+        ),  # off by -10% and -0.01
+        Row(
+            account_identifier=10000001237,
+            dollar_amount=0.505000000001,
+            name="Mr. F",
+            float_field=1.0,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=False,
+        ),  # off by greater than 10% and +0.01
+        Row(
+            account_identifier=10000001238,
+            dollar_amount=1209.98999,
+            name="Steve Holt!",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=False,
+        ),  # off by greater than -10% and -0.01
+        Row(
+            account_identifier=10000001239,
+            dollar_amount=135801.609999,
+            name="Blue Man Group",
+            float_field=345.12,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=False,
+        ),  # off by just under 10% and just under +0.01
+        Row(
+            account_identifier=10000001240,
+            dollar_amount=0.99000001,
+            name="Her?",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=True,
+        ),  # off by just under -10% and just under -0.01
+        Row(
+            account_identifier=10000001241,
+            dollar_amount=0.0,
+            name="Mrs. Featherbottom",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=True,
+        ),  # both zero
+        Row(
+            account_identifier=10000001242,
+            dollar_amount=1.0,
+            name="Ice",
+            float_field=345.12,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=False,
+        ),  # base 0, compare 1
+        Row(
+            account_identifier=10000001243,
+            dollar_amount=0.0,
+            name="Frank Wrench",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=True,
+        ),  # base -10, compare 0
+        Row(
+            account_identifier=10000001244,
+            dollar_amount=-1.0,
+            name="Lucille 2",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=True,
+        ),  # base NULL, compare -1
+        Row(
+            account_identifier=10000001245,
+            dollar_amount=None,
+            name="Gene Parmesan",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=True,
+        ),  # base 0.009999, compare NULL
+        Row(
+            account_identifier=10000001246,
+            dollar_amount=None,
+            name="Motherboy",
+            float_field=None,
+            date_field=datetime.date(2017, 1, 1),
+            accnt_purge=True,
+        ),  # both NULL
+    ]
+
+    return spark_session.createDataFrame(tol_data4)
+
+
+@pytest.fixture(scope="module", name="base_td")
+def base_td_fixture(spark_session):
+    mock_data = [
+        Row(
+            acct=10000001234,
+            acct_seq=0,
+            stat_cd="*2",
+            open_dt=datetime.date(2017, 5, 1),
+            cd="0001",
+        ),
+        Row(
+            acct=10000001235,
+            acct_seq=0,
+            stat_cd="V1",
+            open_dt=datetime.date(2017, 5, 2),
+            cd="0002",
+        ),
+        Row(
+            acct=10000001236,
+            acct_seq=0,
+            stat_cd="V2",
+            open_dt=datetime.date(2017, 5, 3),
+            cd="0003",
+        ),
+        Row(
+            acct=10000001237,
+            acct_seq=0,
+            stat_cd="*2",
+            open_dt=datetime.date(2017, 5, 4),
+            cd="0004",
+        ),
+        Row(
+            acct=10000001238,
+            acct_seq=0,
+            stat_cd="*2",
+            open_dt=datetime.date(2017, 5, 5),
+            cd="0005",
+        ),
+    ]
+
+    return spark_session.createDataFrame(mock_data)
+
+
+@pytest.fixture(scope="module", name="compare_source")
+def compare_source_fixture(spark_session):
+    mock_data = [
+        Row(
+            ACCOUNT_IDENTIFIER=10000001234,
+            SEQ_NUMBER=0,
+            STATC=None,
+            ACCOUNT_OPEN=2017121,
+            CODE=1.0,
+        ),
+        Row(
+            ACCOUNT_IDENTIFIER=10000001235,
+            SEQ_NUMBER=0,
+            STATC="V1",
+            ACCOUNT_OPEN=2017122,
+            CODE=2.0,
+        ),
+        Row(
+            ACCOUNT_IDENTIFIER=10000001236,
+            SEQ_NUMBER=0,
+            STATC="V2",
+            ACCOUNT_OPEN=2017123,
+            CODE=3.0,
+        ),
+        Row(
+            ACCOUNT_IDENTIFIER=10000001237,
+            SEQ_NUMBER=0,
+            STATC="V3",
+            ACCOUNT_OPEN=2017124,
+            CODE=4.0,
+        ),
+        Row(
+            ACCOUNT_IDENTIFIER=10000001238,
+            SEQ_NUMBER=0,
+            STATC=None,
+            ACCOUNT_OPEN=2017125,
+            CODE=5.0,
+        ),
+    ]
+
+    return spark_session.createDataFrame(mock_data)
+
+
+@pytest.fixture(scope="module", name="base_decimal")
+def base_decimal_fixture(spark_session):
+    mock_data = [
+        Row(acct=10000001234, dollar_amt=Decimal(123.4)),
+        Row(acct=10000001235, dollar_amt=Decimal(0.45)),
+    ]
+
+    return spark_session.createDataFrame(
+        mock_data,
+        schema=StructType(
+            [
+                StructField("acct", LongType(), True),
+                StructField("dollar_amt", DecimalType(8, 2), True),
+            ]
+        ),
+    )
+
+
+@pytest.fixture(scope="module", name="compare_decimal")
+def compare_decimal_fixture(spark_session):
+    mock_data = [
+        Row(acct=10000001234, dollar_amt=123.4),
+        Row(acct=10000001235, dollar_amt=0.456),
+    ]
+
+    return spark_session.createDataFrame(mock_data)
+
+
+@pytest.fixture(scope="module", name="comparison_abs_tol")
+def comparison_abs_tol_fixture(base_tol, compare_abs_tol, spark_session):
+    return LegacySparkCompare(
+        spark_session,
+        base_tol,
+        compare_abs_tol,
+        join_columns=["account_identifier"],
+        abs_tol=0.01,
+    )
+
+
+@pytest.fixture(scope="module", name="comparison_rel_tol")
+def comparison_rel_tol_fixture(base_tol, compare_rel_tol, spark_session):
+    return LegacySparkCompare(
+        spark_session,
+        base_tol,
+        compare_rel_tol,
+        join_columns=["account_identifier"],
+        rel_tol=0.1,
+    )
+
+
+@pytest.fixture(scope="module", name="comparison_both_tol")
+def comparison_both_tol_fixture(base_tol, compare_both_tol, spark_session):
+    return LegacySparkCompare(
+        spark_session,
+        base_tol,
+        compare_both_tol,
+        join_columns=["account_identifier"],
+        rel_tol=0.1,
+        abs_tol=0.01,
+    )
+
+
+@pytest.fixture(scope="module", name="comparison_neg_tol")
+def comparison_neg_tol_fixture(base_tol, compare_both_tol, spark_session):
+    return LegacySparkCompare(
+        spark_session,
+        base_tol,
+        compare_both_tol,
+        join_columns=["account_identifier"],
+        rel_tol=-0.2,
+        abs_tol=0.01,
+    )
+
+
+@pytest.fixture(scope="module", name="show_all_columns_and_match_rate")
+def show_all_columns_and_match_rate_fixture(base_tol, compare_both_tol, spark_session):
+    return LegacySparkCompare(
+        spark_session,
+        base_tol,
+        compare_both_tol,
+        join_columns=["account_identifier"],
+        show_all_columns=True,
+        match_rates=True,
+    )
+
+
+@pytest.fixture(scope="module", name="comparison_kd1")
+def comparison_known_diffs1(base_td, compare_source, spark_session):
+    return LegacySparkCompare(
+        spark_session,
+        base_td,
+        compare_source,
+        join_columns=[("acct", "ACCOUNT_IDENTIFIER"), ("acct_seq", "SEQ_NUMBER")],
+        column_mapping=[
+            ("stat_cd", "STATC"),
+            ("open_dt", "ACCOUNT_OPEN"),
+            ("cd", "CODE"),
+        ],
+        known_differences=[
+            {
+                "name": "Left-padded, four-digit numeric code",
+                "types": NUMERIC_SPARK_TYPES,
+                "transformation": "lpad(cast({input} AS bigint), 4, '0')",
+            },
+            {
+                "name": "Null to *2",
+                "types": ["string"],
+                "transformation": "case when {input} is null then '*2' else {input} end",
+            },
+            {
+                "name": "Julian date -> date",
+                "types": ["bigint"],
+                "transformation": "to_date(cast(unix_timestamp(cast({input} AS string), 'yyyyDDD') AS timestamp))",
+            },
+        ],
+    )
+
+
+@pytest.fixture(scope="module", name="comparison_kd2")
+def comparison_known_diffs2(base_td, compare_source, spark_session):
+    return LegacySparkCompare(
+        spark_session,
+        base_td,
+        compare_source,
+        join_columns=[("acct", "ACCOUNT_IDENTIFIER"), ("acct_seq", "SEQ_NUMBER")],
+        column_mapping=[
+            ("stat_cd", "STATC"),
+            ("open_dt", "ACCOUNT_OPEN"),
+            ("cd", "CODE"),
+        ],
+        known_differences=[
+            {
+                "name": "Left-padded, four-digit numeric code",
+                "types": NUMERIC_SPARK_TYPES,
+                "transformation": "lpad(cast({input} AS bigint), 4, '0')",
+            },
+            {
+                "name": "Null to *2",
+                "types": ["string"],
+                "transformation": "case when {input} is null then '*2' else {input} end",
+            },
+        ],
+    )
+
+
+@pytest.fixture(scope="module", name="comparison1")
+def comparison1_fixture(base_df1, compare_df1, spark_session):
+    return LegacySparkCompare(
+        spark_session,
+        base_df1,
+        compare_df1,
+        join_columns=["acct"],
+        cache_intermediates=CACHE_INTERMEDIATES,
+    )
+
+
+@pytest.fixture(scope="module", name="comparison2")
+def comparison2_fixture(base_df1, compare_df2, spark_session):
+    return LegacySparkCompare(
+        spark_session, base_df1, compare_df2, join_columns=["acct"]
+    )
+
+
+@pytest.fixture(scope="module", name="comparison3")
+def comparison3_fixture(base_df1, compare_df3, spark_session):
+    return LegacySparkCompare(
+        spark_session,
+        base_df1,
+        compare_df3,
+        join_columns=[("acct", "account_identifier")],
+        column_mapping=[
+            ("dollar_amt", "dollar_amount"),
+            ("float_fld", "float_field"),
+            ("date_fld", "date_field"),
+        ],
+        cache_intermediates=CACHE_INTERMEDIATES,
+    )
+
+
+@pytest.fixture(scope="module", name="comparison4")
+def comparison4_fixture(base_df2, compare_df1, spark_session):
+    return LegacySparkCompare(
+        spark_session,
+        base_df2,
+        compare_df1,
+        join_columns=["acct"],
+        column_mapping=[("super_duper_big_long_name", "name")],
+    )
+
+
+@pytest.fixture(scope="module", name="comparison_decimal")
+def comparison_decimal_fixture(base_decimal, compare_decimal, spark_session):
+    return LegacySparkCompare(
+        spark_session, base_decimal, compare_decimal, join_columns=["acct"]
+    )
+
+
+def test_absolute_tolerances(comparison_abs_tol):
+    stdout = io.StringIO()
+
+    comparison_abs_tol.report(file=stdout)
+    stdout.seek(0)
+    assert "****** Row Comparison ******" in stdout.getvalue()
+    assert "Number of rows with some columns unequal: 6" in stdout.getvalue()
+    assert "Number of rows with all columns equal: 7" in stdout.getvalue()
+    assert "Number of columns compared with some values unequal: 1" in stdout.getvalue()
+    assert "Number of columns compared with all values equal: 4" in stdout.getvalue()
+
+
+def test_relative_tolerances(comparison_rel_tol):
+    stdout = io.StringIO()
+
+    comparison_rel_tol.report(file=stdout)
+    stdout.seek(0)
+    assert "****** Row Comparison ******" in stdout.getvalue()
+    assert "Number of rows with some columns unequal: 6" in stdout.getvalue()
+    assert "Number of rows with all columns equal: 7" in stdout.getvalue()
+    assert "Number of columns compared with some values unequal: 1" in stdout.getvalue()
+    assert "Number of columns compared with all values equal: 4" in stdout.getvalue()
+
+
+def test_both_tolerances(comparison_both_tol):
+    stdout = io.StringIO()
+
+    comparison_both_tol.report(file=stdout)
+    stdout.seek(0)
+    assert "****** Row Comparison ******" in stdout.getvalue()
+    assert "Number of rows with some columns unequal: 6" in stdout.getvalue()
+    assert "Number of rows with all columns equal: 7" in stdout.getvalue()
+    assert "Number of columns compared with some values unequal: 1" in stdout.getvalue()
+    assert "Number of columns compared with all values equal: 4" in stdout.getvalue()
+
+
+def test_negative_tolerances(spark_session, base_tol, compare_both_tol):
+    with pytest.raises(ValueError, match="Please enter positive valued tolerances"):
+        comp = LegacySparkCompare(
+            spark_session,
+            base_tol,
+            compare_both_tol,
+            join_columns=["account_identifier"],
+            rel_tol=-0.2,
+            abs_tol=0.01,
+        )
+        comp.report()
+        pass
+
+
+def test_show_all_columns_and_match_rate(show_all_columns_and_match_rate):
+    stdout = io.StringIO()
+
+    show_all_columns_and_match_rate.report(file=stdout)
+
+    assert "****** Columns with Equal/Unequal Values ******" in stdout.getvalue()
+    assert (
+        "accnt_purge       accnt_purge          boolean        boolean               13             0     100.00000"
+        in stdout.getvalue()
+    )
+    assert (
+        "date_field        date_field           date           date                  13             0     100.00000"
+        in stdout.getvalue()
+    )
+    assert (
+        "dollar_amount     dollar_amount        double         double                 3            10      23.07692"
+        in stdout.getvalue()
+    )
+    assert (
+        "float_field       float_field          double         double                13             0     100.00000"
+        in stdout.getvalue()
+    )
+    assert (
+        "name              name                 string         string                13             0     100.00000"
+        in stdout.getvalue()
+    )
+
+
+def test_decimal_comparisons():
+    true_decimals = ["decimal", "decimal()", "decimal(20, 10)"]
+    assert all(v in NUMERIC_SPARK_TYPES for v in true_decimals)
+
+
+def test_decimal_comparator_acts_like_string():
+    acc = False
+    for t in NUMERIC_SPARK_TYPES:
+        acc = acc or (len(t) > 2 and t[0:3] == "dec")
+    assert acc
+
+
+def test_decimals_and_doubles_are_comparable():
+    assert _is_comparable("double", "decimal(10, 2)")
+
+
+def test_report_outputs_the_column_summary(comparison1):
+    stdout = io.StringIO()
+
+    comparison1.report(file=stdout)
+
+    assert "****** Column Summary ******" in stdout.getvalue()
+    assert "Number of columns in common with matching schemas: 3" in stdout.getvalue()
+    assert "Number of columns in common with schema differences: 1" in stdout.getvalue()
+    assert "Number of columns in base but not compare: 1" in stdout.getvalue()
+    assert "Number of columns in compare but not base: 1" in stdout.getvalue()
+
+
+def test_report_outputs_the_column_summary_for_identical_schemas(comparison2):
+    stdout = io.StringIO()
+
+    comparison2.report(file=stdout)
+
+    assert "****** Column Summary ******" in stdout.getvalue()
+    assert "Number of columns in common with matching schemas: 5" in stdout.getvalue()
+    assert "Number of columns in common with schema differences: 0" in stdout.getvalue()
+    assert "Number of columns in base but not compare: 0" in stdout.getvalue()
+    assert "Number of columns in compare but not base: 0" in stdout.getvalue()
+
+
+def test_report_outputs_the_column_summary_for_differently_named_columns(comparison3):
+    stdout = io.StringIO()
+
+    comparison3.report(file=stdout)
+
+    assert "****** Column Summary ******" in stdout.getvalue()
+    assert "Number of columns in common with matching schemas: 4" in stdout.getvalue()
+    assert "Number of columns in common with schema differences: 1" in stdout.getvalue()
+    assert "Number of columns in base but not compare: 0" in stdout.getvalue()
+    assert "Number of columns in compare but not base: 1" in stdout.getvalue()
+
+
+def test_report_outputs_the_row_summary(comparison1):
+    stdout = io.StringIO()
+
+    comparison1.report(file=stdout)
+
+    assert "****** Row Summary ******" in stdout.getvalue()
+    assert "Number of rows in common: 4" in stdout.getvalue()
+    assert "Number of rows in base but not compare: 1" in stdout.getvalue()
+    assert "Number of rows in compare but not base: 1" in stdout.getvalue()
+    assert "Number of duplicate rows found in base: 0" in stdout.getvalue()
+    assert "Number of duplicate rows found in compare: 1" in stdout.getvalue()
+
+
+def test_report_outputs_the_row_equality_comparison(comparison1):
+    stdout = io.StringIO()
+
+    comparison1.report(file=stdout)
+
+    assert "****** Row Comparison ******" in stdout.getvalue()
+    assert "Number of rows with some columns unequal: 3" in stdout.getvalue()
+    assert "Number of rows with all columns equal: 1" in stdout.getvalue()
+
+
+def test_report_outputs_the_row_summary_for_differently_named_columns(comparison3):
+    stdout = io.StringIO()
+
+    comparison3.report(file=stdout)
+
+    assert "****** Row Summary ******" in stdout.getvalue()
+    assert "Number of rows in common: 5" in stdout.getvalue()
+    assert "Number of rows in base but not compare: 0" in stdout.getvalue()
+    assert "Number of rows in compare but not base: 0" in stdout.getvalue()
+    assert "Number of duplicate rows found in base: 0" in stdout.getvalue()
+    assert "Number of duplicate rows found in compare: 0" in stdout.getvalue()
+
+
+def test_report_outputs_the_row_equality_comparison_for_differently_named_columns(
+    comparison3,
+):
+    stdout = io.StringIO()
+
+    comparison3.report(file=stdout)
+
+    assert "****** Row Comparison ******" in stdout.getvalue()
+    assert "Number of rows with some columns unequal: 3" in stdout.getvalue()
+    assert "Number of rows with all columns equal: 2" in stdout.getvalue()
+
+
+def test_report_outputs_column_detail_for_columns_in_only_one_dataframe(comparison1):
+    stdout = io.StringIO()
+
+    comparison1.report(file=stdout)
+    comparison1.report()
+    assert "****** Columns In Base Only ******" in stdout.getvalue()
+    r2 = r"""Column\s*Name \s* Dtype \n -+ \s+ -+ \ndate_fld \s+ date"""
+    assert re.search(r2, str(stdout.getvalue()), re.X) is not None
+
+
+def test_report_outputs_column_detail_for_columns_in_only_compare_dataframe(
+    comparison1,
+):
+    stdout = io.StringIO()
+
+    comparison1.report(file=stdout)
+    comparison1.report()
+    assert "****** Columns In Compare Only ******" in stdout.getvalue()
+    r2 = r"""Column\s*Name \s* Dtype \n -+ \s+ -+ \n accnt_purge \s+  boolean"""
+    assert re.search(r2, str(stdout.getvalue()), re.X) is not None
+
+
+def test_report_outputs_schema_difference_details(comparison1):
+    stdout = io.StringIO()
+
+    comparison1.report(file=stdout)
+
+    assert "****** Schema Differences ******" in stdout.getvalue()
+    assert re.search(
+        r"""Base\sColumn\sName \s+ Compare\sColumn\sName \s+ Base\sDtype \s+ Compare\sDtype \n
+            -+ \s+ -+ \s+ -+ \s+ -+ \n
+            dollar_amt \s+ dollar_amt \s+ bigint \s+ double""",
+        stdout.getvalue(),
+        re.X,
+    )
+
+
+def test_report_outputs_schema_difference_details_for_differently_named_columns(
+    comparison3,
+):
+    stdout = io.StringIO()
+
+    comparison3.report(file=stdout)
+
+    assert "****** Schema Differences ******" in stdout.getvalue()
+    assert re.search(
+        r"""Base\sColumn\sName \s+ Compare\sColumn\sName \s+ Base\sDtype \s+ Compare\sDtype \n
+            -+ \s+ -+ \s+ -+ \s+ -+ \n
+            dollar_amt \s+ dollar_amount \s+ bigint \s+ double""",
+        stdout.getvalue(),
+        re.X,
+    )
+
+
+def test_column_comparison_outputs_number_of_columns_with_differences(comparison1):
+    stdout = io.StringIO()
+
+    comparison1.report(file=stdout)
+
+    assert "****** Column Comparison ******" in stdout.getvalue()
+    assert "Number of columns compared with some values unequal: 3" in stdout.getvalue()
+    assert "Number of columns compared with all values equal: 0" in stdout.getvalue()
+
+
+def test_column_comparison_outputs_all_columns_equal_for_identical_dataframes(
+    comparison2,
+):
+    stdout = io.StringIO()
+
+    comparison2.report(file=stdout)
+
+    assert "****** Column Comparison ******" in stdout.getvalue()
+    assert "Number of columns compared with some values unequal: 0" in stdout.getvalue()
+    assert "Number of columns compared with all values equal: 4" in stdout.getvalue()
+
+
+def test_column_comparison_outputs_number_of_columns_with_differences_for_differently_named_columns(
+    comparison3,
+):
+    stdout = io.StringIO()
+
+    comparison3.report(file=stdout)
+
+    assert "****** Column Comparison ******" in stdout.getvalue()
+    assert "Number of columns compared with some values unequal: 3" in stdout.getvalue()
+    assert "Number of columns compared with all values equal: 1" in stdout.getvalue()
+
+
+def test_column_comparison_outputs_number_of_columns_with_differences_for_known_diffs(
+    comparison_kd1,
+):
+    stdout = io.StringIO()
+
+    comparison_kd1.report(file=stdout)
+
+    assert "****** Column Comparison ******" in stdout.getvalue()
+    assert (
+        "Number of columns compared with unexpected differences in some values: 1"
+        in stdout.getvalue()
+    )
+    assert (
+        "Number of columns compared with all values equal but known differences found: 2"
+        in stdout.getvalue()
+    )
+    assert (
+        "Number of columns compared with all values completely equal: 0"
+        in stdout.getvalue()
+    )
+
+
+def test_column_comparison_outputs_number_of_columns_with_differences_for_custom_known_diffs(
+    comparison_kd2,
+):
+    stdout = io.StringIO()
+
+    comparison_kd2.report(file=stdout)
+
+    assert "****** Column Comparison ******" in stdout.getvalue()
+    assert (
+        "Number of columns compared with unexpected differences in some values: 2"
+        in stdout.getvalue()
+    )
+    assert (
+        "Number of columns compared with all values equal but known differences found: 1"
+        in stdout.getvalue()
+    )
+    assert (
+        "Number of columns compared with all values completely equal: 0"
+        in stdout.getvalue()
+    )
+
+
+def test_columns_with_unequal_values_show_mismatch_counts(comparison1):
+    stdout = io.StringIO()
+
+    comparison1.report(file=stdout)
+
+    assert "****** Columns with Unequal Values ******" in stdout.getvalue()
+    assert re.search(
+        r"""Base\s*Column\s*Name \s+ Compare\s*Column\s*Name \s+ Base\s*Dtype \s+ Compare\sDtype \s*
+            \#\sMatches \s* \#\sMismatches \n
+            -+ \s+ -+ \s+ -+ \s+ -+ \s+ -+ \s+ -+""",
+        stdout.getvalue(),
+        re.X,
+    )
+    assert re.search(
+        r"""dollar_amt \s+ dollar_amt \s+ bigint \s+ double \s+ 2 \s+ 2""",
+        stdout.getvalue(),
+        re.X,
+    )
+    assert re.search(
+        r"""float_fld \s+ float_fld \s+ double \s+ double \s+ 1 \s+ 3""",
+        stdout.getvalue(),
+        re.X,
+    )
+    assert re.search(
+        r"""name \s+ name \s+ string \s+ string \s+ 3 \s+ 1""", stdout.getvalue(), re.X
+    )
+
+
+def test_columns_with_different_names_with_unequal_values_show_mismatch_counts(
+    comparison3,
+):
+    stdout = io.StringIO()
+
+    comparison3.report(file=stdout)
+
+    assert "****** Columns with Unequal Values ******" in stdout.getvalue()
+    assert re.search(
+        r"""Base\s*Column\s*Name \s+ Compare\s*Column\s*Name \s+ Base\s*Dtype \s+ Compare\sDtype \s*
+            \#\sMatches \s* \#\sMismatches \n
+            -+ \s+ -+ \s+ -+ \s+ -+ \s+ -+ \s+ -+""",
+        stdout.getvalue(),
+        re.X,
+    )
+    assert re.search(
+        r"""dollar_amt \s+ dollar_amount \s+ bigint \s+ double \s+ 2 \s+ 3""",
+        stdout.getvalue(),
+        re.X,
+    )
+    assert re.search(
+        r"""float_fld \s+ float_field \s+ double \s+ double \s+ 4 \s+ 1""",
+        stdout.getvalue(),
+        re.X,
+    )
+    assert re.search(
+        r"""name \s+ name \s+ string \s+ string \s+ 4 \s+ 1""", stdout.getvalue(), re.X
+    )
+
+
+def test_rows_only_base_returns_a_dataframe_with_rows_only_in_base(
+    spark_session, comparison1
+):
+    # require schema if contains only 1 row and contain field value as None
+    schema = StructType(
+        [
+            StructField("acct", LongType(), True),
+            StructField("date_fld", DateType(), True),
+            StructField("dollar_amt", LongType(), True),
+            StructField("float_fld", DoubleType(), True),
+            StructField("name", StringType(), True),
+        ]
+    )
+    expected_df = spark_session.createDataFrame(
+        [
+            Row(
+                acct=10000001239,
+                date_fld=datetime.date(2017, 1, 1),
+                dollar_amt=1,
+                float_fld=None,
+                name="Lucille Bluth",
+            )
+        ],
+        schema,
+    )
+    assert comparison1.rows_only_base.count() == 1
+    assert (
+        expected_df.union(
+            comparison1.rows_only_base.select(
+                "acct", "date_fld", "dollar_amt", "float_fld", "name"
+            )
+        )
+        .distinct()
+        .count()
+        == 1
+    )
+
+
+def test_rows_only_compare_returns_a_dataframe_with_rows_only_in_compare(
+    spark_session, comparison1
+):
+    expected_df = spark_session.createDataFrame(
+        [
+            Row(
+                acct=10000001238,
+                dollar_amt=1.05,
+                name="Loose Seal Bluth",
+                float_fld=111.0,
+                accnt_purge=True,
+            )
+        ]
+    )
+
+    assert comparison1.rows_only_compare.count() == 1
+    assert expected_df.union(comparison1.rows_only_compare).distinct().count() == 1
+
+
+def test_rows_both_mismatch_returns_a_dataframe_with_rows_where_variables_mismatched(
+    spark_session, comparison1
+):
+    expected_df = spark_session.createDataFrame(
+        [
+            Row(
+                accnt_purge=False,
+                acct=10000001234,
+                date_fld=datetime.date(2017, 1, 1),
+                dollar_amt_base=123,
+                dollar_amt_compare=123.4,
+                dollar_amt_match=False,
+                float_fld_base=14530.1555,
+                float_fld_compare=14530.155,
+                float_fld_match=False,
+                name_base="George Maharis",
+                name_compare="George Michael Bluth",
+                name_match=False,
+            ),
+            Row(
+                accnt_purge=False,
+                acct=10000001235,
+                date_fld=datetime.date(2017, 1, 1),
+                dollar_amt_base=0,
+                dollar_amt_compare=0.45,
+                dollar_amt_match=False,
+                float_fld_base=1.0,
+                float_fld_compare=None,
+                float_fld_match=False,
+                name_base="Michael Bluth",
+                name_compare="Michael Bluth",
+                name_match=True,
+            ),
+            Row(
+                accnt_purge=False,
+                acct=10000001236,
+                date_fld=datetime.date(2017, 1, 1),
+                dollar_amt_base=1345,
+                dollar_amt_compare=1345.0,
+                dollar_amt_match=True,
+                float_fld_base=None,
+                float_fld_compare=1.0,
+                float_fld_match=False,
+                name_base="George Bluth",
+                name_compare="George Bluth",
+                name_match=True,
+            ),
+        ]
+    )
+
+    assert comparison1.rows_both_mismatch.count() == 3
+    assert expected_df.union(comparison1.rows_both_mismatch).distinct().count() == 3
+
+
+def test_rows_both_mismatch_only_includes_rows_with_true_mismatches_when_known_diffs_are_present(
+    spark_session, comparison_kd1
+):
+    expected_df = spark_session.createDataFrame(
+        [
+            Row(
+                acct=10000001237,
+                acct_seq=0,
+                cd_base="0004",
+                cd_compare=4.0,
+                cd_match=True,
+                cd_match_type="KNOWN_DIFFERENCE",
+                open_dt_base=datetime.date(2017, 5, 4),
+                open_dt_compare=2017124,
+                open_dt_match=True,
+                open_dt_match_type="KNOWN_DIFFERENCE",
+                stat_cd_base="*2",
+                stat_cd_compare="V3",
+                stat_cd_match=False,
+                stat_cd_match_type="MISMATCH",
+            )
+        ]
+    )
+    assert comparison_kd1.rows_both_mismatch.count() == 1
+    assert expected_df.union(comparison_kd1.rows_both_mismatch).distinct().count() == 1
+
+
+def test_rows_both_all_returns_a_dataframe_with_all_rows_in_both_dataframes(
+    spark_session, comparison1
+):
+    expected_df = spark_session.createDataFrame(
+        [
+            Row(
+                accnt_purge=False,
+                acct=10000001234,
+                date_fld=datetime.date(2017, 1, 1),
+                dollar_amt_base=123,
+                dollar_amt_compare=123.4,
+                dollar_amt_match=False,
+                float_fld_base=14530.1555,
+                float_fld_compare=14530.155,
+                float_fld_match=False,
+                name_base="George Maharis",
+                name_compare="George Michael Bluth",
+                name_match=False,
+            ),
+            Row(
+                accnt_purge=False,
+                acct=10000001235,
+                date_fld=datetime.date(2017, 1, 1),
+                dollar_amt_base=0,
+                dollar_amt_compare=0.45,
+                dollar_amt_match=False,
+                float_fld_base=1.0,
+                float_fld_compare=None,
+                float_fld_match=False,
+                name_base="Michael Bluth",
+                name_compare="Michael Bluth",
+                name_match=True,
+            ),
+            Row(
+                accnt_purge=False,
+                acct=10000001236,
+                date_fld=datetime.date(2017, 1, 1),
+                dollar_amt_base=1345,
+                dollar_amt_compare=1345.0,
+                dollar_amt_match=True,
+                float_fld_base=None,
+                float_fld_compare=1.0,
+                float_fld_match=False,
+                name_base="George Bluth",
+                name_compare="George Bluth",
+                name_match=True,
+            ),
+            Row(
+                accnt_purge=False,
+                acct=10000001237,
+                date_fld=datetime.date(2017, 1, 1),
+                dollar_amt_base=123456,
+                dollar_amt_compare=123456.0,
+                dollar_amt_match=True,
+                float_fld_base=345.12,
+                float_fld_compare=345.12,
+                float_fld_match=True,
+                name_base="Bob Loblaw",
+                name_compare="Bob Loblaw",
+                name_match=True,
+            ),
+        ]
+    )
+
+    assert comparison1.rows_both_all.count() == 4
+    assert expected_df.union(comparison1.rows_both_all).distinct().count() == 4
+
+
+def test_rows_both_all_shows_known_diffs_flag_and_known_diffs_count_as_matches(
+    spark_session, comparison_kd1
+):
+    expected_df = spark_session.createDataFrame(
+        [
+            Row(
+                acct=10000001234,
+                acct_seq=0,
+                cd_base="0001",
+                cd_compare=1.0,
+                cd_match=True,
+                cd_match_type="KNOWN_DIFFERENCE",
+                open_dt_base=datetime.date(2017, 5, 1),
+                open_dt_compare=2017121,
+                open_dt_match=True,
+                open_dt_match_type="KNOWN_DIFFERENCE",
+                stat_cd_base="*2",
+                stat_cd_compare=None,
+                stat_cd_match=True,
+                stat_cd_match_type="KNOWN_DIFFERENCE",
+            ),
+            Row(
+                acct=10000001235,
+                acct_seq=0,
+                cd_base="0002",
+                cd_compare=2.0,
+                cd_match=True,
+                cd_match_type="KNOWN_DIFFERENCE",
+                open_dt_base=datetime.date(2017, 5, 2),
+                open_dt_compare=2017122,
+                open_dt_match=True,
+                open_dt_match_type="KNOWN_DIFFERENCE",
+                stat_cd_base="V1",
+                stat_cd_compare="V1",
+                stat_cd_match=True,
+                stat_cd_match_type="MATCH",
+            ),
+            Row(
+                acct=10000001236,
+                acct_seq=0,
+                cd_base="0003",
+                cd_compare=3.0,
+                cd_match=True,
+                cd_match_type="KNOWN_DIFFERENCE",
+                open_dt_base=datetime.date(2017, 5, 3),
+                open_dt_compare=2017123,
+                open_dt_match=True,
+                open_dt_match_type="KNOWN_DIFFERENCE",
+                stat_cd_base="V2",
+                stat_cd_compare="V2",
+                stat_cd_match=True,
+                stat_cd_match_type="MATCH",
+            ),
+            Row(
+                acct=10000001237,
+                acct_seq=0,
+                cd_base="0004",
+                cd_compare=4.0,
+                cd_match=True,
+                cd_match_type="KNOWN_DIFFERENCE",
+                open_dt_base=datetime.date(2017, 5, 4),
+                open_dt_compare=2017124,
+                open_dt_match=True,
+                open_dt_match_type="KNOWN_DIFFERENCE",
+                stat_cd_base="*2",
+                stat_cd_compare="V3",
+                stat_cd_match=False,
+                stat_cd_match_type="MISMATCH",
+            ),
+            Row(
+                acct=10000001238,
+                acct_seq=0,
+                cd_base="0005",
+                cd_compare=5.0,
+                cd_match=True,
+                cd_match_type="KNOWN_DIFFERENCE",
+                open_dt_base=datetime.date(2017, 5, 5),
+                open_dt_compare=2017125,
+                open_dt_match=True,
+                open_dt_match_type="KNOWN_DIFFERENCE",
+                stat_cd_base="*2",
+                stat_cd_compare=None,
+                stat_cd_match=True,
+                stat_cd_match_type="KNOWN_DIFFERENCE",
+            ),
+        ]
+    )
+
+    assert comparison_kd1.rows_both_all.count() == 5
+    assert expected_df.union(comparison_kd1.rows_both_all).distinct().count() == 5
+
+
+def test_rows_both_all_returns_a_dataframe_with_all_rows_in_identical_dataframes(
+    spark_session, comparison2
+):
+    expected_df = spark_session.createDataFrame(
+        [
+            Row(
+                acct=10000001234,
+                date_fld_base=datetime.date(2017, 1, 1),
+                date_fld_compare=datetime.date(2017, 1, 1),
+                date_fld_match=True,
+                dollar_amt_base=123,
+                dollar_amt_compare=123,
+                dollar_amt_match=True,
+                float_fld_base=14530.1555,
+                float_fld_compare=14530.1555,
+                float_fld_match=True,
+                name_base="George Maharis",
+                name_compare="George Maharis",
+                name_match=True,
+            ),
+            Row(
+                acct=10000001235,
+                date_fld_base=datetime.date(2017, 1, 1),
+                date_fld_compare=datetime.date(2017, 1, 1),
+                date_fld_match=True,
+                dollar_amt_base=0,
+                dollar_amt_compare=0,
+                dollar_amt_match=True,
+                float_fld_base=1.0,
+                float_fld_compare=1.0,
+                float_fld_match=True,
+                name_base="Michael Bluth",
+                name_compare="Michael Bluth",
+                name_match=True,
+            ),
+            Row(
+                acct=10000001236,
+                date_fld_base=datetime.date(2017, 1, 1),
+                date_fld_compare=datetime.date(2017, 1, 1),
+                date_fld_match=True,
+                dollar_amt_base=1345,
+                dollar_amt_compare=1345,
+                dollar_amt_match=True,
+                float_fld_base=None,
+                float_fld_compare=None,
+                float_fld_match=True,
+                name_base="George Bluth",
+                name_compare="George Bluth",
+                name_match=True,
+            ),
+            Row(
+                acct=10000001237,
+                date_fld_base=datetime.date(2017, 1, 1),
+                date_fld_compare=datetime.date(2017, 1, 1),
+                date_fld_match=True,
+                dollar_amt_base=123456,
+                dollar_amt_compare=123456,
+                dollar_amt_match=True,
+                float_fld_base=345.12,
+                float_fld_compare=345.12,
+                float_fld_match=True,
+                name_base="Bob Loblaw",
+                name_compare="Bob Loblaw",
+                name_match=True,
+            ),
+            Row(
+                acct=10000001239,
+                date_fld_base=datetime.date(2017, 1, 1),
+                date_fld_compare=datetime.date(2017, 1, 1),
+                date_fld_match=True,
+                dollar_amt_base=1,
+                dollar_amt_compare=1,
+                dollar_amt_match=True,
+                float_fld_base=None,
+                float_fld_compare=None,
+                float_fld_match=True,
+                name_base="Lucille Bluth",
+                name_compare="Lucille Bluth",
+                name_match=True,
+            ),
+        ]
+    )
+
+    assert comparison2.rows_both_all.count() == 5
+    assert expected_df.union(comparison2.rows_both_all).distinct().count() == 5
+
+
+def test_rows_both_all_returns_all_rows_in_both_dataframes_for_differently_named_columns(
+    spark_session, comparison3
+):
+    expected_df = spark_session.createDataFrame(
+        [
+            Row(
+                accnt_purge=False,
+                acct=10000001234,
+                date_fld_base=datetime.date(2017, 1, 1),
+                date_fld_compare=datetime.date(2017, 1, 1),
+                date_fld_match=True,
+                dollar_amt_base=123,
+                dollar_amt_compare=123.4,
+                dollar_amt_match=False,
+                float_fld_base=14530.1555,
+                float_fld_compare=14530.155,
+                float_fld_match=False,
+                name_base="George Maharis",
+                name_compare="George Michael Bluth",
+                name_match=False,
+            ),
+            Row(
+                accnt_purge=False,
+                acct=10000001235,
+                date_fld_base=datetime.date(2017, 1, 1),
+                date_fld_compare=datetime.date(2017, 1, 1),
+                date_fld_match=True,
+                dollar_amt_base=0,
+                dollar_amt_compare=0.45,
+                dollar_amt_match=False,
+                float_fld_base=1.0,
+                float_fld_compare=1.0,
+                float_fld_match=True,
+                name_base="Michael Bluth",
+                name_compare="Michael Bluth",
+                name_match=True,
+            ),
+            Row(
+                accnt_purge=False,
+                acct=10000001236,
+                date_fld_base=datetime.date(2017, 1, 1),
+                date_fld_compare=datetime.date(2017, 1, 1),
+                date_fld_match=True,
+                dollar_amt_base=1345,
+                dollar_amt_compare=1345.0,
+                dollar_amt_match=True,
+                float_fld_base=None,
+                float_fld_compare=None,
+                float_fld_match=True,
+                name_base="George Bluth",
+                name_compare="George Bluth",
+                name_match=True,
+            ),
+            Row(
+                accnt_purge=False,
+                acct=10000001237,
+                date_fld_base=datetime.date(2017, 1, 1),
+                date_fld_compare=datetime.date(2017, 1, 1),
+                date_fld_match=True,
+                dollar_amt_base=123456,
+                dollar_amt_compare=123456.0,
+                dollar_amt_match=True,
+                float_fld_base=345.12,
+                float_fld_compare=345.12,
+                float_fld_match=True,
+                name_base="Bob Loblaw",
+                name_compare="Bob Loblaw",
+                name_match=True,
+            ),
+            Row(
+                accnt_purge=True,
+                acct=10000001239,
+                date_fld_base=datetime.date(2017, 1, 1),
+                date_fld_compare=datetime.date(2017, 1, 1),
+                date_fld_match=True,
+                dollar_amt_base=1,
+                dollar_amt_compare=1.05,
+                dollar_amt_match=False,
+                float_fld_base=None,
+                float_fld_compare=None,
+                float_fld_match=True,
+                name_base="Lucille Bluth",
+                name_compare="Lucille Bluth",
+                name_match=True,
+            ),
+        ]
+    )
+
+    assert comparison3.rows_both_all.count() == 5
+    assert expected_df.union(comparison3.rows_both_all).distinct().count() == 5
+
+
+def test_columns_with_unequal_values_text_is_aligned(comparison4):
+    stdout = io.StringIO()
+
+    comparison4.report(file=stdout)
+    stdout.seek(0)  # Back up to the beginning of the stream
+
+    text_alignment_validator(
+        report=stdout,
+        section_start="****** Columns with Unequal Values ******",
+        section_end="\n",
+        left_indices=(1, 2, 3, 4),
+        right_indices=(5, 6),
+        column_regexes=[
+            r"""(Base\sColumn\sName) \s+ (Compare\sColumn\sName) \s+ (Base\sDtype) \s+ (Compare\sDtype) \s+
+                (\#\sMatches) \s+ (\#\sMismatches)""",
+            r"""(-+) \s+ (-+) \s+ (-+) \s+ (-+) \s+ (-+) \s+ (-+)""",
+            r"""(dollar_amt) \s+ (dollar_amt) \s+ (bigint) \s+ (double) \s+ (2) \s+ (2)""",
+            r"""(float_fld) \s+ (float_fld) \s+ (double) \s+ (double) \s+ (1) \s+ (3)""",
+            r"""(super_duper_big_long_name) \s+ (name) \s+ (string) \s+ (string) \s+ (3) \s+ (1)\s*""",
+        ],
+    )
+
+
+def test_columns_with_unequal_values_text_is_aligned_with_known_differences(
+    comparison_kd1,
+):
+    stdout = io.StringIO()
+
+    comparison_kd1.report(file=stdout)
+    stdout.seek(0)  # Back up to the beginning of the stream
+
+    text_alignment_validator(
+        report=stdout,
+        section_start="****** Columns with Unequal Values ******",
+        section_end="\n",
+        left_indices=(1, 2, 3, 4),
+        right_indices=(5, 6, 7),
+        column_regexes=[
+            r"""(Base\sColumn\sName) \s+ (Compare\sColumn\sName) \s+ (Base\sDtype) \s+ (Compare\sDtype) \s+
+                (\#\sMatches) \s+ (\#\sKnown\sDiffs) \s+ (\#\sMismatches)""",
+            r"""(-+) \s+ (-+) \s+ (-+) \s+ (-+) \s+ (-+) \s+ (-+) \s+ (-+)""",
+            r"""(stat_cd) \s+ (STATC) \s+ (string) \s+ (string) \s+ (2) \s+ (2) \s+ (1)""",
+            r"""(open_dt) \s+ (ACCOUNT_OPEN) \s+ (date) \s+ (bigint) \s+ (0) \s+ (5) \s+ (0)""",
+            r"""(cd) \s+ (CODE) \s+ (string) \s+ (double) \s+ (0) \s+ (5) \s+ (0)\s*""",
+        ],
+    )
+
+
+def test_columns_with_unequal_values_text_is_aligned_with_custom_known_differences(
+    comparison_kd2,
+):
+    stdout = io.StringIO()
+
+    comparison_kd2.report(file=stdout)
+    stdout.seek(0)  # Back up to the beginning of the stream
+
+    text_alignment_validator(
+        report=stdout,
+        section_start="****** Columns with Unequal Values ******",
+        section_end="\n",
+        left_indices=(1, 2, 3, 4),
+        right_indices=(5, 6, 7),
+        column_regexes=[
+            r"""(Base\sColumn\sName) \s+ (Compare\sColumn\sName) \s+ (Base\sDtype) \s+ (Compare\sDtype) \s+
+                (\#\sMatches) \s+ (\#\sKnown\sDiffs) \s+ (\#\sMismatches)""",
+            r"""(-+) \s+ (-+) \s+ (-+) \s+ (-+) \s+ (-+) \s+ (-+) \s+ (-+)""",
+            r"""(stat_cd) \s+ (STATC) \s+ (string) \s+ (string) \s+ (2) \s+ (2) \s+ (1)""",
+            r"""(open_dt) \s+ (ACCOUNT_OPEN) \s+ (date) \s+ (bigint) \s+ (0) \s+ (0) \s+ (5)""",
+            r"""(cd) \s+ (CODE) \s+ (string) \s+ (double) \s+ (0) \s+ (5) \s+ (0)\s*""",
+        ],
+    )
+
+
+def test_columns_with_unequal_values_text_is_aligned_for_decimals(comparison_decimal):
+    stdout = io.StringIO()
+
+    comparison_decimal.report(file=stdout)
+    stdout.seek(0)  # Back up to the beginning of the stream
+
+    text_alignment_validator(
+        report=stdout,
+        section_start="****** Columns with Unequal Values ******",
+        section_end="\n",
+        left_indices=(1, 2, 3, 4),
+        right_indices=(5, 6),
+        column_regexes=[
+            r"""(Base\sColumn\sName) \s+ (Compare\sColumn\sName) \s+ (Base\sDtype) \s+ (Compare\sDtype) \s+
+                (\#\sMatches) \s+ (\#\sMismatches)""",
+            r"""(-+) \s+ (-+) \s+ (-+) \s+ (-+) \s+ (-+) \s+ (-+)""",
+            r"""(dollar_amt) \s+ (dollar_amt) \s+ (decimal\(8,2\)) \s+ (double) \s+ (1) \s+ (1)""",
+        ],
+    )
+
+
+def test_schema_differences_text_is_aligned(comparison4):
+    stdout = io.StringIO()
+
+    comparison4.report(file=stdout)
+    comparison4.report()
+    stdout.seek(0)  # Back up to the beginning of the stream
+
+    text_alignment_validator(
+        report=stdout,
+        section_start="****** Schema Differences ******",
+        section_end="\n",
+        left_indices=(1, 2, 3, 4),
+        right_indices=(),
+        column_regexes=[
+            r"""(Base\sColumn\sName) \s+ (Compare\sColumn\sName) \s+ (Base\sDtype) \s+ (Compare\sDtype)""",
+            r"""(-+) \s+ (-+) \s+ (-+) \s+ (-+)""",
+            r"""(dollar_amt) \s+ (dollar_amt) \s+ (bigint) \s+ (double)""",
+        ],
+    )
+
+
+def test_schema_differences_text_is_aligned_for_decimals(comparison_decimal):
+    stdout = io.StringIO()
+
+    comparison_decimal.report(file=stdout)
+    stdout.seek(0)  # Back up to the beginning of the stream
+
+    text_alignment_validator(
+        report=stdout,
+        section_start="****** Schema Differences ******",
+        section_end="\n",
+        left_indices=(1, 2, 3, 4),
+        right_indices=(),
+        column_regexes=[
+            r"""(Base\sColumn\sName) \s+ (Compare\sColumn\sName) \s+ (Base\sDtype) \s+ (Compare\sDtype)""",
+            r"""(-+) \s+ (-+) \s+ (-+) \s+ (-+)""",
+            r"""(dollar_amt) \s+ (dollar_amt) \s+ (decimal\(8,2\)) \s+ (double)""",
+        ],
+    )
+
+
+def test_base_only_columns_text_is_aligned(comparison4):
+    stdout = io.StringIO()
+
+    comparison4.report(file=stdout)
+    stdout.seek(0)  # Back up to the beginning of the stream
+
+    text_alignment_validator(
+        report=stdout,
+        section_start="****** Columns In Base Only ******",
+        section_end="\n",
+        left_indices=(1, 2),
+        right_indices=(),
+        column_regexes=[
+            r"""(Column\sName) \s+ (Dtype)""",
+            r"""(-+) \s+ (-+)""",
+            r"""(date_fld) \s+ (date)""",
+        ],
+    )
+
+
+def test_compare_only_columns_text_is_aligned(comparison4):
+    stdout = io.StringIO()
+
+    comparison4.report(file=stdout)
+    stdout.seek(0)  # Back up to the beginning of the stream
+
+    text_alignment_validator(
+        report=stdout,
+        section_start="****** Columns In Compare Only ******",
+        section_end="\n",
+        left_indices=(1, 2),
+        right_indices=(),
+        column_regexes=[
+            r"""(Column\sName) \s+ (Dtype)""",
+            r"""(-+) \s+ (-+)""",
+            r"""(accnt_purge) \s+ (boolean)""",
+        ],
+    )
+
+
+def text_alignment_validator(
+    report, section_start, section_end, left_indices, right_indices, column_regexes
+):
+    r"""Check to make sure that report output columns are vertically aligned.
+
+    Parameters
+    ----------
+    report: An iterable returning lines of report output to be validated.
+    section_start: A string that represents the beginning of the section to be validated.
+    section_end: A string that represents the end of the section to be validated.
+    left_indices: The match group indexes (starting with 1) that should be left-aligned
+        in the output column.
+    right_indices: The match group indexes (starting with 1) that should be right-aligned
+        in the output column.
+    column_regexes: A list of regular expressions representing the expected output, with
+        each column enclosed with parentheses to return a match. The regular expression will
+        use the "X" flag, so it may contain whitespace, and any whitespace to be matched
+        should be explicitly given with \s. The first line will represent the alignments
+        that are expected in the following lines. The number of match groups should cover
+        all of the indices given in left/right_indices.
+
+    Runs assertions for every match group specified by left/right_indices to ensure that
+    all lines past the first are either left- or right-aligned with the same match group
+    on the first line.
+    """
+
+    at_column_section = False
+    processed_first_line = False
+    match_positions = [None] * (len(left_indices + right_indices) + 1)
+
+    for line in report:
+        if at_column_section:
+            if line == section_end:  # Detect end of section and stop
+                break
+
+            if (
+                not processed_first_line
+            ):  # First line in section - capture text start/end positions
+                matches = re.search(column_regexes[0], line, re.X)
+                assert matches is not None  # Make sure we found at least this...
+
+                for n in left_indices:
+                    match_positions[n] = matches.start(n)
+                for n in right_indices:
+                    match_positions[n] = matches.end(n)
+                processed_first_line = True
+            else:  # Match the stuff after the header text
+                match = None
+                for regex in column_regexes[1:]:
+                    match = re.search(regex, line, re.X)
+                    if match:
+                        break
+
+                if not match:
+                    raise AssertionError(f'Did not find a match for line: "{line}"')
+
+                for n in left_indices:
+                    assert match_positions[n] == match.start(n)
+                for n in right_indices:
+                    assert match_positions[n] == match.end(n)
+
+        if not at_column_section and section_start in line:
+            at_column_section = True
+
+
+def test_unicode_columns(spark_session):
+    df1 = spark_session.createDataFrame(
+        [
+            (1, "foo", "test"),
+            (2, "bar", "test"),
+        ],
+        ["id", "例", "予測対象日"],
+    )
+    df2 = spark_session.createDataFrame(
+        [
+            (1, "foo", "test"),
+            (2, "baz", "test"),
+        ],
+        ["id", "例", "予測対象日"],
+    )
+    compare = LegacySparkCompare(spark_session, df1, df2, join_columns=["例"])
+    # Just render the report to make sure it renders.
+    compare.report()

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -1231,7 +1231,7 @@ def test_dupes_with_nulls():
         ),
         (
             pl.DataFrame(
-                {"a": [datetime(2018, 1, 1), np.nan, np.nan], "b": ["1", "2", "2"]}
+                {"a": [datetime(2018, 1, 1), None, None], "b": ["1", "2", "2"]}
             ),
             pl.Series([1, 1, 2]),
         ),

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -13,2103 +13,1311 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import datetime
-import io
+"""
+Testing out the datacompy functionality
+"""
+
 import logging
 import re
+import sys
+from datetime import datetime
 from decimal import Decimal
+from io import StringIO
+from unittest import mock
 
+import numpy as np
+import pandas as pd
 import pytest
+from pytest import raises
 
 pytest.importorskip("pyspark")
 
-from pyspark.sql import Row, SparkSession
-from pyspark.sql.types import (
-    DateType,
-    DecimalType,
-    DoubleType,
-    LongType,
-    StringType,
-    StructField,
-    StructType,
+import pyspark.pandas as ps  # noqa: E402
+from pandas.testing import assert_series_equal  # noqa: E402
+
+from datacompy.spark import (  # noqa: E402
+    SparkCompare,
+    calculate_max_diff,
+    columns_equal,
+    generate_id_within_group,
+    temp_column_name,
 )
 
-import datacompy
-from datacompy import SparkCompare
-from datacompy.spark import _is_comparable
-
-# Turn off py4j debug messages for all tests in this module
-logging.getLogger("py4j").setLevel(logging.INFO)
-
-CACHE_INTERMEDIATES = True
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
 
-# Declare fixtures
-# (if we need to use these in other modules, move to conftest.py)
-@pytest.fixture(scope="module", name="spark")
-def spark_fixture():
-    spark = (
-        SparkSession.builder.master("local[2]")
-        .config("spark.driver.bindAddress", "127.0.0.1")
-        .appName("pytest")
-        .getOrCreate()
-    )
-    yield spark
-    spark.stop()
+pandas_version = pytest.mark.skipif(
+    pd.__version__ >= "2.0.0", reason="Pandas 2 is currently not supported"
+)
+
+pd.DataFrame.iteritems = pd.DataFrame.items  # Pandas 2+ compatability
+np.bool = np.bool_  # Numpy 1.24.3+ comptability
 
 
-@pytest.fixture(scope="module", name="base_df1")
-def base_df1_fixture(spark):
-    mock_data = [
-        Row(
-            acct=10000001234,
-            dollar_amt=123,
-            name="George Maharis",
-            float_fld=14530.1555,
-            date_fld=datetime.date(2017, 1, 1),
-        ),
-        Row(
-            acct=10000001235,
-            dollar_amt=0,
-            name="Michael Bluth",
-            float_fld=1.0,
-            date_fld=datetime.date(2017, 1, 1),
-        ),
-        Row(
-            acct=10000001236,
-            dollar_amt=1345,
-            name="George Bluth",
-            float_fld=None,
-            date_fld=datetime.date(2017, 1, 1),
-        ),
-        Row(
-            acct=10000001237,
-            dollar_amt=123456,
-            name="Bob Loblaw",
-            float_fld=345.12,
-            date_fld=datetime.date(2017, 1, 1),
-        ),
-        Row(
-            acct=10000001239,
-            dollar_amt=1,
-            name="Lucille Bluth",
-            float_fld=None,
-            date_fld=datetime.date(2017, 1, 1),
-        ),
-    ]
+@pandas_version
+def test_numeric_columns_equal_abs():
+    data = """a|b|expected
+1|1|True
+2|2.1|True
+3|4|False
+4|NULL|False
+NULL|4|False
+NULL|NULL|True"""
 
-    return spark.createDataFrame(mock_data)
-
-
-@pytest.fixture(scope="module", name="base_df2")
-def base_df2_fixture(spark):
-    mock_data = [
-        Row(
-            acct=10000001234,
-            dollar_amt=123,
-            super_duper_big_long_name="George Maharis",
-            float_fld=14530.1555,
-            date_fld=datetime.date(2017, 1, 1),
-        ),
-        Row(
-            acct=10000001235,
-            dollar_amt=0,
-            super_duper_big_long_name="Michael Bluth",
-            float_fld=1.0,
-            date_fld=datetime.date(2017, 1, 1),
-        ),
-        Row(
-            acct=10000001236,
-            dollar_amt=1345,
-            super_duper_big_long_name="George Bluth",
-            float_fld=None,
-            date_fld=datetime.date(2017, 1, 1),
-        ),
-        Row(
-            acct=10000001237,
-            dollar_amt=123456,
-            super_duper_big_long_name="Bob Loblaw",
-            float_fld=345.12,
-            date_fld=datetime.date(2017, 1, 1),
-        ),
-        Row(
-            acct=10000001239,
-            dollar_amt=1,
-            super_duper_big_long_name="Lucille Bluth",
-            float_fld=None,
-            date_fld=datetime.date(2017, 1, 1),
-        ),
-    ]
-
-    return spark.createDataFrame(mock_data)
-
-
-@pytest.fixture(scope="module", name="compare_df1")
-def compare_df1_fixture(spark):
-    mock_data2 = [
-        Row(
-            acct=10000001234,
-            dollar_amt=123.4,
-            name="George Michael Bluth",
-            float_fld=14530.155,
-            accnt_purge=False,
-        ),
-        Row(
-            acct=10000001235,
-            dollar_amt=0.45,
-            name="Michael Bluth",
-            float_fld=None,
-            accnt_purge=False,
-        ),
-        Row(
-            acct=10000001236,
-            dollar_amt=1345.0,
-            name="George Bluth",
-            float_fld=1.0,
-            accnt_purge=False,
-        ),
-        Row(
-            acct=10000001237,
-            dollar_amt=123456.0,
-            name="Bob Loblaw",
-            float_fld=345.12,
-            accnt_purge=False,
-        ),
-        Row(
-            acct=10000001238,
-            dollar_amt=1.05,
-            name="Loose Seal Bluth",
-            float_fld=111.0,
-            accnt_purge=True,
-        ),
-        Row(
-            acct=10000001238,
-            dollar_amt=1.05,
-            name="Loose Seal Bluth",
-            float_fld=111.0,
-            accnt_purge=True,
-        ),
-    ]
-
-    return spark.createDataFrame(mock_data2)
-
-
-@pytest.fixture(scope="module", name="compare_df2")
-def compare_df2_fixture(spark):
-    mock_data = [
-        Row(
-            acct=10000001234,
-            dollar_amt=123,
-            name="George Maharis",
-            float_fld=14530.1555,
-            date_fld=datetime.date(2017, 1, 1),
-        ),
-        Row(
-            acct=10000001235,
-            dollar_amt=0,
-            name="Michael Bluth",
-            float_fld=1.0,
-            date_fld=datetime.date(2017, 1, 1),
-        ),
-        Row(
-            acct=10000001236,
-            dollar_amt=1345,
-            name="George Bluth",
-            float_fld=None,
-            date_fld=datetime.date(2017, 1, 1),
-        ),
-        Row(
-            acct=10000001237,
-            dollar_amt=123456,
-            name="Bob Loblaw",
-            float_fld=345.12,
-            date_fld=datetime.date(2017, 1, 1),
-        ),
-        Row(
-            acct=10000001239,
-            dollar_amt=1,
-            name="Lucille Bluth",
-            float_fld=None,
-            date_fld=datetime.date(2017, 1, 1),
-        ),
-    ]
-
-    return spark.createDataFrame(mock_data)
-
-
-@pytest.fixture(scope="module", name="compare_df3")
-def compare_df3_fixture(spark):
-    mock_data2 = [
-        Row(
-            account_identifier=10000001234,
-            dollar_amount=123.4,
-            name="George Michael Bluth",
-            float_field=14530.155,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=False,
-        ),
-        Row(
-            account_identifier=10000001235,
-            dollar_amount=0.45,
-            name="Michael Bluth",
-            float_field=1.0,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=False,
-        ),
-        Row(
-            account_identifier=10000001236,
-            dollar_amount=1345.0,
-            name="George Bluth",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=False,
-        ),
-        Row(
-            account_identifier=10000001237,
-            dollar_amount=123456.0,
-            name="Bob Loblaw",
-            float_field=345.12,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=False,
-        ),
-        Row(
-            account_identifier=10000001239,
-            dollar_amount=1.05,
-            name="Lucille Bluth",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=True,
-        ),
-    ]
-
-    return spark.createDataFrame(mock_data2)
-
-
-@pytest.fixture(scope="module", name="base_tol")
-def base_tol_fixture(spark):
-    tol_data1 = [
-        Row(
-            account_identifier=10000001234,
-            dollar_amount=123.4,
-            name="Franklin Delano Bluth",
-            float_field=14530.155,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=False,
-        ),
-        Row(
-            account_identifier=10000001235,
-            dollar_amount=500.0,
-            name="Surely Funke",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=True,
-        ),
-        Row(
-            account_identifier=10000001236,
-            dollar_amount=-1100.0,
-            name="Nichael Bluth",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=True,
-        ),
-        Row(
-            account_identifier=10000001237,
-            dollar_amount=0.45,
-            name="Mr. F",
-            float_field=1.0,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=False,
-        ),
-        Row(
-            account_identifier=10000001238,
-            dollar_amount=1345.0,
-            name="Steve Holt!",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=False,
-        ),
-        Row(
-            account_identifier=10000001239,
-            dollar_amount=123456.0,
-            name="Blue Man Group",
-            float_field=345.12,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=False,
-        ),
-        Row(
-            account_identifier=10000001240,
-            dollar_amount=1.1,
-            name="Her?",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=True,
-        ),
-        Row(
-            account_identifier=10000001241,
-            dollar_amount=0.0,
-            name="Mrs. Featherbottom",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=True,
-        ),
-        Row(
-            account_identifier=10000001242,
-            dollar_amount=0.0,
-            name="Ice",
-            float_field=345.12,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=False,
-        ),
-        Row(
-            account_identifier=10000001243,
-            dollar_amount=-10.0,
-            name="Frank Wrench",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=True,
-        ),
-        Row(
-            account_identifier=10000001244,
-            dollar_amount=None,
-            name="Lucille 2",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=True,
-        ),
-        Row(
-            account_identifier=10000001245,
-            dollar_amount=0.009999,
-            name="Gene Parmesan",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=True,
-        ),
-        Row(
-            account_identifier=10000001246,
-            dollar_amount=None,
-            name="Motherboy",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=True,
-        ),
-    ]
-
-    return spark.createDataFrame(tol_data1)
-
-
-@pytest.fixture(scope="module", name="compare_abs_tol")
-def compare_tol2_fixture(spark):
-    tol_data2 = [
-        Row(
-            account_identifier=10000001234,
-            dollar_amount=123.4,
-            name="Franklin Delano Bluth",
-            float_field=14530.155,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=False,
-        ),  # full match
-        Row(
-            account_identifier=10000001235,
-            dollar_amount=500.01,
-            name="Surely Funke",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=True,
-        ),  # off by 0.01
-        Row(
-            account_identifier=10000001236,
-            dollar_amount=-1100.01,
-            name="Nichael Bluth",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=True,
-        ),  # off by -0.01
-        Row(
-            account_identifier=10000001237,
-            dollar_amount=0.46000000001,
-            name="Mr. F",
-            float_field=1.0,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=False,
-        ),  # off by 0.01000000001
-        Row(
-            account_identifier=10000001238,
-            dollar_amount=1344.8999999999,
-            name="Steve Holt!",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=False,
-        ),  # off by -0.01000000001
-        Row(
-            account_identifier=10000001239,
-            dollar_amount=123456.0099999999,
-            name="Blue Man Group",
-            float_field=345.12,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=False,
-        ),  # off by 0.00999999999
-        Row(
-            account_identifier=10000001240,
-            dollar_amount=1.090000001,
-            name="Her?",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=True,
-        ),  # off by -0.00999999999
-        Row(
-            account_identifier=10000001241,
-            dollar_amount=0.0,
-            name="Mrs. Featherbottom",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=True,
-        ),  # both zero
-        Row(
-            account_identifier=10000001242,
-            dollar_amount=1.0,
-            name="Ice",
-            float_field=345.12,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=False,
-        ),  # base 0, compare 1
-        Row(
-            account_identifier=10000001243,
-            dollar_amount=0.0,
-            name="Frank Wrench",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=True,
-        ),  # base -10, compare 0
-        Row(
-            account_identifier=10000001244,
-            dollar_amount=-1.0,
-            name="Lucille 2",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=True,
-        ),  # base NULL, compare -1
-        Row(
-            account_identifier=10000001245,
-            dollar_amount=None,
-            name="Gene Parmesan",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=True,
-        ),  # base 0.009999, compare NULL
-        Row(
-            account_identifier=10000001246,
-            dollar_amount=None,
-            name="Motherboy",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=True,
-        ),  # both NULL
-    ]
-
-    return spark.createDataFrame(tol_data2)
-
-
-@pytest.fixture(scope="module", name="compare_rel_tol")
-def compare_tol3_fixture(spark):
-    tol_data3 = [
-        Row(
-            account_identifier=10000001234,
-            dollar_amount=123.4,
-            name="Franklin Delano Bluth",
-            float_field=14530.155,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=False,
-        ),  # full match   #MATCH
-        Row(
-            account_identifier=10000001235,
-            dollar_amount=550.0,
-            name="Surely Funke",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=True,
-        ),  # off by 10%   #MATCH
-        Row(
-            account_identifier=10000001236,
-            dollar_amount=-1000.0,
-            name="Nichael Bluth",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=True,
-        ),  # off by -10%    #MATCH
-        Row(
-            account_identifier=10000001237,
-            dollar_amount=0.49501,
-            name="Mr. F",
-            float_field=1.0,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=False,
-        ),  # off by greater than 10%
-        Row(
-            account_identifier=10000001238,
-            dollar_amount=1210.001,
-            name="Steve Holt!",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=False,
-        ),  # off by greater than -10%
-        Row(
-            account_identifier=10000001239,
-            dollar_amount=135801.59999,
-            name="Blue Man Group",
-            float_field=345.12,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=False,
-        ),  # off by just under 10%   #MATCH
-        Row(
-            account_identifier=10000001240,
-            dollar_amount=1.000001,
-            name="Her?",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=True,
-        ),  # off by just under -10%   #MATCH
-        Row(
-            account_identifier=10000001241,
-            dollar_amount=0.0,
-            name="Mrs. Featherbottom",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=True,
-        ),  # both zero   #MATCH
-        Row(
-            account_identifier=10000001242,
-            dollar_amount=1.0,
-            name="Ice",
-            float_field=345.12,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=False,
-        ),  # base 0, compare 1
-        Row(
-            account_identifier=10000001243,
-            dollar_amount=0.0,
-            name="Frank Wrench",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=True,
-        ),  # base -10, compare 0
-        Row(
-            account_identifier=10000001244,
-            dollar_amount=-1.0,
-            name="Lucille 2",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=True,
-        ),  # base NULL, compare -1
-        Row(
-            account_identifier=10000001245,
-            dollar_amount=None,
-            name="Gene Parmesan",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=True,
-        ),  # base 0.009999, compare NULL
-        Row(
-            account_identifier=10000001246,
-            dollar_amount=None,
-            name="Motherboy",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=True,
-        ),  # both NULL  #MATCH
-    ]
-
-    return spark.createDataFrame(tol_data3)
-
-
-@pytest.fixture(scope="module", name="compare_both_tol")
-def compare_tol4_fixture(spark):
-    tol_data4 = [
-        Row(
-            account_identifier=10000001234,
-            dollar_amount=123.4,
-            name="Franklin Delano Bluth",
-            float_field=14530.155,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=False,
-        ),  # full match
-        Row(
-            account_identifier=10000001235,
-            dollar_amount=550.01,
-            name="Surely Funke",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=True,
-        ),  # off by 10% and +0.01
-        Row(
-            account_identifier=10000001236,
-            dollar_amount=-1000.01,
-            name="Nichael Bluth",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=True,
-        ),  # off by -10% and -0.01
-        Row(
-            account_identifier=10000001237,
-            dollar_amount=0.505000000001,
-            name="Mr. F",
-            float_field=1.0,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=False,
-        ),  # off by greater than 10% and +0.01
-        Row(
-            account_identifier=10000001238,
-            dollar_amount=1209.98999,
-            name="Steve Holt!",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=False,
-        ),  # off by greater than -10% and -0.01
-        Row(
-            account_identifier=10000001239,
-            dollar_amount=135801.609999,
-            name="Blue Man Group",
-            float_field=345.12,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=False,
-        ),  # off by just under 10% and just under +0.01
-        Row(
-            account_identifier=10000001240,
-            dollar_amount=0.99000001,
-            name="Her?",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=True,
-        ),  # off by just under -10% and just under -0.01
-        Row(
-            account_identifier=10000001241,
-            dollar_amount=0.0,
-            name="Mrs. Featherbottom",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=True,
-        ),  # both zero
-        Row(
-            account_identifier=10000001242,
-            dollar_amount=1.0,
-            name="Ice",
-            float_field=345.12,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=False,
-        ),  # base 0, compare 1
-        Row(
-            account_identifier=10000001243,
-            dollar_amount=0.0,
-            name="Frank Wrench",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=True,
-        ),  # base -10, compare 0
-        Row(
-            account_identifier=10000001244,
-            dollar_amount=-1.0,
-            name="Lucille 2",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=True,
-        ),  # base NULL, compare -1
-        Row(
-            account_identifier=10000001245,
-            dollar_amount=None,
-            name="Gene Parmesan",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=True,
-        ),  # base 0.009999, compare NULL
-        Row(
-            account_identifier=10000001246,
-            dollar_amount=None,
-            name="Motherboy",
-            float_field=None,
-            date_field=datetime.date(2017, 1, 1),
-            accnt_purge=True,
-        ),  # both NULL
-    ]
-
-    return spark.createDataFrame(tol_data4)
-
-
-@pytest.fixture(scope="module", name="base_td")
-def base_td_fixture(spark):
-    mock_data = [
-        Row(
-            acct=10000001234,
-            acct_seq=0,
-            stat_cd="*2",
-            open_dt=datetime.date(2017, 5, 1),
-            cd="0001",
-        ),
-        Row(
-            acct=10000001235,
-            acct_seq=0,
-            stat_cd="V1",
-            open_dt=datetime.date(2017, 5, 2),
-            cd="0002",
-        ),
-        Row(
-            acct=10000001236,
-            acct_seq=0,
-            stat_cd="V2",
-            open_dt=datetime.date(2017, 5, 3),
-            cd="0003",
-        ),
-        Row(
-            acct=10000001237,
-            acct_seq=0,
-            stat_cd="*2",
-            open_dt=datetime.date(2017, 5, 4),
-            cd="0004",
-        ),
-        Row(
-            acct=10000001238,
-            acct_seq=0,
-            stat_cd="*2",
-            open_dt=datetime.date(2017, 5, 5),
-            cd="0005",
-        ),
-    ]
-
-    return spark.createDataFrame(mock_data)
-
-
-@pytest.fixture(scope="module", name="compare_source")
-def compare_source_fixture(spark):
-    mock_data = [
-        Row(
-            ACCOUNT_IDENTIFIER=10000001234,
-            SEQ_NUMBER=0,
-            STATC=None,
-            ACCOUNT_OPEN=2017121,
-            CODE=1.0,
-        ),
-        Row(
-            ACCOUNT_IDENTIFIER=10000001235,
-            SEQ_NUMBER=0,
-            STATC="V1",
-            ACCOUNT_OPEN=2017122,
-            CODE=2.0,
-        ),
-        Row(
-            ACCOUNT_IDENTIFIER=10000001236,
-            SEQ_NUMBER=0,
-            STATC="V2",
-            ACCOUNT_OPEN=2017123,
-            CODE=3.0,
-        ),
-        Row(
-            ACCOUNT_IDENTIFIER=10000001237,
-            SEQ_NUMBER=0,
-            STATC="V3",
-            ACCOUNT_OPEN=2017124,
-            CODE=4.0,
-        ),
-        Row(
-            ACCOUNT_IDENTIFIER=10000001238,
-            SEQ_NUMBER=0,
-            STATC=None,
-            ACCOUNT_OPEN=2017125,
-            CODE=5.0,
-        ),
-    ]
-
-    return spark.createDataFrame(mock_data)
-
-
-@pytest.fixture(scope="module", name="base_decimal")
-def base_decimal_fixture(spark):
-    mock_data = [
-        Row(acct=10000001234, dollar_amt=Decimal(123.4)),
-        Row(acct=10000001235, dollar_amt=Decimal(0.45)),
-    ]
-
-    return spark.createDataFrame(
-        mock_data,
-        schema=StructType(
-            [
-                StructField("acct", LongType(), True),
-                StructField("dollar_amt", DecimalType(8, 2), True),
-            ]
-        ),
+    df = ps.from_pandas(pd.read_csv(StringIO(data), sep="|"))
+    actual_out = columns_equal(df.a, df.b, abs_tol=0.2)
+    expect_out = df["expected"]
+    assert_series_equal(
+        expect_out.to_pandas(), actual_out.to_pandas(), check_names=False
     )
 
 
-@pytest.fixture(scope="module", name="compare_decimal")
-def compare_decimal_fixture(spark):
-    mock_data = [
-        Row(acct=10000001234, dollar_amt=123.4),
-        Row(acct=10000001235, dollar_amt=0.456),
-    ]
-
-    return spark.createDataFrame(mock_data)
-
-
-@pytest.fixture(scope="module", name="comparison_abs_tol")
-def comparison_abs_tol_fixture(base_tol, compare_abs_tol, spark):
-    return SparkCompare(
-        spark,
-        base_tol,
-        compare_abs_tol,
-        join_columns=["account_identifier"],
-        abs_tol=0.01,
+@pandas_version
+def test_numeric_columns_equal_rel():
+    data = """a|b|expected
+1|1|True
+2|2.1|True
+3|4|False
+4|NULL|False
+NULL|4|False
+NULL|NULL|True"""
+    df = ps.from_pandas(pd.read_csv(StringIO(data), sep="|"))
+    actual_out = columns_equal(df.a, df.b, rel_tol=0.2)
+    expect_out = df["expected"]
+    assert_series_equal(
+        expect_out.to_pandas(), actual_out.to_pandas(), check_names=False
     )
 
 
-@pytest.fixture(scope="module", name="comparison_rel_tol")
-def comparison_rel_tol_fixture(base_tol, compare_rel_tol, spark):
-    return SparkCompare(
-        spark,
-        base_tol,
-        compare_rel_tol,
-        join_columns=["account_identifier"],
-        rel_tol=0.1,
+@pandas_version
+def test_string_columns_equal():
+    data = """a|b|expected
+Hi|Hi|True
+Yo|Yo|True
+Hey|Hey |False
+résumé|resume|False
+résumé|résumé|True
+💩|💩|True
+💩|🤔|False
+ | |True
+  | |False
+datacompy|DataComPy|False
+something||False
+|something|False
+||True"""
+    df = ps.from_pandas(pd.read_csv(StringIO(data), sep="|"))
+    actual_out = columns_equal(df.a, df.b, rel_tol=0.2)
+    expect_out = df["expected"]
+    assert_series_equal(
+        expect_out.to_pandas(), actual_out.to_pandas(), check_names=False
     )
 
 
-@pytest.fixture(scope="module", name="comparison_both_tol")
-def comparison_both_tol_fixture(base_tol, compare_both_tol, spark):
-    return SparkCompare(
-        spark,
-        base_tol,
-        compare_both_tol,
-        join_columns=["account_identifier"],
-        rel_tol=0.1,
-        abs_tol=0.01,
+@pandas_version
+def test_string_columns_equal_with_ignore_spaces():
+    data = """a|b|expected
+Hi|Hi|True
+Yo|Yo|True
+Hey|Hey |True
+résumé|resume|False
+résumé|résumé|True
+💩|💩|True
+💩|🤔|False
+ | |True
+  |       |True
+datacompy|DataComPy|False
+something||False
+|something|False
+||True"""
+    df = ps.from_pandas(pd.read_csv(StringIO(data), sep="|"))
+    actual_out = columns_equal(df.a, df.b, rel_tol=0.2, ignore_spaces=True)
+    expect_out = df["expected"]
+    assert_series_equal(
+        expect_out.to_pandas(), actual_out.to_pandas(), check_names=False
     )
 
 
-@pytest.fixture(scope="module", name="comparison_neg_tol")
-def comparison_neg_tol_fixture(base_tol, compare_both_tol, spark):
-    return SparkCompare(
-        spark,
-        base_tol,
-        compare_both_tol,
-        join_columns=["account_identifier"],
-        rel_tol=-0.2,
-        abs_tol=0.01,
+@pandas_version
+def test_string_columns_equal_with_ignore_spaces_and_case():
+    data = """a|b|expected
+Hi|Hi|True
+Yo|Yo|True
+Hey|Hey |True
+résumé|resume|False
+résumé|résumé|True
+💩|💩|True
+💩|🤔|False
+ | |True
+  |       |True
+datacompy|DataComPy|True
+something||False
+|something|False
+||True"""
+    df = ps.from_pandas(pd.read_csv(StringIO(data), sep="|"))
+    actual_out = columns_equal(
+        df.a, df.b, rel_tol=0.2, ignore_spaces=True, ignore_case=True
+    )
+    expect_out = df["expected"]
+    assert_series_equal(
+        expect_out.to_pandas(), actual_out.to_pandas(), check_names=False
     )
 
 
-@pytest.fixture(scope="module", name="show_all_columns_and_match_rate")
-def show_all_columns_and_match_rate_fixture(base_tol, compare_both_tol, spark):
-    return SparkCompare(
-        spark,
-        base_tol,
-        compare_both_tol,
-        join_columns=["account_identifier"],
-        show_all_columns=True,
-        match_rates=True,
+@pandas_version
+def test_date_columns_equal(tmp_path):
+    data = """a|b|expected
+2017-01-01|2017-01-01|True
+2017-01-02|2017-01-02|True
+2017-10-01|2017-10-10|False
+2017-01-01||False
+|2017-01-01|False
+||True"""
+    df = ps.from_pandas(pd.read_csv(StringIO(data), sep="|"))
+    # First compare just the strings
+    actual_out = columns_equal(df.a, df.b, rel_tol=0.2)
+    expect_out = df["expected"]
+    assert_series_equal(
+        expect_out.to_pandas(), actual_out.to_pandas(), check_names=False
+    )
+
+    # Then compare converted to datetime objects
+    df["a"] = ps.to_datetime(df["a"])
+    df["b"] = ps.to_datetime(df["b"])
+    actual_out = columns_equal(df.a, df.b, rel_tol=0.2)
+    expect_out = df["expected"]
+    assert_series_equal(
+        expect_out.to_pandas(), actual_out.to_pandas(), check_names=False
+    )
+    # and reverse
+    actual_out_rev = columns_equal(df.b, df.a, rel_tol=0.2)
+    assert_series_equal(
+        expect_out.to_pandas(), actual_out_rev.to_pandas(), check_names=False
     )
 
 
-@pytest.fixture(scope="module", name="comparison_kd1")
-def comparison_known_diffs1(base_td, compare_source, spark):
-    return SparkCompare(
-        spark,
-        base_td,
-        compare_source,
-        join_columns=[("acct", "ACCOUNT_IDENTIFIER"), ("acct_seq", "SEQ_NUMBER")],
-        column_mapping=[
-            ("stat_cd", "STATC"),
-            ("open_dt", "ACCOUNT_OPEN"),
-            ("cd", "CODE"),
-        ],
-        known_differences=[
+@pandas_version
+def test_date_columns_equal_with_ignore_spaces(tmp_path):
+    data = """a|b|expected
+2017-01-01|2017-01-01   |True
+2017-01-02  |2017-01-02|True
+2017-10-01  |2017-10-10   |False
+2017-01-01||False
+|2017-01-01|False
+||True"""
+    df = ps.from_pandas(pd.read_csv(StringIO(data), sep="|"))
+    # First compare just the strings
+    actual_out = columns_equal(df.a, df.b, rel_tol=0.2, ignore_spaces=True)
+    expect_out = df["expected"]
+    assert_series_equal(
+        expect_out.to_pandas(), actual_out.to_pandas(), check_names=False
+    )
+
+    # Then compare converted to datetime objects
+    df["a"] = ps.to_datetime(df["a"], errors="coerce")
+    df["b"] = ps.to_datetime(df["b"], errors="coerce")
+    actual_out = columns_equal(df.a, df.b, rel_tol=0.2, ignore_spaces=True)
+    expect_out = df["expected"]
+    assert_series_equal(
+        expect_out.to_pandas(), actual_out.to_pandas(), check_names=False
+    )
+    # and reverse
+    actual_out_rev = columns_equal(df.b, df.a, rel_tol=0.2, ignore_spaces=True)
+    assert_series_equal(
+        expect_out.to_pandas(), actual_out_rev.to_pandas(), check_names=False
+    )
+
+
+@pandas_version
+def test_date_columns_equal_with_ignore_spaces_and_case(tmp_path):
+    data = """a|b|expected
+2017-01-01|2017-01-01   |True
+2017-01-02  |2017-01-02|True
+2017-10-01  |2017-10-10   |False
+2017-01-01||False
+|2017-01-01|False
+||True"""
+    df = ps.from_pandas(pd.read_csv(StringIO(data), sep="|"))
+    # First compare just the strings
+    actual_out = columns_equal(
+        df.a, df.b, rel_tol=0.2, ignore_spaces=True, ignore_case=True
+    )
+    expect_out = df["expected"]
+    assert_series_equal(
+        expect_out.to_pandas(), actual_out.to_pandas(), check_names=False
+    )
+
+    # Then compare converted to datetime objects
+    df["a"] = ps.to_datetime(df["a"], errors="coerce")
+    df["b"] = ps.to_datetime(df["b"], errors="coerce")
+    actual_out = columns_equal(df.a, df.b, rel_tol=0.2, ignore_spaces=True)
+    expect_out = df["expected"]
+    assert_series_equal(
+        expect_out.to_pandas(), actual_out.to_pandas(), check_names=False
+    )
+    # and reverse
+    actual_out_rev = columns_equal(df.b, df.a, rel_tol=0.2, ignore_spaces=True)
+    assert_series_equal(
+        expect_out.to_pandas(), actual_out_rev.to_pandas(), check_names=False
+    )
+
+
+@pandas_version
+def test_date_columns_unequal():
+    """I want datetime fields to match with dates stored as strings"""
+    df = ps.DataFrame([{"a": "2017-01-01", "b": "2017-01-02"}, {"a": "2017-01-01"}])
+    df["a_dt"] = ps.to_datetime(df["a"])
+    df["b_dt"] = ps.to_datetime(df["b"])
+    assert columns_equal(df.a, df.a_dt).all()
+    assert columns_equal(df.b, df.b_dt).all()
+    assert columns_equal(df.a_dt, df.a).all()
+    assert columns_equal(df.b_dt, df.b).all()
+    assert not columns_equal(df.b_dt, df.a).any()
+    assert not columns_equal(df.a_dt, df.b).any()
+    assert not columns_equal(df.a, df.b_dt).any()
+    assert not columns_equal(df.b, df.a_dt).any()
+
+
+@pandas_version
+def test_bad_date_columns():
+    """If strings can't be coerced into dates then it should be false for the
+    whole column.
+    """
+    df = ps.DataFrame(
+        [{"a": "2017-01-01", "b": "2017-01-01"}, {"a": "2017-01-01", "b": "217-01-01"}]
+    )
+    df["a_dt"] = ps.to_datetime(df["a"])
+    assert not columns_equal(df.a_dt, df.b).any()
+
+
+@pandas_version
+def test_rounded_date_columns():
+    """If strings can't be coerced into dates then it should be false for the
+    whole column.
+    """
+    df = ps.DataFrame(
+        [
+            {"a": "2017-01-01", "b": "2017-01-01 00:00:00.000000", "exp": True},
+            {"a": "2017-01-01", "b": "2017-01-01 00:00:00.123456", "exp": False},
+            {"a": "2017-01-01", "b": "2017-01-01 00:00:01.000000", "exp": False},
+            {"a": "2017-01-01", "b": "2017-01-01 00:00:00", "exp": True},
+        ]
+    )
+    df["a_dt"] = ps.to_datetime(df["a"])
+    actual = columns_equal(df.a_dt, df.b)
+    expected = df["exp"]
+    assert_series_equal(actual.to_pandas(), expected.to_pandas(), check_names=False)
+
+
+@pandas_version
+def test_decimal_float_columns_equal():
+    df = ps.DataFrame(
+        [
+            {"a": Decimal("1"), "b": 1, "expected": True},
+            {"a": Decimal("1.3"), "b": 1.3, "expected": True},
+            {"a": Decimal("1.000003"), "b": 1.000003, "expected": True},
+            {"a": Decimal("1.000000004"), "b": 1.000000003, "expected": False},
+            {"a": Decimal("1.3"), "b": 1.2, "expected": False},
+            {"a": np.nan, "b": np.nan, "expected": True},
+            {"a": np.nan, "b": 1, "expected": False},
+            {"a": Decimal("1"), "b": np.nan, "expected": False},
+        ]
+    )
+    actual_out = columns_equal(df.a, df.b)
+    expect_out = df["expected"]
+    assert_series_equal(
+        expect_out.to_pandas(), actual_out.to_pandas(), check_names=False
+    )
+
+
+@pandas_version
+def test_decimal_float_columns_equal_rel():
+    df = ps.DataFrame(
+        [
+            {"a": Decimal("1"), "b": 1, "expected": True},
+            {"a": Decimal("1.3"), "b": 1.3, "expected": True},
+            {"a": Decimal("1.000003"), "b": 1.000003, "expected": True},
+            {"a": Decimal("1.000000004"), "b": 1.000000003, "expected": True},
+            {"a": Decimal("1.3"), "b": 1.2, "expected": False},
+            {"a": np.nan, "b": np.nan, "expected": True},
+            {"a": np.nan, "b": 1, "expected": False},
+            {"a": Decimal("1"), "b": np.nan, "expected": False},
+        ]
+    )
+    actual_out = columns_equal(df.a, df.b, abs_tol=0.001)
+    expect_out = df["expected"]
+    assert_series_equal(
+        expect_out.to_pandas(), actual_out.to_pandas(), check_names=False
+    )
+
+
+@pandas_version
+def test_decimal_columns_equal():
+    df = ps.DataFrame(
+        [
+            {"a": Decimal("1"), "b": Decimal("1"), "expected": True},
+            {"a": Decimal("1.3"), "b": Decimal("1.3"), "expected": True},
+            {"a": Decimal("1.000003"), "b": Decimal("1.000003"), "expected": True},
             {
-                "name": "Left-padded, four-digit numeric code",
-                "types": datacompy.NUMERIC_SPARK_TYPES,
-                "transformation": "lpad(cast({input} AS bigint), 4, '0')",
+                "a": Decimal("1.000000004"),
+                "b": Decimal("1.000000003"),
+                "expected": False,
             },
+            {"a": Decimal("1.3"), "b": Decimal("1.2"), "expected": False},
+            {"a": np.nan, "b": np.nan, "expected": True},
+            {"a": np.nan, "b": Decimal("1"), "expected": False},
+            {"a": Decimal("1"), "b": np.nan, "expected": False},
+        ]
+    )
+    actual_out = columns_equal(df.a, df.b)
+    expect_out = df["expected"]
+    assert_series_equal(
+        expect_out.to_pandas(), actual_out.to_pandas(), check_names=False
+    )
+
+
+@pandas_version
+def test_decimal_columns_equal_rel():
+    df = ps.DataFrame(
+        [
+            {"a": Decimal("1"), "b": Decimal("1"), "expected": True},
+            {"a": Decimal("1.3"), "b": Decimal("1.3"), "expected": True},
+            {"a": Decimal("1.000003"), "b": Decimal("1.000003"), "expected": True},
             {
-                "name": "Null to *2",
-                "types": ["string"],
-                "transformation": "case when {input} is null then '*2' else {input} end",
+                "a": Decimal("1.000000004"),
+                "b": Decimal("1.000000003"),
+                "expected": True,
             },
-            {
-                "name": "Julian date -> date",
-                "types": ["bigint"],
-                "transformation": "to_date(cast(unix_timestamp(cast({input} AS string), 'yyyyDDD') AS timestamp))",
-            },
-        ],
-    )
-
-
-@pytest.fixture(scope="module", name="comparison_kd2")
-def comparison_known_diffs2(base_td, compare_source, spark):
-    return SparkCompare(
-        spark,
-        base_td,
-        compare_source,
-        join_columns=[("acct", "ACCOUNT_IDENTIFIER"), ("acct_seq", "SEQ_NUMBER")],
-        column_mapping=[
-            ("stat_cd", "STATC"),
-            ("open_dt", "ACCOUNT_OPEN"),
-            ("cd", "CODE"),
-        ],
-        known_differences=[
-            {
-                "name": "Left-padded, four-digit numeric code",
-                "types": datacompy.NUMERIC_SPARK_TYPES,
-                "transformation": "lpad(cast({input} AS bigint), 4, '0')",
-            },
-            {
-                "name": "Null to *2",
-                "types": ["string"],
-                "transformation": "case when {input} is null then '*2' else {input} end",
-            },
-        ],
-    )
-
-
-@pytest.fixture(scope="module", name="comparison1")
-def comparison1_fixture(base_df1, compare_df1, spark):
-    return SparkCompare(
-        spark,
-        base_df1,
-        compare_df1,
-        join_columns=["acct"],
-        cache_intermediates=CACHE_INTERMEDIATES,
-    )
-
-
-@pytest.fixture(scope="module", name="comparison2")
-def comparison2_fixture(base_df1, compare_df2, spark):
-    return SparkCompare(spark, base_df1, compare_df2, join_columns=["acct"])
-
-
-@pytest.fixture(scope="module", name="comparison3")
-def comparison3_fixture(base_df1, compare_df3, spark):
-    return SparkCompare(
-        spark,
-        base_df1,
-        compare_df3,
-        join_columns=[("acct", "account_identifier")],
-        column_mapping=[
-            ("dollar_amt", "dollar_amount"),
-            ("float_fld", "float_field"),
-            ("date_fld", "date_field"),
-        ],
-        cache_intermediates=CACHE_INTERMEDIATES,
-    )
-
-
-@pytest.fixture(scope="module", name="comparison4")
-def comparison4_fixture(base_df2, compare_df1, spark):
-    return SparkCompare(
-        spark,
-        base_df2,
-        compare_df1,
-        join_columns=["acct"],
-        column_mapping=[("super_duper_big_long_name", "name")],
-    )
-
-
-@pytest.fixture(scope="module", name="comparison_decimal")
-def comparison_decimal_fixture(base_decimal, compare_decimal, spark):
-    return SparkCompare(spark, base_decimal, compare_decimal, join_columns=["acct"])
-
-
-def test_absolute_tolerances(comparison_abs_tol):
-    stdout = io.StringIO()
-
-    comparison_abs_tol.report(file=stdout)
-    stdout.seek(0)
-    assert "****** Row Comparison ******" in stdout.getvalue()
-    assert "Number of rows with some columns unequal: 6" in stdout.getvalue()
-    assert "Number of rows with all columns equal: 7" in stdout.getvalue()
-    assert "Number of columns compared with some values unequal: 1" in stdout.getvalue()
-    assert "Number of columns compared with all values equal: 4" in stdout.getvalue()
-
-
-def test_relative_tolerances(comparison_rel_tol):
-    stdout = io.StringIO()
-
-    comparison_rel_tol.report(file=stdout)
-    stdout.seek(0)
-    assert "****** Row Comparison ******" in stdout.getvalue()
-    assert "Number of rows with some columns unequal: 6" in stdout.getvalue()
-    assert "Number of rows with all columns equal: 7" in stdout.getvalue()
-    assert "Number of columns compared with some values unequal: 1" in stdout.getvalue()
-    assert "Number of columns compared with all values equal: 4" in stdout.getvalue()
-
-
-def test_both_tolerances(comparison_both_tol):
-    stdout = io.StringIO()
-
-    comparison_both_tol.report(file=stdout)
-    stdout.seek(0)
-    assert "****** Row Comparison ******" in stdout.getvalue()
-    assert "Number of rows with some columns unequal: 6" in stdout.getvalue()
-    assert "Number of rows with all columns equal: 7" in stdout.getvalue()
-    assert "Number of columns compared with some values unequal: 1" in stdout.getvalue()
-    assert "Number of columns compared with all values equal: 4" in stdout.getvalue()
-
-
-def test_negative_tolerances(spark, base_tol, compare_both_tol):
-    with pytest.raises(ValueError, match="Please enter positive valued tolerances"):
-        comp = SparkCompare(
-            spark,
-            base_tol,
-            compare_both_tol,
-            join_columns=["account_identifier"],
-            rel_tol=-0.2,
-            abs_tol=0.01,
-        )
-        comp.report()
-        pass
-
-
-def test_show_all_columns_and_match_rate(show_all_columns_and_match_rate):
-    stdout = io.StringIO()
-
-    show_all_columns_and_match_rate.report(file=stdout)
-
-    assert "****** Columns with Equal/Unequal Values ******" in stdout.getvalue()
-    assert (
-        "accnt_purge       accnt_purge          boolean        boolean               13             0     100.00000"
-        in stdout.getvalue()
-    )
-    assert (
-        "date_field        date_field           date           date                  13             0     100.00000"
-        in stdout.getvalue()
-    )
-    assert (
-        "dollar_amount     dollar_amount        double         double                 3            10      23.07692"
-        in stdout.getvalue()
-    )
-    assert (
-        "float_field       float_field          double         double                13             0     100.00000"
-        in stdout.getvalue()
-    )
-    assert (
-        "name              name                 string         string                13             0     100.00000"
-        in stdout.getvalue()
-    )
-
-
-def test_decimal_comparisons():
-    true_decimals = ["decimal", "decimal()", "decimal(20, 10)"]
-    assert all(v in datacompy.NUMERIC_SPARK_TYPES for v in true_decimals)
-
-
-def test_decimal_comparator_acts_like_string():
-    acc = False
-    for t in datacompy.NUMERIC_SPARK_TYPES:
-        acc = acc or (len(t) > 2 and t[0:3] == "dec")
-    assert acc
-
-
-def test_decimals_and_doubles_are_comparable():
-    assert _is_comparable("double", "decimal(10, 2)")
-
-
-def test_report_outputs_the_column_summary(comparison1):
-    stdout = io.StringIO()
-
-    comparison1.report(file=stdout)
-
-    assert "****** Column Summary ******" in stdout.getvalue()
-    assert "Number of columns in common with matching schemas: 3" in stdout.getvalue()
-    assert "Number of columns in common with schema differences: 1" in stdout.getvalue()
-    assert "Number of columns in base but not compare: 1" in stdout.getvalue()
-    assert "Number of columns in compare but not base: 1" in stdout.getvalue()
-
-
-def test_report_outputs_the_column_summary_for_identical_schemas(comparison2):
-    stdout = io.StringIO()
-
-    comparison2.report(file=stdout)
-
-    assert "****** Column Summary ******" in stdout.getvalue()
-    assert "Number of columns in common with matching schemas: 5" in stdout.getvalue()
-    assert "Number of columns in common with schema differences: 0" in stdout.getvalue()
-    assert "Number of columns in base but not compare: 0" in stdout.getvalue()
-    assert "Number of columns in compare but not base: 0" in stdout.getvalue()
-
-
-def test_report_outputs_the_column_summary_for_differently_named_columns(comparison3):
-    stdout = io.StringIO()
-
-    comparison3.report(file=stdout)
-
-    assert "****** Column Summary ******" in stdout.getvalue()
-    assert "Number of columns in common with matching schemas: 4" in stdout.getvalue()
-    assert "Number of columns in common with schema differences: 1" in stdout.getvalue()
-    assert "Number of columns in base but not compare: 0" in stdout.getvalue()
-    assert "Number of columns in compare but not base: 1" in stdout.getvalue()
-
-
-def test_report_outputs_the_row_summary(comparison1):
-    stdout = io.StringIO()
-
-    comparison1.report(file=stdout)
-
-    assert "****** Row Summary ******" in stdout.getvalue()
-    assert "Number of rows in common: 4" in stdout.getvalue()
-    assert "Number of rows in base but not compare: 1" in stdout.getvalue()
-    assert "Number of rows in compare but not base: 1" in stdout.getvalue()
-    assert "Number of duplicate rows found in base: 0" in stdout.getvalue()
-    assert "Number of duplicate rows found in compare: 1" in stdout.getvalue()
-
-
-def test_report_outputs_the_row_equality_comparison(comparison1):
-    stdout = io.StringIO()
-
-    comparison1.report(file=stdout)
-
-    assert "****** Row Comparison ******" in stdout.getvalue()
-    assert "Number of rows with some columns unequal: 3" in stdout.getvalue()
-    assert "Number of rows with all columns equal: 1" in stdout.getvalue()
-
-
-def test_report_outputs_the_row_summary_for_differently_named_columns(comparison3):
-    stdout = io.StringIO()
-
-    comparison3.report(file=stdout)
-
-    assert "****** Row Summary ******" in stdout.getvalue()
-    assert "Number of rows in common: 5" in stdout.getvalue()
-    assert "Number of rows in base but not compare: 0" in stdout.getvalue()
-    assert "Number of rows in compare but not base: 0" in stdout.getvalue()
-    assert "Number of duplicate rows found in base: 0" in stdout.getvalue()
-    assert "Number of duplicate rows found in compare: 0" in stdout.getvalue()
-
-
-def test_report_outputs_the_row_equality_comparison_for_differently_named_columns(
-    comparison3,
-):
-    stdout = io.StringIO()
-
-    comparison3.report(file=stdout)
-
-    assert "****** Row Comparison ******" in stdout.getvalue()
-    assert "Number of rows with some columns unequal: 3" in stdout.getvalue()
-    assert "Number of rows with all columns equal: 2" in stdout.getvalue()
-
-
-def test_report_outputs_column_detail_for_columns_in_only_one_dataframe(comparison1):
-    stdout = io.StringIO()
-
-    comparison1.report(file=stdout)
-    comparison1.report()
-    assert "****** Columns In Base Only ******" in stdout.getvalue()
-    r2 = r"""Column\s*Name \s* Dtype \n -+ \s+ -+ \ndate_fld \s+ date"""
-    assert re.search(r2, str(stdout.getvalue()), re.X) is not None
-
-
-def test_report_outputs_column_detail_for_columns_in_only_compare_dataframe(
-    comparison1,
-):
-    stdout = io.StringIO()
-
-    comparison1.report(file=stdout)
-    comparison1.report()
-    assert "****** Columns In Compare Only ******" in stdout.getvalue()
-    r2 = r"""Column\s*Name \s* Dtype \n -+ \s+ -+ \n accnt_purge \s+  boolean"""
-    assert re.search(r2, str(stdout.getvalue()), re.X) is not None
-
-
-def test_report_outputs_schema_difference_details(comparison1):
-    stdout = io.StringIO()
-
-    comparison1.report(file=stdout)
-
-    assert "****** Schema Differences ******" in stdout.getvalue()
-    assert re.search(
-        r"""Base\sColumn\sName \s+ Compare\sColumn\sName \s+ Base\sDtype \s+ Compare\sDtype \n
-            -+ \s+ -+ \s+ -+ \s+ -+ \n
-            dollar_amt \s+ dollar_amt \s+ bigint \s+ double""",
-        stdout.getvalue(),
-        re.X,
-    )
-
-
-def test_report_outputs_schema_difference_details_for_differently_named_columns(
-    comparison3,
-):
-    stdout = io.StringIO()
-
-    comparison3.report(file=stdout)
-
-    assert "****** Schema Differences ******" in stdout.getvalue()
-    assert re.search(
-        r"""Base\sColumn\sName \s+ Compare\sColumn\sName \s+ Base\sDtype \s+ Compare\sDtype \n
-            -+ \s+ -+ \s+ -+ \s+ -+ \n
-            dollar_amt \s+ dollar_amount \s+ bigint \s+ double""",
-        stdout.getvalue(),
-        re.X,
-    )
-
-
-def test_column_comparison_outputs_number_of_columns_with_differences(comparison1):
-    stdout = io.StringIO()
-
-    comparison1.report(file=stdout)
-
-    assert "****** Column Comparison ******" in stdout.getvalue()
-    assert "Number of columns compared with some values unequal: 3" in stdout.getvalue()
-    assert "Number of columns compared with all values equal: 0" in stdout.getvalue()
-
-
-def test_column_comparison_outputs_all_columns_equal_for_identical_dataframes(
-    comparison2,
-):
-    stdout = io.StringIO()
-
-    comparison2.report(file=stdout)
-
-    assert "****** Column Comparison ******" in stdout.getvalue()
-    assert "Number of columns compared with some values unequal: 0" in stdout.getvalue()
-    assert "Number of columns compared with all values equal: 4" in stdout.getvalue()
-
-
-def test_column_comparison_outputs_number_of_columns_with_differences_for_differently_named_columns(
-    comparison3,
-):
-    stdout = io.StringIO()
-
-    comparison3.report(file=stdout)
-
-    assert "****** Column Comparison ******" in stdout.getvalue()
-    assert "Number of columns compared with some values unequal: 3" in stdout.getvalue()
-    assert "Number of columns compared with all values equal: 1" in stdout.getvalue()
-
-
-def test_column_comparison_outputs_number_of_columns_with_differences_for_known_diffs(
-    comparison_kd1,
-):
-    stdout = io.StringIO()
-
-    comparison_kd1.report(file=stdout)
-
-    assert "****** Column Comparison ******" in stdout.getvalue()
-    assert (
-        "Number of columns compared with unexpected differences in some values: 1"
-        in stdout.getvalue()
-    )
-    assert (
-        "Number of columns compared with all values equal but known differences found: 2"
-        in stdout.getvalue()
-    )
-    assert (
-        "Number of columns compared with all values completely equal: 0"
-        in stdout.getvalue()
-    )
-
-
-def test_column_comparison_outputs_number_of_columns_with_differences_for_custom_known_diffs(
-    comparison_kd2,
-):
-    stdout = io.StringIO()
-
-    comparison_kd2.report(file=stdout)
-
-    assert "****** Column Comparison ******" in stdout.getvalue()
-    assert (
-        "Number of columns compared with unexpected differences in some values: 2"
-        in stdout.getvalue()
-    )
-    assert (
-        "Number of columns compared with all values equal but known differences found: 1"
-        in stdout.getvalue()
-    )
-    assert (
-        "Number of columns compared with all values completely equal: 0"
-        in stdout.getvalue()
-    )
-
-
-def test_columns_with_unequal_values_show_mismatch_counts(comparison1):
-    stdout = io.StringIO()
-
-    comparison1.report(file=stdout)
-
-    assert "****** Columns with Unequal Values ******" in stdout.getvalue()
-    assert re.search(
-        r"""Base\s*Column\s*Name \s+ Compare\s*Column\s*Name \s+ Base\s*Dtype \s+ Compare\sDtype \s*
-            \#\sMatches \s* \#\sMismatches \n
-            -+ \s+ -+ \s+ -+ \s+ -+ \s+ -+ \s+ -+""",
-        stdout.getvalue(),
-        re.X,
-    )
-    assert re.search(
-        r"""dollar_amt \s+ dollar_amt \s+ bigint \s+ double \s+ 2 \s+ 2""",
-        stdout.getvalue(),
-        re.X,
-    )
-    assert re.search(
-        r"""float_fld \s+ float_fld \s+ double \s+ double \s+ 1 \s+ 3""",
-        stdout.getvalue(),
-        re.X,
-    )
-    assert re.search(
-        r"""name \s+ name \s+ string \s+ string \s+ 3 \s+ 1""", stdout.getvalue(), re.X
-    )
-
-
-def test_columns_with_different_names_with_unequal_values_show_mismatch_counts(
-    comparison3,
-):
-    stdout = io.StringIO()
-
-    comparison3.report(file=stdout)
-
-    assert "****** Columns with Unequal Values ******" in stdout.getvalue()
-    assert re.search(
-        r"""Base\s*Column\s*Name \s+ Compare\s*Column\s*Name \s+ Base\s*Dtype \s+ Compare\sDtype \s*
-            \#\sMatches \s* \#\sMismatches \n
-            -+ \s+ -+ \s+ -+ \s+ -+ \s+ -+ \s+ -+""",
-        stdout.getvalue(),
-        re.X,
-    )
-    assert re.search(
-        r"""dollar_amt \s+ dollar_amount \s+ bigint \s+ double \s+ 2 \s+ 3""",
-        stdout.getvalue(),
-        re.X,
-    )
-    assert re.search(
-        r"""float_fld \s+ float_field \s+ double \s+ double \s+ 4 \s+ 1""",
-        stdout.getvalue(),
-        re.X,
-    )
-    assert re.search(
-        r"""name \s+ name \s+ string \s+ string \s+ 4 \s+ 1""", stdout.getvalue(), re.X
-    )
-
-
-def test_rows_only_base_returns_a_dataframe_with_rows_only_in_base(spark, comparison1):
-    # require schema if contains only 1 row and contain field value as None
-    schema = StructType(
-        [
-            StructField("acct", LongType(), True),
-            StructField("date_fld", DateType(), True),
-            StructField("dollar_amt", LongType(), True),
-            StructField("float_fld", DoubleType(), True),
-            StructField("name", StringType(), True),
+            {"a": Decimal("1.3"), "b": Decimal("1.2"), "expected": False},
+            {"a": np.nan, "b": np.nan, "expected": True},
+            {"a": np.nan, "b": Decimal("1"), "expected": False},
+            {"a": Decimal("1"), "b": np.nan, "expected": False},
         ]
     )
-    expected_df = spark.createDataFrame(
-        [
-            Row(
-                acct=10000001239,
-                date_fld=datetime.date(2017, 1, 1),
-                dollar_amt=1,
-                float_fld=None,
-                name="Lucille Bluth",
-            )
-        ],
-        schema,
+    actual_out = columns_equal(df.a, df.b, abs_tol=0.001)
+    expect_out = df["expected"]
+    assert_series_equal(
+        expect_out.to_pandas(), actual_out.to_pandas(), check_names=False
     )
-    assert comparison1.rows_only_base.count() == 1
+
+
+@pandas_version
+def test_infinity_and_beyond():
+    # https://spark.apache.org/docs/latest/sql-ref-datatypes.html#positivenegative-infinity-semantics
+    # Positive/negative infinity multiplied by 0 returns NaN.
+    # Positive infinity sorts lower than NaN and higher than any other values.
+    # Negative infinity sorts lower than any other values.
+    df = ps.DataFrame(
+        [
+            {"a": np.inf, "b": np.inf, "expected": True},
+            {"a": -np.inf, "b": -np.inf, "expected": True},
+            {"a": -np.inf, "b": np.inf, "expected": True},
+            {"a": np.inf, "b": -np.inf, "expected": True},
+            {"a": 1, "b": 1, "expected": True},
+            {"a": 1, "b": 0, "expected": False},
+        ]
+    )
+    actual_out = columns_equal(df.a, df.b)
+    expect_out = df["expected"]
+    assert_series_equal(
+        expect_out.to_pandas(), actual_out.to_pandas(), check_names=False
+    )
+
+
+@pandas_version
+def test_compare_df_setter_bad():
+    df = ps.DataFrame([{"a": 1, "c": 2}, {"a": 2, "c": 2}])
+    with raises(TypeError, match="df1 must be a pyspark.pandas.frame.DataFrame"):
+        compare = SparkCompare("a", "a", ["a"])
+    with raises(ValueError, match="df1 must have all columns from join_columns"):
+        compare = SparkCompare(df, df.copy(), ["b"])
+    df_dupe = ps.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 3}])
     assert (
-        expected_df.union(
-            comparison1.rows_only_base.select(
-                "acct", "date_fld", "dollar_amt", "float_fld", "name"
-            )
-        )
-        .distinct()
-        .count()
-        == 1
+        SparkCompare(df_dupe, df_dupe.copy(), ["a", "b"])
+        .df1.equals(df_dupe)
+        .all()
+        .all()
     )
 
 
-def test_rows_only_compare_returns_a_dataframe_with_rows_only_in_compare(
-    spark, comparison1
-):
-    expected_df = spark.createDataFrame(
+@pandas_version
+def test_compare_df_setter_good():
+    df1 = ps.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 2}])
+    df2 = ps.DataFrame([{"A": 1, "B": 2}, {"A": 2, "B": 3}])
+    compare = SparkCompare(df1, df2, ["a"])
+    assert compare.df1.equals(df1).all().all()
+    assert compare.df2.equals(df2).all().all()
+    assert compare.join_columns == ["a"]
+    compare = SparkCompare(df1, df2, ["A", "b"])
+    assert compare.df1.equals(df1).all().all()
+    assert compare.df2.equals(df2).all().all()
+    assert compare.join_columns == ["a", "b"]
+
+
+@pandas_version
+def test_compare_df_setter_different_cases():
+    df1 = ps.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 2}])
+    df2 = ps.DataFrame([{"A": 1, "b": 2}, {"A": 2, "b": 3}])
+    compare = SparkCompare(df1, df2, ["a"])
+    assert compare.df1.equals(df1).all().all()
+    assert compare.df2.equals(df2).all().all()
+
+
+@pandas_version
+def test_columns_overlap():
+    df1 = ps.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 2}])
+    df2 = ps.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 3}])
+    compare = SparkCompare(df1, df2, ["a"])
+    assert compare.df1_unq_columns() == set()
+    assert compare.df2_unq_columns() == set()
+    assert compare.intersect_columns() == {"a", "b"}
+
+
+@pandas_version
+def test_columns_no_overlap():
+    df1 = ps.DataFrame([{"a": 1, "b": 2, "c": "hi"}, {"a": 2, "b": 2, "c": "yo"}])
+    df2 = ps.DataFrame([{"a": 1, "b": 2, "d": "oh"}, {"a": 2, "b": 3, "d": "ya"}])
+    compare = SparkCompare(df1, df2, ["a"])
+    assert compare.df1_unq_columns() == {"c"}
+    assert compare.df2_unq_columns() == {"d"}
+    assert compare.intersect_columns() == {"a", "b"}
+
+
+@pandas_version
+def test_columns_maintain_order_through_set_operations():
+    df1 = ps.DataFrame(
         [
-            Row(
-                acct=10000001238,
-                dollar_amt=1.05,
-                name="Loose Seal Bluth",
-                float_fld=111.0,
-                accnt_purge=True,
-            )
+            (("A"), (0), (1), (2), (3), (4), (-2)),
+            (("B"), (0), (2), (2), (3), (4), (-3)),
+        ],
+        columns=["join", "f", "g", "b", "h", "a", "c"],
+    )
+    df2 = ps.DataFrame(
+        [
+            (("A"), (0), (1), (2), (-1), (4), (-3)),
+            (("B"), (1), (2), (3), (-1), (4), (-2)),
+        ],
+        columns=["join", "e", "h", "b", "a", "g", "d"],
+    )
+    compare = SparkCompare(df1, df2, ["join"])
+    assert list(compare.df1_unq_columns()) == ["f", "c"]
+    assert list(compare.df2_unq_columns()) == ["e", "d"]
+    assert list(compare.intersect_columns()) == ["join", "g", "b", "h", "a"]
+
+
+@pandas_version
+def test_10k_rows():
+    df1 = ps.DataFrame(np.random.randint(0, 100, size=(10000, 2)), columns=["b", "c"])
+    df1.reset_index(inplace=True)
+    df1.columns = ["a", "b", "c"]
+    df2 = df1.copy()
+    df2["b"] = df2["b"] + 0.1
+    compare_tol = SparkCompare(df1, df2, ["a"], abs_tol=0.2)
+    assert compare_tol.matches()
+    assert len(compare_tol.df1_unq_rows) == 0
+    assert len(compare_tol.df2_unq_rows) == 0
+    assert compare_tol.intersect_columns() == {"a", "b", "c"}
+    assert compare_tol.all_columns_match()
+    assert compare_tol.all_rows_overlap()
+    assert compare_tol.intersect_rows_match()
+
+    compare_no_tol = SparkCompare(df1, df2, ["a"])
+    assert not compare_no_tol.matches()
+    assert len(compare_no_tol.df1_unq_rows) == 0
+    assert len(compare_no_tol.df2_unq_rows) == 0
+    assert compare_no_tol.intersect_columns() == {"a", "b", "c"}
+    assert compare_no_tol.all_columns_match()
+    assert compare_no_tol.all_rows_overlap()
+    assert not compare_no_tol.intersect_rows_match()
+
+
+@pandas_version
+def test_subset(caplog):
+    caplog.set_level(logging.DEBUG)
+    df1 = ps.DataFrame([{"a": 1, "b": 2, "c": "hi"}, {"a": 2, "b": 2, "c": "yo"}])
+    df2 = ps.DataFrame([{"a": 1, "c": "hi"}])
+    comp = SparkCompare(df1, df2, ["a"])
+    assert comp.subset()
+    assert "Checking equality" in caplog.text
+
+
+@pandas_version
+def test_not_subset(caplog):
+    caplog.set_level(logging.INFO)
+    df1 = ps.DataFrame([{"a": 1, "b": 2, "c": "hi"}, {"a": 2, "b": 2, "c": "yo"}])
+    df2 = ps.DataFrame([{"a": 1, "b": 2, "c": "hi"}, {"a": 2, "b": 2, "c": "great"}])
+    comp = SparkCompare(df1, df2, ["a"])
+    assert not comp.subset()
+    assert "c: 1 / 2 (50.00%) match" in caplog.text
+
+
+@pandas_version
+def test_large_subset():
+    df1 = ps.DataFrame(np.random.randint(0, 100, size=(10000, 2)), columns=["b", "c"])
+    df1.reset_index(inplace=True)
+    df1.columns = ["a", "b", "c"]
+    df2 = df1[["a", "b"]].head(50).copy()
+    comp = SparkCompare(df1, df2, ["a"])
+    assert not comp.matches()
+    assert comp.subset()
+
+
+@pandas_version
+def test_string_joiner():
+    df1 = ps.DataFrame([{"ab": 1, "bc": 2}, {"ab": 2, "bc": 2}])
+    df2 = ps.DataFrame([{"ab": 1, "bc": 2}, {"ab": 2, "bc": 2}])
+    compare = SparkCompare(df1, df2, "ab")
+    assert compare.matches()
+
+
+@pandas_version
+def test_decimal_with_joins():
+    df1 = ps.DataFrame([{"a": Decimal("1"), "b": 2}, {"a": Decimal("2"), "b": 2}])
+    df2 = ps.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 2}])
+    compare = SparkCompare(df1, df2, "a")
+    assert compare.matches()
+    assert compare.all_columns_match()
+    assert compare.all_rows_overlap()
+    assert compare.intersect_rows_match()
+
+
+@pandas_version
+def test_decimal_with_nulls():
+    df1 = ps.DataFrame([{"a": 1, "b": Decimal("2")}, {"a": 2, "b": Decimal("2")}])
+    df2 = ps.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 2}, {"a": 3, "b": 2}])
+    compare = SparkCompare(df1, df2, "a")
+    assert not compare.matches()
+    assert compare.all_columns_match()
+    assert not compare.all_rows_overlap()
+    assert compare.intersect_rows_match()
+
+
+@pandas_version
+def test_strings_with_joins():
+    df1 = ps.DataFrame([{"a": "hi", "b": 2}, {"a": "bye", "b": 2}])
+    df2 = ps.DataFrame([{"a": "hi", "b": 2}, {"a": "bye", "b": 2}])
+    compare = SparkCompare(df1, df2, "a")
+    assert compare.matches()
+    assert compare.all_columns_match()
+    assert compare.all_rows_overlap()
+    assert compare.intersect_rows_match()
+
+
+@pandas_version
+def test_temp_column_name():
+    df1 = ps.DataFrame([{"a": "hi", "b": 2}, {"a": "bye", "b": 2}])
+    df2 = ps.DataFrame(
+        [{"a": "hi", "b": 2}, {"a": "bye", "b": 2}, {"a": "back fo mo", "b": 3}]
+    )
+    actual = temp_column_name(df1, df2)
+    assert actual == "_temp_0"
+
+
+@pandas_version
+def test_temp_column_name_one_has():
+    df1 = ps.DataFrame([{"_temp_0": "hi", "b": 2}, {"_temp_0": "bye", "b": 2}])
+    df2 = ps.DataFrame(
+        [{"a": "hi", "b": 2}, {"a": "bye", "b": 2}, {"a": "back fo mo", "b": 3}]
+    )
+    actual = temp_column_name(df1, df2)
+    assert actual == "_temp_1"
+
+
+@pandas_version
+def test_temp_column_name_both_have():
+    df1 = ps.DataFrame([{"_temp_0": "hi", "b": 2}, {"_temp_0": "bye", "b": 2}])
+    df2 = ps.DataFrame(
+        [
+            {"_temp_0": "hi", "b": 2},
+            {"_temp_0": "bye", "b": 2},
+            {"a": "back fo mo", "b": 3},
         ]
     )
+    actual = temp_column_name(df1, df2)
+    assert actual == "_temp_1"
 
-    assert comparison1.rows_only_compare.count() == 1
-    assert expected_df.union(comparison1.rows_only_compare).distinct().count() == 1
 
-
-def test_rows_both_mismatch_returns_a_dataframe_with_rows_where_variables_mismatched(
-    spark, comparison1
-):
-    expected_df = spark.createDataFrame(
+@pandas_version
+def test_temp_column_name_both_have():
+    df1 = ps.DataFrame([{"_temp_0": "hi", "b": 2}, {"_temp_0": "bye", "b": 2}])
+    df2 = ps.DataFrame(
         [
-            Row(
-                accnt_purge=False,
-                acct=10000001234,
-                date_fld=datetime.date(2017, 1, 1),
-                dollar_amt_base=123,
-                dollar_amt_compare=123.4,
-                dollar_amt_match=False,
-                float_fld_base=14530.1555,
-                float_fld_compare=14530.155,
-                float_fld_match=False,
-                name_base="George Maharis",
-                name_compare="George Michael Bluth",
-                name_match=False,
-            ),
-            Row(
-                accnt_purge=False,
-                acct=10000001235,
-                date_fld=datetime.date(2017, 1, 1),
-                dollar_amt_base=0,
-                dollar_amt_compare=0.45,
-                dollar_amt_match=False,
-                float_fld_base=1.0,
-                float_fld_compare=None,
-                float_fld_match=False,
-                name_base="Michael Bluth",
-                name_compare="Michael Bluth",
-                name_match=True,
-            ),
-            Row(
-                accnt_purge=False,
-                acct=10000001236,
-                date_fld=datetime.date(2017, 1, 1),
-                dollar_amt_base=1345,
-                dollar_amt_compare=1345.0,
-                dollar_amt_match=True,
-                float_fld_base=None,
-                float_fld_compare=1.0,
-                float_fld_match=False,
-                name_base="George Bluth",
-                name_compare="George Bluth",
-                name_match=True,
-            ),
+            {"_temp_0": "hi", "b": 2},
+            {"_temp_1": "bye", "b": 2},
+            {"a": "back fo mo", "b": 3},
         ]
     )
+    actual = temp_column_name(df1, df2)
+    assert actual == "_temp_2"
 
-    assert comparison1.rows_both_mismatch.count() == 3
-    assert expected_df.union(comparison1.rows_both_mismatch).distinct().count() == 3
 
-
-def test_rows_both_mismatch_only_includes_rows_with_true_mismatches_when_known_diffs_are_present(
-    spark, comparison_kd1
-):
-    expected_df = spark.createDataFrame(
+@pandas_version
+def test_temp_column_name_one_already():
+    df1 = ps.DataFrame([{"_temp_1": "hi", "b": 2}, {"_temp_1": "bye", "b": 2}])
+    df2 = ps.DataFrame(
         [
-            Row(
-                acct=10000001237,
-                acct_seq=0,
-                cd_base="0004",
-                cd_compare=4.0,
-                cd_match=True,
-                cd_match_type="KNOWN_DIFFERENCE",
-                open_dt_base=datetime.date(2017, 5, 4),
-                open_dt_compare=2017124,
-                open_dt_match=True,
-                open_dt_match_type="KNOWN_DIFFERENCE",
-                stat_cd_base="*2",
-                stat_cd_compare="V3",
-                stat_cd_match=False,
-                stat_cd_match_type="MISMATCH",
-            )
+            {"_temp_1": "hi", "b": 2},
+            {"_temp_1": "bye", "b": 2},
+            {"a": "back fo mo", "b": 3},
         ]
     )
-    assert comparison_kd1.rows_both_mismatch.count() == 1
-    assert expected_df.union(comparison_kd1.rows_both_mismatch).distinct().count() == 1
+    actual = temp_column_name(df1, df2)
+    assert actual == "_temp_0"
 
 
-def test_rows_both_all_returns_a_dataframe_with_all_rows_in_both_dataframes(
-    spark, comparison1
-):
-    expected_df = spark.createDataFrame(
-        [
-            Row(
-                accnt_purge=False,
-                acct=10000001234,
-                date_fld=datetime.date(2017, 1, 1),
-                dollar_amt_base=123,
-                dollar_amt_compare=123.4,
-                dollar_amt_match=False,
-                float_fld_base=14530.1555,
-                float_fld_compare=14530.155,
-                float_fld_match=False,
-                name_base="George Maharis",
-                name_compare="George Michael Bluth",
-                name_match=False,
-            ),
-            Row(
-                accnt_purge=False,
-                acct=10000001235,
-                date_fld=datetime.date(2017, 1, 1),
-                dollar_amt_base=0,
-                dollar_amt_compare=0.45,
-                dollar_amt_match=False,
-                float_fld_base=1.0,
-                float_fld_compare=None,
-                float_fld_match=False,
-                name_base="Michael Bluth",
-                name_compare="Michael Bluth",
-                name_match=True,
-            ),
-            Row(
-                accnt_purge=False,
-                acct=10000001236,
-                date_fld=datetime.date(2017, 1, 1),
-                dollar_amt_base=1345,
-                dollar_amt_compare=1345.0,
-                dollar_amt_match=True,
-                float_fld_base=None,
-                float_fld_compare=1.0,
-                float_fld_match=False,
-                name_base="George Bluth",
-                name_compare="George Bluth",
-                name_match=True,
-            ),
-            Row(
-                accnt_purge=False,
-                acct=10000001237,
-                date_fld=datetime.date(2017, 1, 1),
-                dollar_amt_base=123456,
-                dollar_amt_compare=123456.0,
-                dollar_amt_match=True,
-                float_fld_base=345.12,
-                float_fld_compare=345.12,
-                float_fld_match=True,
-                name_base="Bob Loblaw",
-                name_compare="Bob Loblaw",
-                name_match=True,
-            ),
-        ]
+### Duplicate testing!
+@pandas_version
+def test_simple_dupes_one_field():
+    df1 = ps.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 2}])
+    df2 = ps.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 2}])
+    compare = SparkCompare(df1, df2, join_columns=["a"])
+    assert compare.matches()
+    # Just render the report to make sure it renders.
+    t = compare.report()
+
+
+@pandas_version
+def test_simple_dupes_two_fields():
+    df1 = ps.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 2, "c": 2}])
+    df2 = ps.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 2, "c": 2}])
+    compare = SparkCompare(df1, df2, join_columns=["a", "b"])
+    assert compare.matches()
+    # Just render the report to make sure it renders.
+    t = compare.report()
+
+
+@pandas_version
+def test_simple_dupes_one_field_two_vals_1():
+    df1 = ps.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = ps.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    compare = SparkCompare(df1, df2, join_columns=["a"])
+    assert compare.matches()
+    # Just render the report to make sure it renders.
+    t = compare.report()
+
+
+@pandas_version
+def test_simple_dupes_one_field_two_vals_2():
+    df1 = ps.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = ps.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = SparkCompare(df1, df2, join_columns=["a"])
+    assert not compare.matches()
+    assert len(compare.df1_unq_rows) == 1
+    assert len(compare.df2_unq_rows) == 1
+    assert len(compare.intersect_rows) == 1
+    # Just render the report to make sure it renders.
+    t = compare.report()
+
+
+@pandas_version
+def test_simple_dupes_one_field_three_to_two_vals():
+    df1 = ps.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}, {"a": 1, "b": 0}])
+    df2 = ps.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    compare = SparkCompare(df1, df2, join_columns=["a"])
+    assert not compare.matches()
+    assert len(compare.df1_unq_rows) == 1
+    assert len(compare.df2_unq_rows) == 0
+    assert len(compare.intersect_rows) == 2
+    # Just render the report to make sure it renders.
+    t = compare.report()
+
+    assert "(First 1 Columns)" in compare.report(column_count=1)
+    assert "(First 2 Columns)" in compare.report(column_count=2)
+
+
+@pandas_version
+def test_dupes_from_real_data():
+    data = """acct_id,acct_sfx_num,trxn_post_dt,trxn_post_seq_num,trxn_amt,trxn_dt,debit_cr_cd,cash_adv_trxn_comn_cntry_cd,mrch_catg_cd,mrch_pstl_cd,visa_mail_phn_cd,visa_rqstd_pmt_svc_cd,mc_pmt_facilitator_idn_num
+100,0,2017-06-17,1537019,30.64,2017-06-15,D,CAN,5812,M2N5P5,,,0.0
+200,0,2017-06-24,1022477,485.32,2017-06-22,D,USA,4511,7114,7.0,1,
+100,0,2017-06-17,1537039,2.73,2017-06-16,D,CAN,5812,M4J 1M9,,,0.0
+200,0,2017-06-29,1049223,22.41,2017-06-28,D,USA,4789,21211,,A,
+100,0,2017-06-17,1537029,34.05,2017-06-16,D,CAN,5812,M4E 2C7,,,0.0
+200,0,2017-06-29,1049213,9.12,2017-06-28,D,CAN,5814,0,,,
+100,0,2017-06-19,1646426,165.21,2017-06-17,D,CAN,5411,M4M 3H9,,,0.0
+200,0,2017-06-30,1233082,28.54,2017-06-29,D,USA,4121,94105,7.0,G,
+100,0,2017-06-19,1646436,17.87,2017-06-18,D,CAN,5812,M4J 1M9,,,0.0
+200,0,2017-06-30,1233092,24.39,2017-06-29,D,USA,4121,94105,7.0,G,
+100,0,2017-06-19,1646446,5.27,2017-06-17,D,CAN,5200,M4M 3G6,,,0.0
+200,0,2017-06-30,1233102,61.8,2017-06-30,D,CAN,4121,0,,,
+100,0,2017-06-20,1607573,41.99,2017-06-19,D,CAN,5661,M4C1M9,,,0.0
+200,0,2017-07-01,1009403,2.31,2017-06-29,D,USA,5814,22102,,F,
+100,0,2017-06-20,1607553,86.88,2017-06-19,D,CAN,4812,H2R3A8,,,0.0
+200,0,2017-07-01,1009423,5.5,2017-06-29,D,USA,5812,2903,,F,
+100,0,2017-06-20,1607563,25.17,2017-06-19,D,CAN,5641,M4C 1M9,,,0.0
+200,0,2017-07-01,1009433,214.12,2017-06-29,D,USA,3640,20170,,A,
+100,0,2017-06-20,1607593,1.67,2017-06-19,D,CAN,5814,M2N 6L7,,,0.0
+200,0,2017-07-01,1009393,2.01,2017-06-29,D,USA,5814,22102,,F,"""
+    df1 = ps.from_pandas(pd.read_csv(StringIO(data), sep=","))
+    df2 = df1.copy()
+    compare_acct = SparkCompare(df1, df2, join_columns=["acct_id"])
+    assert compare_acct.matches()
+    compare_unq = SparkCompare(
+        df1,
+        df2,
+        join_columns=["acct_id", "acct_sfx_num", "trxn_post_dt", "trxn_post_seq_num"],
     )
-
-    assert comparison1.rows_both_all.count() == 4
-    assert expected_df.union(comparison1.rows_both_all).distinct().count() == 4
-
-
-def test_rows_both_all_shows_known_diffs_flag_and_known_diffs_count_as_matches(
-    spark, comparison_kd1
-):
-    expected_df = spark.createDataFrame(
-        [
-            Row(
-                acct=10000001234,
-                acct_seq=0,
-                cd_base="0001",
-                cd_compare=1.0,
-                cd_match=True,
-                cd_match_type="KNOWN_DIFFERENCE",
-                open_dt_base=datetime.date(2017, 5, 1),
-                open_dt_compare=2017121,
-                open_dt_match=True,
-                open_dt_match_type="KNOWN_DIFFERENCE",
-                stat_cd_base="*2",
-                stat_cd_compare=None,
-                stat_cd_match=True,
-                stat_cd_match_type="KNOWN_DIFFERENCE",
-            ),
-            Row(
-                acct=10000001235,
-                acct_seq=0,
-                cd_base="0002",
-                cd_compare=2.0,
-                cd_match=True,
-                cd_match_type="KNOWN_DIFFERENCE",
-                open_dt_base=datetime.date(2017, 5, 2),
-                open_dt_compare=2017122,
-                open_dt_match=True,
-                open_dt_match_type="KNOWN_DIFFERENCE",
-                stat_cd_base="V1",
-                stat_cd_compare="V1",
-                stat_cd_match=True,
-                stat_cd_match_type="MATCH",
-            ),
-            Row(
-                acct=10000001236,
-                acct_seq=0,
-                cd_base="0003",
-                cd_compare=3.0,
-                cd_match=True,
-                cd_match_type="KNOWN_DIFFERENCE",
-                open_dt_base=datetime.date(2017, 5, 3),
-                open_dt_compare=2017123,
-                open_dt_match=True,
-                open_dt_match_type="KNOWN_DIFFERENCE",
-                stat_cd_base="V2",
-                stat_cd_compare="V2",
-                stat_cd_match=True,
-                stat_cd_match_type="MATCH",
-            ),
-            Row(
-                acct=10000001237,
-                acct_seq=0,
-                cd_base="0004",
-                cd_compare=4.0,
-                cd_match=True,
-                cd_match_type="KNOWN_DIFFERENCE",
-                open_dt_base=datetime.date(2017, 5, 4),
-                open_dt_compare=2017124,
-                open_dt_match=True,
-                open_dt_match_type="KNOWN_DIFFERENCE",
-                stat_cd_base="*2",
-                stat_cd_compare="V3",
-                stat_cd_match=False,
-                stat_cd_match_type="MISMATCH",
-            ),
-            Row(
-                acct=10000001238,
-                acct_seq=0,
-                cd_base="0005",
-                cd_compare=5.0,
-                cd_match=True,
-                cd_match_type="KNOWN_DIFFERENCE",
-                open_dt_base=datetime.date(2017, 5, 5),
-                open_dt_compare=2017125,
-                open_dt_match=True,
-                open_dt_match_type="KNOWN_DIFFERENCE",
-                stat_cd_base="*2",
-                stat_cd_compare=None,
-                stat_cd_match=True,
-                stat_cd_match_type="KNOWN_DIFFERENCE",
-            ),
-        ]
-    )
-
-    assert comparison_kd1.rows_both_all.count() == 5
-    assert expected_df.union(comparison_kd1.rows_both_all).distinct().count() == 5
+    assert compare_unq.matches()
+    # Just render the report to make sure it renders.
+    t = compare_acct.report()
+    r = compare_unq.report()
 
 
-def test_rows_both_all_returns_a_dataframe_with_all_rows_in_identical_dataframes(
-    spark, comparison2
-):
-    expected_df = spark.createDataFrame(
-        [
-            Row(
-                acct=10000001234,
-                date_fld_base=datetime.date(2017, 1, 1),
-                date_fld_compare=datetime.date(2017, 1, 1),
-                date_fld_match=True,
-                dollar_amt_base=123,
-                dollar_amt_compare=123,
-                dollar_amt_match=True,
-                float_fld_base=14530.1555,
-                float_fld_compare=14530.1555,
-                float_fld_match=True,
-                name_base="George Maharis",
-                name_compare="George Maharis",
-                name_match=True,
-            ),
-            Row(
-                acct=10000001235,
-                date_fld_base=datetime.date(2017, 1, 1),
-                date_fld_compare=datetime.date(2017, 1, 1),
-                date_fld_match=True,
-                dollar_amt_base=0,
-                dollar_amt_compare=0,
-                dollar_amt_match=True,
-                float_fld_base=1.0,
-                float_fld_compare=1.0,
-                float_fld_match=True,
-                name_base="Michael Bluth",
-                name_compare="Michael Bluth",
-                name_match=True,
-            ),
-            Row(
-                acct=10000001236,
-                date_fld_base=datetime.date(2017, 1, 1),
-                date_fld_compare=datetime.date(2017, 1, 1),
-                date_fld_match=True,
-                dollar_amt_base=1345,
-                dollar_amt_compare=1345,
-                dollar_amt_match=True,
-                float_fld_base=None,
-                float_fld_compare=None,
-                float_fld_match=True,
-                name_base="George Bluth",
-                name_compare="George Bluth",
-                name_match=True,
-            ),
-            Row(
-                acct=10000001237,
-                date_fld_base=datetime.date(2017, 1, 1),
-                date_fld_compare=datetime.date(2017, 1, 1),
-                date_fld_match=True,
-                dollar_amt_base=123456,
-                dollar_amt_compare=123456,
-                dollar_amt_match=True,
-                float_fld_base=345.12,
-                float_fld_compare=345.12,
-                float_fld_match=True,
-                name_base="Bob Loblaw",
-                name_compare="Bob Loblaw",
-                name_match=True,
-            ),
-            Row(
-                acct=10000001239,
-                date_fld_base=datetime.date(2017, 1, 1),
-                date_fld_compare=datetime.date(2017, 1, 1),
-                date_fld_match=True,
-                dollar_amt_base=1,
-                dollar_amt_compare=1,
-                dollar_amt_match=True,
-                float_fld_base=None,
-                float_fld_compare=None,
-                float_fld_match=True,
-                name_base="Lucille Bluth",
-                name_compare="Lucille Bluth",
-                name_match=True,
-            ),
-        ]
-    )
+@pandas_version
+def test_strings_with_joins_with_ignore_spaces():
+    df1 = ps.DataFrame([{"a": "hi", "b": " A"}, {"a": "bye", "b": "A"}])
+    df2 = ps.DataFrame([{"a": "hi", "b": "A"}, {"a": "bye", "b": "A "}])
+    compare = SparkCompare(df1, df2, "a", ignore_spaces=False)
+    assert not compare.matches()
+    assert compare.all_columns_match()
+    assert compare.all_rows_overlap()
+    assert not compare.intersect_rows_match()
 
-    assert comparison2.rows_both_all.count() == 5
-    assert expected_df.union(comparison2.rows_both_all).distinct().count() == 5
+    compare = SparkCompare(df1, df2, "a", ignore_spaces=True)
+    assert compare.matches()
+    assert compare.all_columns_match()
+    assert compare.all_rows_overlap()
+    assert compare.intersect_rows_match()
 
 
-def test_rows_both_all_returns_all_rows_in_both_dataframes_for_differently_named_columns(
-    spark, comparison3
-):
-    expected_df = spark.createDataFrame(
-        [
-            Row(
-                accnt_purge=False,
-                acct=10000001234,
-                date_fld_base=datetime.date(2017, 1, 1),
-                date_fld_compare=datetime.date(2017, 1, 1),
-                date_fld_match=True,
-                dollar_amt_base=123,
-                dollar_amt_compare=123.4,
-                dollar_amt_match=False,
-                float_fld_base=14530.1555,
-                float_fld_compare=14530.155,
-                float_fld_match=False,
-                name_base="George Maharis",
-                name_compare="George Michael Bluth",
-                name_match=False,
-            ),
-            Row(
-                accnt_purge=False,
-                acct=10000001235,
-                date_fld_base=datetime.date(2017, 1, 1),
-                date_fld_compare=datetime.date(2017, 1, 1),
-                date_fld_match=True,
-                dollar_amt_base=0,
-                dollar_amt_compare=0.45,
-                dollar_amt_match=False,
-                float_fld_base=1.0,
-                float_fld_compare=1.0,
-                float_fld_match=True,
-                name_base="Michael Bluth",
-                name_compare="Michael Bluth",
-                name_match=True,
-            ),
-            Row(
-                accnt_purge=False,
-                acct=10000001236,
-                date_fld_base=datetime.date(2017, 1, 1),
-                date_fld_compare=datetime.date(2017, 1, 1),
-                date_fld_match=True,
-                dollar_amt_base=1345,
-                dollar_amt_compare=1345.0,
-                dollar_amt_match=True,
-                float_fld_base=None,
-                float_fld_compare=None,
-                float_fld_match=True,
-                name_base="George Bluth",
-                name_compare="George Bluth",
-                name_match=True,
-            ),
-            Row(
-                accnt_purge=False,
-                acct=10000001237,
-                date_fld_base=datetime.date(2017, 1, 1),
-                date_fld_compare=datetime.date(2017, 1, 1),
-                date_fld_match=True,
-                dollar_amt_base=123456,
-                dollar_amt_compare=123456.0,
-                dollar_amt_match=True,
-                float_fld_base=345.12,
-                float_fld_compare=345.12,
-                float_fld_match=True,
-                name_base="Bob Loblaw",
-                name_compare="Bob Loblaw",
-                name_match=True,
-            ),
-            Row(
-                accnt_purge=True,
-                acct=10000001239,
-                date_fld_base=datetime.date(2017, 1, 1),
-                date_fld_compare=datetime.date(2017, 1, 1),
-                date_fld_match=True,
-                dollar_amt_base=1,
-                dollar_amt_compare=1.05,
-                dollar_amt_match=False,
-                float_fld_base=None,
-                float_fld_compare=None,
-                float_fld_match=True,
-                name_base="Lucille Bluth",
-                name_compare="Lucille Bluth",
-                name_match=True,
-            ),
-        ]
-    )
+@pandas_version
+def test_strings_with_joins_with_ignore_case():
+    df1 = ps.DataFrame([{"a": "hi", "b": "a"}, {"a": "bye", "b": "A"}])
+    df2 = ps.DataFrame([{"a": "hi", "b": "A"}, {"a": "bye", "b": "a"}])
+    compare = SparkCompare(df1, df2, "a", ignore_case=False)
+    assert not compare.matches()
+    assert compare.all_columns_match()
+    assert compare.all_rows_overlap()
+    assert not compare.intersect_rows_match()
 
-    assert comparison3.rows_both_all.count() == 5
-    assert expected_df.union(comparison3.rows_both_all).distinct().count() == 5
+    compare = SparkCompare(df1, df2, "a", ignore_case=True)
+    assert compare.matches()
+    assert compare.all_columns_match()
+    assert compare.all_rows_overlap()
+    assert compare.intersect_rows_match()
 
 
-def test_columns_with_unequal_values_text_is_aligned(comparison4):
-    stdout = io.StringIO()
+@pandas_version
+def test_decimal_with_joins_with_ignore_spaces():
+    df1 = ps.DataFrame([{"a": 1, "b": " A"}, {"a": 2, "b": "A"}])
+    df2 = ps.DataFrame([{"a": 1, "b": "A"}, {"a": 2, "b": "A "}])
+    compare = SparkCompare(df1, df2, "a", ignore_spaces=False)
+    assert not compare.matches()
+    assert compare.all_columns_match()
+    assert compare.all_rows_overlap()
+    assert not compare.intersect_rows_match()
 
-    comparison4.report(file=stdout)
-    stdout.seek(0)  # Back up to the beginning of the stream
-
-    text_alignment_validator(
-        report=stdout,
-        section_start="****** Columns with Unequal Values ******",
-        section_end="\n",
-        left_indices=(1, 2, 3, 4),
-        right_indices=(5, 6),
-        column_regexes=[
-            r"""(Base\sColumn\sName) \s+ (Compare\sColumn\sName) \s+ (Base\sDtype) \s+ (Compare\sDtype) \s+
-                (\#\sMatches) \s+ (\#\sMismatches)""",
-            r"""(-+) \s+ (-+) \s+ (-+) \s+ (-+) \s+ (-+) \s+ (-+)""",
-            r"""(dollar_amt) \s+ (dollar_amt) \s+ (bigint) \s+ (double) \s+ (2) \s+ (2)""",
-            r"""(float_fld) \s+ (float_fld) \s+ (double) \s+ (double) \s+ (1) \s+ (3)""",
-            r"""(super_duper_big_long_name) \s+ (name) \s+ (string) \s+ (string) \s+ (3) \s+ (1)\s*""",
-        ],
-    )
+    compare = SparkCompare(df1, df2, "a", ignore_spaces=True)
+    assert compare.matches()
+    assert compare.all_columns_match()
+    assert compare.all_rows_overlap()
+    assert compare.intersect_rows_match()
 
 
-def test_columns_with_unequal_values_text_is_aligned_with_known_differences(
-    comparison_kd1,
-):
-    stdout = io.StringIO()
+@pandas_version
+def test_decimal_with_joins_with_ignore_case():
+    df1 = ps.DataFrame([{"a": 1, "b": "a"}, {"a": 2, "b": "A"}])
+    df2 = ps.DataFrame([{"a": 1, "b": "A"}, {"a": 2, "b": "a"}])
+    compare = SparkCompare(df1, df2, "a", ignore_case=False)
+    assert not compare.matches()
+    assert compare.all_columns_match()
+    assert compare.all_rows_overlap()
+    assert not compare.intersect_rows_match()
 
-    comparison_kd1.report(file=stdout)
-    stdout.seek(0)  # Back up to the beginning of the stream
-
-    text_alignment_validator(
-        report=stdout,
-        section_start="****** Columns with Unequal Values ******",
-        section_end="\n",
-        left_indices=(1, 2, 3, 4),
-        right_indices=(5, 6, 7),
-        column_regexes=[
-            r"""(Base\sColumn\sName) \s+ (Compare\sColumn\sName) \s+ (Base\sDtype) \s+ (Compare\sDtype) \s+
-                (\#\sMatches) \s+ (\#\sKnown\sDiffs) \s+ (\#\sMismatches)""",
-            r"""(-+) \s+ (-+) \s+ (-+) \s+ (-+) \s+ (-+) \s+ (-+) \s+ (-+)""",
-            r"""(stat_cd) \s+ (STATC) \s+ (string) \s+ (string) \s+ (2) \s+ (2) \s+ (1)""",
-            r"""(open_dt) \s+ (ACCOUNT_OPEN) \s+ (date) \s+ (bigint) \s+ (0) \s+ (5) \s+ (0)""",
-            r"""(cd) \s+ (CODE) \s+ (string) \s+ (double) \s+ (0) \s+ (5) \s+ (0)\s*""",
-        ],
-    )
+    compare = SparkCompare(df1, df2, "a", ignore_case=True)
+    assert compare.matches()
+    assert compare.all_columns_match()
+    assert compare.all_rows_overlap()
+    assert compare.intersect_rows_match()
 
 
-def test_columns_with_unequal_values_text_is_aligned_with_custom_known_differences(
-    comparison_kd2,
-):
-    stdout = io.StringIO()
+@pandas_version
+def test_joins_with_ignore_spaces():
+    df1 = ps.DataFrame([{"a": 1, "b": " A"}, {"a": 2, "b": "A"}])
+    df2 = ps.DataFrame([{"a": 1, "b": "A"}, {"a": 2, "b": "A "}])
 
-    comparison_kd2.report(file=stdout)
-    stdout.seek(0)  # Back up to the beginning of the stream
-
-    text_alignment_validator(
-        report=stdout,
-        section_start="****** Columns with Unequal Values ******",
-        section_end="\n",
-        left_indices=(1, 2, 3, 4),
-        right_indices=(5, 6, 7),
-        column_regexes=[
-            r"""(Base\sColumn\sName) \s+ (Compare\sColumn\sName) \s+ (Base\sDtype) \s+ (Compare\sDtype) \s+
-                (\#\sMatches) \s+ (\#\sKnown\sDiffs) \s+ (\#\sMismatches)""",
-            r"""(-+) \s+ (-+) \s+ (-+) \s+ (-+) \s+ (-+) \s+ (-+) \s+ (-+)""",
-            r"""(stat_cd) \s+ (STATC) \s+ (string) \s+ (string) \s+ (2) \s+ (2) \s+ (1)""",
-            r"""(open_dt) \s+ (ACCOUNT_OPEN) \s+ (date) \s+ (bigint) \s+ (0) \s+ (0) \s+ (5)""",
-            r"""(cd) \s+ (CODE) \s+ (string) \s+ (double) \s+ (0) \s+ (5) \s+ (0)\s*""",
-        ],
-    )
+    compare = SparkCompare(df1, df2, "a", ignore_spaces=True)
+    assert compare.matches()
+    assert compare.all_columns_match()
+    assert compare.all_rows_overlap()
+    assert compare.intersect_rows_match()
 
 
-def test_columns_with_unequal_values_text_is_aligned_for_decimals(comparison_decimal):
-    stdout = io.StringIO()
+@pandas_version
+def test_joins_with_ignore_case():
+    df1 = ps.DataFrame([{"a": 1, "b": "a"}, {"a": 2, "b": "A"}])
+    df2 = ps.DataFrame([{"a": 1, "b": "A"}, {"a": 2, "b": "a"}])
 
-    comparison_decimal.report(file=stdout)
-    stdout.seek(0)  # Back up to the beginning of the stream
-
-    text_alignment_validator(
-        report=stdout,
-        section_start="****** Columns with Unequal Values ******",
-        section_end="\n",
-        left_indices=(1, 2, 3, 4),
-        right_indices=(5, 6),
-        column_regexes=[
-            r"""(Base\sColumn\sName) \s+ (Compare\sColumn\sName) \s+ (Base\sDtype) \s+ (Compare\sDtype) \s+
-                (\#\sMatches) \s+ (\#\sMismatches)""",
-            r"""(-+) \s+ (-+) \s+ (-+) \s+ (-+) \s+ (-+) \s+ (-+)""",
-            r"""(dollar_amt) \s+ (dollar_amt) \s+ (decimal\(8,2\)) \s+ (double) \s+ (1) \s+ (1)""",
-        ],
-    )
+    compare = SparkCompare(df1, df2, "a", ignore_case=True)
+    assert compare.matches()
+    assert compare.all_columns_match()
+    assert compare.all_rows_overlap()
+    assert compare.intersect_rows_match()
 
 
-def test_schema_differences_text_is_aligned(comparison4):
-    stdout = io.StringIO()
+@pandas_version
+def test_strings_with_ignore_spaces_and_join_columns():
+    df1 = ps.DataFrame([{"a": "hi", "b": "A"}, {"a": "bye", "b": "A"}])
+    df2 = ps.DataFrame([{"a": " hi ", "b": "A"}, {"a": " bye ", "b": "A"}])
+    compare = SparkCompare(df1, df2, "a", ignore_spaces=False)
+    assert not compare.matches()
+    assert compare.all_columns_match()
+    assert not compare.all_rows_overlap()
+    assert compare.count_matching_rows() == 0
 
-    comparison4.report(file=stdout)
-    comparison4.report()
-    stdout.seek(0)  # Back up to the beginning of the stream
-
-    text_alignment_validator(
-        report=stdout,
-        section_start="****** Schema Differences ******",
-        section_end="\n",
-        left_indices=(1, 2, 3, 4),
-        right_indices=(),
-        column_regexes=[
-            r"""(Base\sColumn\sName) \s+ (Compare\sColumn\sName) \s+ (Base\sDtype) \s+ (Compare\sDtype)""",
-            r"""(-+) \s+ (-+) \s+ (-+) \s+ (-+)""",
-            r"""(dollar_amt) \s+ (dollar_amt) \s+ (bigint) \s+ (double)""",
-        ],
-    )
+    compare = SparkCompare(df1, df2, "a", ignore_spaces=True)
+    assert compare.matches()
+    assert compare.all_columns_match()
+    assert compare.all_rows_overlap()
+    assert compare.intersect_rows_match()
+    assert compare.count_matching_rows() == 2
 
 
-def test_schema_differences_text_is_aligned_for_decimals(comparison_decimal):
-    stdout = io.StringIO()
+@pandas_version
+def test_integers_with_ignore_spaces_and_join_columns():
+    df1 = ps.DataFrame([{"a": 1, "b": "A"}, {"a": 2, "b": "A"}])
+    df2 = ps.DataFrame([{"a": 1, "b": "A"}, {"a": 2, "b": "A"}])
+    compare = SparkCompare(df1, df2, "a", ignore_spaces=False)
+    assert compare.matches()
+    assert compare.all_columns_match()
+    assert compare.all_rows_overlap()
+    assert compare.intersect_rows_match()
+    assert compare.count_matching_rows() == 2
 
-    comparison_decimal.report(file=stdout)
-    stdout.seek(0)  # Back up to the beginning of the stream
-
-    text_alignment_validator(
-        report=stdout,
-        section_start="****** Schema Differences ******",
-        section_end="\n",
-        left_indices=(1, 2, 3, 4),
-        right_indices=(),
-        column_regexes=[
-            r"""(Base\sColumn\sName) \s+ (Compare\sColumn\sName) \s+ (Base\sDtype) \s+ (Compare\sDtype)""",
-            r"""(-+) \s+ (-+) \s+ (-+) \s+ (-+)""",
-            r"""(dollar_amt) \s+ (dollar_amt) \s+ (decimal\(8,2\)) \s+ (double)""",
-        ],
-    )
-
-
-def test_base_only_columns_text_is_aligned(comparison4):
-    stdout = io.StringIO()
-
-    comparison4.report(file=stdout)
-    stdout.seek(0)  # Back up to the beginning of the stream
-
-    text_alignment_validator(
-        report=stdout,
-        section_start="****** Columns In Base Only ******",
-        section_end="\n",
-        left_indices=(1, 2),
-        right_indices=(),
-        column_regexes=[
-            r"""(Column\sName) \s+ (Dtype)""",
-            r"""(-+) \s+ (-+)""",
-            r"""(date_fld) \s+ (date)""",
-        ],
-    )
+    compare = SparkCompare(df1, df2, "a", ignore_spaces=True)
+    assert compare.matches()
+    assert compare.all_columns_match()
+    assert compare.all_rows_overlap()
+    assert compare.intersect_rows_match()
+    assert compare.count_matching_rows() == 2
 
 
-def test_compare_only_columns_text_is_aligned(comparison4):
-    stdout = io.StringIO()
-
-    comparison4.report(file=stdout)
-    stdout.seek(0)  # Back up to the beginning of the stream
-
-    text_alignment_validator(
-        report=stdout,
-        section_start="****** Columns In Compare Only ******",
-        section_end="\n",
-        left_indices=(1, 2),
-        right_indices=(),
-        column_regexes=[
-            r"""(Column\sName) \s+ (Dtype)""",
-            r"""(-+) \s+ (-+)""",
-            r"""(accnt_purge) \s+ (boolean)""",
-        ],
-    )
-
-
-def text_alignment_validator(
-    report, section_start, section_end, left_indices, right_indices, column_regexes
-):
-    r"""Check to make sure that report output columns are vertically aligned.
-
-    Parameters
-    ----------
-    report: An iterable returning lines of report output to be validated.
-    section_start: A string that represents the beginning of the section to be validated.
-    section_end: A string that represents the end of the section to be validated.
-    left_indices: The match group indexes (starting with 1) that should be left-aligned
-        in the output column.
-    right_indices: The match group indexes (starting with 1) that should be right-aligned
-        in the output column.
-    column_regexes: A list of regular expressions representing the expected output, with
-        each column enclosed with parentheses to return a match. The regular expression will
-        use the "X" flag, so it may contain whitespace, and any whitespace to be matched
-        should be explicitly given with \s. The first line will represent the alignments
-        that are expected in the following lines. The number of match groups should cover
-        all of the indices given in left/right_indices.
-
-    Runs assertions for every match group specified by left/right_indices to ensure that
-    all lines past the first are either left- or right-aligned with the same match group
-    on the first line.
+@pandas_version
+def test_sample_mismatch():
+    data1 = """acct_id,dollar_amt,name,float_fld,date_fld
+    10000001234,123.45,George Maharis,14530.1555,2017-01-01
+    10000001235,0.45,Michael Bluth,1,2017-01-01
+    10000001236,1345,George Bluth,,2017-01-01
+    10000001237,123456,Bob Loblaw,345.12,2017-01-01
+    10000001239,1.05,Lucille Bluth,,2017-01-01
+    10000001240,123.45,George Maharis,14530.1555,2017-01-02
     """
 
-    at_column_section = False
-    processed_first_line = False
-    match_positions = [None] * (len(left_indices + right_indices) + 1)
+    data2 = """acct_id,dollar_amt,name,float_fld,date_fld
+    10000001234,123.4,George Michael Bluth,14530.155,
+    10000001235,0.45,Michael Bluth,,
+    10000001236,1345,George Bluth,1,
+    10000001237,123456,Robert Loblaw,345.12,
+    10000001238,1.05,Loose Seal Bluth,111,
+    10000001240,123.45,George Maharis,14530.1555,2017-01-02
+    """
 
-    for line in report:
-        if at_column_section:
-            if line == section_end:  # Detect end of section and stop
-                break
+    df1 = ps.from_pandas(pd.read_csv(StringIO(data1), sep=","))
+    df2 = ps.from_pandas(pd.read_csv(StringIO(data2), sep=","))
 
-            if (
-                not processed_first_line
-            ):  # First line in section - capture text start/end positions
-                matches = re.search(column_regexes[0], line, re.X)
-                assert matches is not None  # Make sure we found at least this...
+    compare = SparkCompare(df1, df2, "acct_id")
 
-                for n in left_indices:
-                    match_positions[n] = matches.start(n)
-                for n in right_indices:
-                    match_positions[n] = matches.end(n)
-                processed_first_line = True
-            else:  # Match the stuff after the header text
-                match = None
-                for regex in column_regexes[1:]:
-                    match = re.search(regex, line, re.X)
-                    if match:
-                        break
+    output = compare.sample_mismatch(column="name", sample_count=1)
+    assert output.shape[0] == 1
+    assert (output.name_df1 != output.name_df2).all()
 
-                if not match:
-                    raise AssertionError(f'Did not find a match for line: "{line}"')
+    output = compare.sample_mismatch(column="name", sample_count=2)
+    assert output.shape[0] == 2
+    assert (output.name_df1 != output.name_df2).all()
 
-                for n in left_indices:
-                    assert match_positions[n] == match.start(n)
-                for n in right_indices:
-                    assert match_positions[n] == match.end(n)
-
-        if not at_column_section and section_start in line:
-            at_column_section = True
+    output = compare.sample_mismatch(column="name", sample_count=3)
+    assert output.shape[0] == 2
+    assert (output.name_df1 != output.name_df2).all()
 
 
-def test_unicode_columns(spark_session):
-    df1 = spark_session.createDataFrame(
-        [
-            (1, "foo", "test"),
-            (2, "bar", "test"),
-        ],
-        ["id", "例", "予測対象日"],
+@pandas_version
+def test_all_mismatch_not_ignore_matching_cols_no_cols_matching():
+    data1 = """acct_id,dollar_amt,name,float_fld,date_fld
+    10000001234,123.45,George Maharis,14530.1555,2017-01-01
+    10000001235,0.45,Michael Bluth,1,2017-01-01
+    10000001236,1345,George Bluth,,2017-01-01
+    10000001237,123456,Bob Loblaw,345.12,2017-01-01
+    10000001239,1.05,Lucille Bluth,,2017-01-01
+    10000001240,123.45,George Maharis,14530.1555,2017-01-02
+    """
+
+    data2 = """acct_id,dollar_amt,name,float_fld,date_fld
+    10000001234,123.4,George Michael Bluth,14530.155,
+    10000001235,0.45,Michael Bluth,,
+    10000001236,1345,George Bluth,1,
+    10000001237,123456,Robert Loblaw,345.12,
+    10000001238,1.05,Loose Seal Bluth,111,
+    10000001240,123.45,George Maharis,14530.1555,2017-01-02
+    """
+    df1 = ps.from_pandas(pd.read_csv(StringIO(data1), sep=","))
+    df2 = ps.from_pandas(pd.read_csv(StringIO(data2), sep=","))
+    compare = SparkCompare(df1, df2, "acct_id")
+
+    output = compare.all_mismatch()
+    assert output.shape[0] == 4
+    assert output.shape[1] == 10
+
+    assert (output.name_df1 != output.name_df2).values.sum() == 2
+    assert (~(output.name_df1 != output.name_df2)).values.sum() == 2
+
+    assert (output.dollar_amt_df1 != output.dollar_amt_df2).values.sum() == 1
+    assert (~(output.dollar_amt_df1 != output.dollar_amt_df2)).values.sum() == 3
+
+    assert (output.float_fld_df1 != output.float_fld_df2).values.sum() == 3
+    assert (~(output.float_fld_df1 != output.float_fld_df2)).values.sum() == 1
+
+    assert (output.date_fld_df1 != output.date_fld_df2).values.sum() == 4
+    assert (~(output.date_fld_df1 != output.date_fld_df2)).values.sum() == 0
+
+
+@pandas_version
+def test_all_mismatch_not_ignore_matching_cols_some_cols_matching():
+    # Columns dollar_amt and name are matching
+    data1 = """acct_id,dollar_amt,name,float_fld,date_fld
+        10000001234,123.45,George Maharis,14530.1555,2017-01-01
+        10000001235,0.45,Michael Bluth,1,2017-01-01
+        10000001236,1345,George Bluth,,2017-01-01
+        10000001237,123456,Bob Loblaw,345.12,2017-01-01
+        10000001239,1.05,Lucille Bluth,,2017-01-01
+        10000001240,123.45,George Maharis,14530.1555,2017-01-02
+        """
+
+    data2 = """acct_id,dollar_amt,name,float_fld,date_fld
+        10000001234,123.45,George Maharis,14530.155,
+        10000001235,0.45,Michael Bluth,,
+        10000001236,1345,George Bluth,1,
+        10000001237,123456,Bob Loblaw,345.12,
+        10000001238,1.05,Lucille Bluth,111,
+        10000001240,123.45,George Maharis,14530.1555,2017-01-02
+        """
+    df1 = ps.from_pandas(pd.read_csv(StringIO(data1), sep=","))
+    df2 = ps.from_pandas(pd.read_csv(StringIO(data2), sep=","))
+    compare = SparkCompare(df1, df2, "acct_id")
+
+    output = compare.all_mismatch()
+    assert output.shape[0] == 4
+    assert output.shape[1] == 10
+
+    assert (output.name_df1 != output.name_df2).values.sum() == 0
+    assert (~(output.name_df1 != output.name_df2)).values.sum() == 4
+
+    assert (output.dollar_amt_df1 != output.dollar_amt_df2).values.sum() == 0
+    assert (~(output.dollar_amt_df1 != output.dollar_amt_df2)).values.sum() == 4
+
+    assert (output.float_fld_df1 != output.float_fld_df2).values.sum() == 3
+    assert (~(output.float_fld_df1 != output.float_fld_df2)).values.sum() == 1
+
+    assert (output.date_fld_df1 != output.date_fld_df2).values.sum() == 4
+    assert (~(output.date_fld_df1 != output.date_fld_df2)).values.sum() == 0
+
+
+@pandas_version
+def test_all_mismatch_ignore_matching_cols_some_cols_matching_diff_rows():
+    # Case where there are rows on either dataset which don't match up.
+    # Columns dollar_amt and name are matching
+    data1 = """acct_id,dollar_amt,name,float_fld,date_fld
+    10000001234,123.45,George Maharis,14530.1555,2017-01-01
+    10000001235,0.45,Michael Bluth,1,2017-01-01
+    10000001236,1345,George Bluth,,2017-01-01
+    10000001237,123456,Bob Loblaw,345.12,2017-01-01
+    10000001239,1.05,Lucille Bluth,,2017-01-01
+    10000001240,123.45,George Maharis,14530.1555,2017-01-02
+    10000001241,1111.05,Lucille Bluth,
+    """
+
+    data2 = """acct_id,dollar_amt,name,float_fld,date_fld
+    10000001234,123.45,George Maharis,14530.155,
+    10000001235,0.45,Michael Bluth,,
+    10000001236,1345,George Bluth,1,
+    10000001237,123456,Bob Loblaw,345.12,
+    10000001238,1.05,Lucille Bluth,111,
+    """
+    df1 = ps.from_pandas(pd.read_csv(StringIO(data1), sep=","))
+    df2 = ps.from_pandas(pd.read_csv(StringIO(data2), sep=","))
+    compare = SparkCompare(df1, df2, "acct_id")
+
+    output = compare.all_mismatch(ignore_matching_cols=True)
+
+    assert output.shape[0] == 4
+    assert output.shape[1] == 6
+
+    assert (output.float_fld_df1 != output.float_fld_df2).values.sum() == 3
+    assert (~(output.float_fld_df1 != output.float_fld_df2)).values.sum() == 1
+
+    assert (output.date_fld_df1 != output.date_fld_df2).values.sum() == 4
+    assert (~(output.date_fld_df1 != output.date_fld_df2)).values.sum() == 0
+
+    assert not ("name_df1" in output and "name_df2" in output)
+    assert not ("dollar_amt_df1" in output and "dollar_amt_df1" in output)
+
+
+@pandas_version
+def test_all_mismatch_ignore_matching_cols_some_calls_matching():
+    # Columns dollar_amt and name are matching
+    data1 = """acct_id,dollar_amt,name,float_fld,date_fld
+    10000001234,123.45,George Maharis,14530.1555,2017-01-01
+    10000001235,0.45,Michael Bluth,1,2017-01-01
+    10000001236,1345,George Bluth,,2017-01-01
+    10000001237,123456,Bob Loblaw,345.12,2017-01-01
+    10000001239,1.05,Lucille Bluth,,2017-01-01
+    10000001240,123.45,George Maharis,14530.1555,2017-01-02
+    """
+
+    data2 = """acct_id,dollar_amt,name,float_fld,date_fld
+    10000001234,123.45,George Maharis,14530.155,
+    10000001235,0.45,Michael Bluth,,
+    10000001236,1345,George Bluth,1,
+    10000001237,123456,Bob Loblaw,345.12,
+    10000001238,1.05,Lucille Bluth,111,
+    10000001240,123.45,George Maharis,14530.1555,2017-01-02
+    """
+    df1 = ps.from_pandas(pd.read_csv(StringIO(data1), sep=","))
+    df2 = ps.from_pandas(pd.read_csv(StringIO(data2), sep=","))
+    compare = SparkCompare(df1, df2, "acct_id")
+
+    output = compare.all_mismatch(ignore_matching_cols=True)
+
+    assert output.shape[0] == 4
+    assert output.shape[1] == 6
+
+    assert (output.float_fld_df1 != output.float_fld_df2).values.sum() == 3
+    assert (~(output.float_fld_df1 != output.float_fld_df2)).values.sum() == 1
+
+    assert (output.date_fld_df1 != output.date_fld_df2).values.sum() == 4
+    assert (~(output.date_fld_df1 != output.date_fld_df2)).values.sum() == 0
+
+    assert not ("name_df1" in output and "name_df2" in output)
+    assert not ("dollar_amt_df1" in output and "dollar_amt_df1" in output)
+
+
+@pandas_version
+def test_all_mismatch_ignore_matching_cols_no_cols_matching():
+    data1 = """acct_id,dollar_amt,name,float_fld,date_fld
+    10000001234,123.45,George Maharis,14530.1555,2017-01-01
+    10000001235,0.45,Michael Bluth,1,2017-01-01
+    10000001236,1345,George Bluth,,2017-01-01
+    10000001237,123456,Bob Loblaw,345.12,2017-01-01
+    10000001239,1.05,Lucille Bluth,,2017-01-01
+    10000001240,123.45,George Maharis,14530.1555,2017-01-02
+    """
+
+    data2 = """acct_id,dollar_amt,name,float_fld,date_fld
+    10000001234,123.4,George Michael Bluth,14530.155,
+    10000001235,0.45,Michael Bluth,,
+    10000001236,1345,George Bluth,1,
+    10000001237,123456,Robert Loblaw,345.12,
+    10000001238,1.05,Loose Seal Bluth,111,
+    10000001240,123.45,George Maharis,14530.1555,2017-01-02
+    """
+    df1 = ps.from_pandas(pd.read_csv(StringIO(data1), sep=","))
+    df2 = ps.from_pandas(pd.read_csv(StringIO(data2), sep=","))
+    compare = SparkCompare(df1, df2, "acct_id")
+
+    output = compare.all_mismatch()
+    assert output.shape[0] == 4
+    assert output.shape[1] == 10
+
+    assert (output.name_df1 != output.name_df2).values.sum() == 2
+    assert (~(output.name_df1 != output.name_df2)).values.sum() == 2
+
+    assert (output.dollar_amt_df1 != output.dollar_amt_df2).values.sum() == 1
+    assert (~(output.dollar_amt_df1 != output.dollar_amt_df2)).values.sum() == 3
+
+    assert (output.float_fld_df1 != output.float_fld_df2).values.sum() == 3
+    assert (~(output.float_fld_df1 != output.float_fld_df2)).values.sum() == 1
+
+    assert (output.date_fld_df1 != output.date_fld_df2).values.sum() == 4
+    assert (~(output.date_fld_df1 != output.date_fld_df2)).values.sum() == 0
+
+
+@pandas_version
+@pytest.mark.parametrize(
+    "column,expected",
+    [
+        ("base", 0),
+        ("floats", 0.2),
+        ("decimals", 0.1),
+        ("null_floats", 0.1),
+        ("strings", 0.1),
+        ("mixed_strings", 1),
+        ("infinity", np.inf),
+    ],
+)
+def test_calculate_max_diff(column, expected):
+    MAX_DIFF_DF = ps.DataFrame(
+        {
+            "base": [1, 1, 1, 1, 1],
+            "floats": [1.1, 1.1, 1.1, 1.2, 0.9],
+            "decimals": [
+                Decimal("1.1"),
+                Decimal("1.1"),
+                Decimal("1.1"),
+                Decimal("1.1"),
+                Decimal("1.1"),
+            ],
+            "null_floats": [np.nan, 1.1, 1, 1, 1],
+            "strings": ["1", "1", "1", "1.1", "1"],
+            "mixed_strings": ["1", "1", "1", "2", "some string"],
+            "infinity": [1, 1, 1, 1, np.inf],
+        }
     )
-    df2 = spark_session.createDataFrame(
-        [
-            (1, "foo", "test"),
-            (2, "baz", "test"),
-        ],
-        ["id", "例", "予測対象日"],
+    assert np.isclose(
+        calculate_max_diff(MAX_DIFF_DF["base"], MAX_DIFF_DF[column]), expected
     )
-    compare = SparkCompare(spark_session, df1, df2, join_columns=["例"])
+
+
+@pandas_version
+def test_dupes_with_nulls_strings():
+    df1 = ps.DataFrame(
+        {
+            "fld_1": [1, 2, 2, 3, 3, 4, 5, 5],
+            "fld_2": ["A", np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
+            "fld_3": [1, 2, 2, 3, 3, 4, 5, 5],
+        }
+    )
+    df2 = ps.DataFrame(
+        {
+            "fld_1": [1, 2, 3, 4, 5],
+            "fld_2": ["A", np.nan, np.nan, np.nan, np.nan],
+            "fld_3": [1, 2, 3, 4, 5],
+        }
+    )
+    comp = SparkCompare(df1, df2, join_columns=["fld_1", "fld_2"])
+    assert comp.subset()
+
+
+@pandas_version
+def test_dupes_with_nulls_ints():
+    df1 = ps.DataFrame(
+        {
+            "fld_1": [1, 2, 2, 3, 3, 4, 5, 5],
+            "fld_2": [1, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
+            "fld_3": [1, 2, 2, 3, 3, 4, 5, 5],
+        }
+    )
+    df2 = ps.DataFrame(
+        {
+            "fld_1": [1, 2, 3, 4, 5],
+            "fld_2": [1, np.nan, np.nan, np.nan, np.nan],
+            "fld_3": [1, 2, 3, 4, 5],
+        }
+    )
+    comp = SparkCompare(df1, df2, join_columns=["fld_1", "fld_2"])
+    assert comp.subset()
+
+
+@pandas_version
+@pytest.mark.parametrize(
+    "dataframe,expected",
+    [
+        (ps.DataFrame({"a": [1, 2, 3], "b": [1, 2, 3]}), ps.Series([0, 0, 0])),
+        (
+            ps.DataFrame({"a": ["a", "a", "DATACOMPY_NULL"], "b": [1, 1, 2]}),
+            ps.Series([0, 1, 0]),
+        ),
+        (ps.DataFrame({"a": [-999, 2, 3], "b": [1, 2, 3]}), ps.Series([0, 0, 0])),
+        (
+            ps.DataFrame({"a": [1, np.nan, np.nan], "b": [1, 2, 2]}),
+            ps.Series([0, 0, 1]),
+        ),
+        (
+            ps.DataFrame({"a": ["1", np.nan, np.nan], "b": ["1", "2", "2"]}),
+            ps.Series([0, 0, 1]),
+        ),
+        (
+            ps.DataFrame(
+                {"a": [datetime(2018, 1, 1), np.nan, np.nan], "b": ["1", "2", "2"]}
+            ),
+            ps.Series([0, 0, 1]),
+        ),
+    ],
+)
+def test_generate_id_within_group(dataframe, expected):
+    assert (generate_id_within_group(dataframe, ["a", "b"]) == expected).all()
+
+
+@pandas_version
+def test_lower():
+    """This function tests the toggle to use lower case for column names or not"""
+    # should match
+    df1 = ps.DataFrame({"a": [1, 2, 3], "b": [0, 1, 2]})
+    df2 = ps.DataFrame({"a": [1, 2, 3], "B": [0, 1, 2]})
+    compare = SparkCompare(df1, df2, join_columns=["a"])
+    assert compare.matches()
+    # should not match
+    df1 = ps.DataFrame({"a": [1, 2, 3], "b": [0, 1, 2]})
+    df2 = ps.DataFrame({"a": [1, 2, 3], "B": [0, 1, 2]})
+    compare = SparkCompare(df1, df2, join_columns=["a"], cast_column_names_lower=False)
+    assert not compare.matches()
+
+    # test join column
+    # should match
+    df1 = ps.DataFrame({"a": [1, 2, 3], "b": [0, 1, 2]})
+    df2 = ps.DataFrame({"A": [1, 2, 3], "B": [0, 1, 2]})
+    compare = SparkCompare(df1, df2, join_columns=["a"])
+    assert compare.matches()
+    # should fail because "a" is not found in df2
+    df1 = ps.DataFrame({"a": [1, 2, 3], "b": [0, 1, 2]})
+    df2 = ps.DataFrame({"A": [1, 2, 3], "B": [0, 1, 2]})
+    expected_message = "df2 must have all columns from join_columns"
+    with raises(ValueError, match=expected_message):
+        compare = SparkCompare(
+            df1, df2, join_columns=["a"], cast_column_names_lower=False
+        )
+
+
+@pandas_version
+def test_integer_column_names():
+    """This function tests that integer column names would also work"""
+    df1 = ps.DataFrame({1: [1, 2, 3], 2: [0, 1, 2]})
+    df2 = ps.DataFrame({1: [1, 2, 3], 2: [0, 1, 2]})
+    compare = SparkCompare(df1, df2, join_columns=[1])
+    assert compare.matches()
+
+
+@pandas_version
+@mock.patch("datacompy.spark.render")
+def test_save_html(mock_render):
+    df1 = ps.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 2}])
+    df2 = ps.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 2}])
+    compare = SparkCompare(df1, df2, join_columns=["a"])
+
+    m = mock.mock_open()
+    with mock.patch("datacompy.spark.open", m, create=True):
+        # assert without HTML call
+        compare.report()
+        assert mock_render.call_count == 4
+        m.assert_not_called()
+
+    mock_render.reset_mock()
+    m = mock.mock_open()
+    with mock.patch("datacompy.spark.open", m, create=True):
+        # assert with HTML call
+        compare.report(html_file="test.html")
+        assert mock_render.call_count == 4
+        m.assert_called_with("test.html", "w")
+
+
+def test_pandas_version():
+    expected_message = "It seems like you are running Pandas 2+. Please note that Pandas 2+ will only be supported in Spark 4+. See: https://issues.apache.org/jira/browse/SPARK-44101. If you need to use Spark DataFrame with Pandas 2+ then consider using Fugue otherwise downgrade to Pandas 1.5.3"
+    df1 = ps.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 2}])
+    df2 = ps.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 2}])
+    with mock.patch("pandas.__version__", "2.0.0"):
+        with raises(Exception, match=re.escape(expected_message)):
+            SparkCompare(df1, df2, join_columns=["a"])
+
+    with mock.patch("pandas.__version__", "1.5.3"):
+        SparkCompare(df1, df2, join_columns=["a"])
+
+
+@pandas_version
+def test_unicode_columns():
+    df1 = ps.DataFrame(
+        [{"a": 1, "例": 2, "予測対象日": "test"}, {"a": 1, "例": 3, "予測対象日": "test"}]
+    )
+    df2 = ps.DataFrame(
+        [{"a": 1, "例": 2, "予測対象日": "test"}, {"a": 1, "例": 3, "予測対象日": "test"}]
+    )
+    compare = SparkCompare(df1, df2, join_columns=["例"])
+    assert compare.matches()
     # Just render the report to make sure it renders.
-    compare.report()
+    t = compare.report()


### PR DESCRIPTION
Release v0.12.0
============

This release has some breaking changes users should be aware of.

- For the new Pandas on Spark implementation only Pandas 1.5.3 and below will be supported due to Pandas 2.0 [compatibility issues with Spark 3](https://issues.apache.org/jira/browse/SPARK-44101).
   - Users wishing to use the older SparkCompare can continue to do so using `LegacySparkCompare`
- Spark 3.1.x support will be dropped
- Python 3.8 support is dropped

## Breaking changes
(#275)
- Pandas on Spark refactor and deprecation of the legacy SparkCompare 
- Drop Python 3.8 and Spark 3.1.x support

## Updates
- Fix suffix on all mismatches reports (#293)
- count matching rows for Fugue (#294)
- Pandas 2.2.2 bump (#295, #296)