### PR TITLE
adding in Python 3.12 support, warnings, and doc updates

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9, '3.10', '3.11']
+        python-version: [3.9, '3.10', '3.11', '3.12']
 
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ If you would like to use Spark or any other backends please make sure you instal
 pip install datacompy[spark]
 pip install datacompy[dask]
 pip install datacompy[duckdb]
-pip install datacompy[polars]
 pip install datacompy[ray]
 
 ```
@@ -79,7 +78,9 @@ With version ``0.12.0``:
 
 
 > [!NOTE]
-> At the current time Python `3.12` is not supported by Spark and also Ray within Fugue.
+> At the current time Python `3.12` is not supported by Spark and also Ray within Fugue. 
+> If you are using Python `3.12` and above, please note that not all functioanlity will be supported.
+> Pandas and Polars support should work fine and are tested.
 
 ## Supported backends
 

--- a/datacompy/__init__.py
+++ b/datacompy/__init__.py
@@ -15,6 +15,9 @@
 
 __version__ = "0.12.0"
 
+import platform
+from warnings import warn
+
 from datacompy.core import *
 from datacompy.fugue import (
     all_columns_match,
@@ -27,3 +30,14 @@ from datacompy.fugue import (
 )
 from datacompy.polars import PolarsCompare
 from datacompy.spark import SparkCompare
+
+major = platform.python_version_tuple()[0]
+minor = platform.python_version_tuple()[1]
+
+if major == "3" and minor >= "12":
+    warn(
+        "Python 3.12 and above currently is not supported by Spark and Ray. "
+        "Please note that some functionality will not work and currently is not supported.",
+        UserWarning,
+        stacklevel=2,
+    )

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -2,9 +2,10 @@
 Installation
 ============
 
-.. note::
+.. important::
 
-    Moving forward ``datacompy`` will not support Python 2. Please make sure you are using Python 3.8+
+    If you are using Python 3.12 and above, please note that not all functioanlity will be supported.
+    Pandas and Polars support should work fine and are tested.
 
 
 PyPI (basic)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,13 @@ maintainers = [
   { name="Faisal Dosani", email="faisal.dosani@capitalone.com" }
 ]
 license = {text = "Apache Software License"}
-dependencies = ["pandas<=2.2.2,>=0.25.0", "numpy<=1.26.4,>=1.22.0", "ordered-set<=4.1.0,>=4.0.2", "fugue<=0.8.7,>=0.8.7"]
+dependencies = [
+  "pandas<=2.2.2,>=0.25.0", 
+  "numpy<=1.26.4,>=1.22.0", 
+  "ordered-set<=4.1.0,>=4.0.2", 
+  "fugue<=0.8.7,>=0.8.7",
+  "polars<=0.20.27,>=0.20.4",
+]
 requires-python = ">=3.9.0"
 classifiers = [
     "Intended Audience :: Developers",
@@ -23,6 +29,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 
 dynamic = ["version"]
@@ -54,7 +61,6 @@ python-tag = "py3"
 
 [project.optional-dependencies]
 duckdb = ["fugue[duckdb]"]
-polars = ["polars"]
 spark = ["pyspark>=3.1.1; python_version < \"3.11\"", "pyspark>=3.4; python_version >= \"3.11\""]
 dask = ["fugue[dask]"]
 ray = ["fugue[ray]"]
@@ -65,7 +71,7 @@ tests-spark = ["pytest", "pytest-cov", "pytest-spark", "spark"]
 qa = ["pre-commit", "black", "isort", "mypy", "pandas-stubs"]
 build = ["build", "twine", "wheel"]
 edgetest = ["edgetest", "edgetest-conda"]
-dev = ["datacompy[duckdb]", "datacompy[polars]", "datacompy[spark]", "datacompy[docs]", "datacompy[tests]", "datacompy[tests-spark]", "datacompy[qa]", "datacompy[build]"]
+dev = ["datacompy[duckdb]", "datacompy[spark]", "datacompy[docs]", "datacompy[tests]", "datacompy[tests-spark]", "datacompy[qa]", "datacompy[build]"]
 
 [tool.isort]
 multi_line_output = 3
@@ -96,4 +102,5 @@ upgrade = [
     "numpy",
     "ordered-set",
     "fugue",
+    "polars",
 ]


### PR DESCRIPTION
3.12 tweaks:

- Moving `polars` from extras to main dependencies
- updating docs to make note about 3.12+
- adding warning about 3.12+ on import


Fixes: #262 