### PR TITLE
bug fix and clean up of temp_column_name

### DIFF
--- a/datacompy/base.py
+++ b/datacompy/base.py
@@ -139,3 +139,33 @@ class BaseCompare(ABC):
         html_file: Optional[str] = None,
     ) -> str:
         pass
+
+
+def temp_column_name(*dataframes) -> str:
+    """Gets a temp column name that isn't included in columns of any dataframes
+
+    Parameters
+    ----------
+    dataframes : list of DataFrames
+        The DataFrames to create a temporary column name for
+
+    Returns
+    -------
+    str
+        String column name that looks like '_temp_x' for some integer x
+    """
+    i = 0
+    columns = []
+    for dataframe in dataframes:
+        columns = columns + list(dataframe.columns)
+    columns = set(columns)
+
+    while True:
+        temp_column = f"_temp_{i}"
+        unique = True
+
+        if temp_column in columns:
+            i += 1
+            unique = False
+        if unique:
+            return temp_column

--- a/datacompy/core.py
+++ b/datacompy/core.py
@@ -29,7 +29,7 @@ import numpy as np
 import pandas as pd
 from ordered_set import OrderedSet
 
-from datacompy.base import BaseCompare
+from datacompy.base import BaseCompare, temp_column_name
 
 LOG = logging.getLogger(__name__)
 
@@ -888,31 +888,6 @@ def get_merged_columns(
         else:
             raise ValueError("Column not found: %s", col)
     return columns
-
-
-def temp_column_name(*dataframes: pd.DataFrame) -> str:
-    """Gets a temp column name that isn't included in columns of any dataframes
-
-    Parameters
-    ----------
-    dataframes : list of Pandas.DataFrame
-        The DataFrames to create a temporary column name for
-
-    Returns
-    -------
-    str
-        String column name that looks like '_temp_x' for some integer x
-    """
-    i = 0
-    while True:
-        temp_column = f"_temp_{i}"
-        unique = True
-        for dataframe in dataframes:
-            if temp_column in dataframe.columns:
-                i += 1
-                unique = False
-        if unique:
-            return temp_column
 
 
 def calculate_max_diff(col_1: "pd.Series[Any]", col_2: "pd.Series[Any]") -> float:

--- a/datacompy/spark.py
+++ b/datacompy/spark.py
@@ -27,7 +27,7 @@ import os
 import pandas as pd
 from ordered_set import OrderedSet
 
-from datacompy.base import BaseCompare
+from datacompy.base import BaseCompare, temp_column_name
 
 try:
     import pyspark.pandas as ps
@@ -301,15 +301,18 @@ class SparkCompare(BaseCompare):
 
         # process merge indicator
         outer_join["_merge"] = outer_join._merge.mask(
-            (outer_join["_merge_left"] == True) & (outer_join["_merge_right"] == True),
+            (outer_join["_merge_left"] == True)
+            & (outer_join["_merge_right"] == True),  # noqa: E712
             "both",
         )
         outer_join["_merge"] = outer_join._merge.mask(
-            (outer_join["_merge_left"] == True) & (outer_join["_merge_right"] != True),
+            (outer_join["_merge_left"] == True)
+            & (outer_join["_merge_right"] != True),  # noqa: E712
             "left_only",
         )
         outer_join["_merge"] = outer_join._merge.mask(
-            (outer_join["_merge_left"] != True) & (outer_join["_merge_right"] == True),
+            (outer_join["_merge_left"] != True)
+            & (outer_join["_merge_right"] == True),  # noqa: E712
             "right_only",
         )
 
@@ -911,31 +914,6 @@ def get_merged_columns(original_df, merged_df, suffix):
         else:
             raise ValueError("Column not found: %s", col)
     return columns
-
-
-def temp_column_name(*dataframes):
-    """Gets a temp column name that isn't included in columns of any dataframes
-
-    Parameters
-    ----------
-    dataframes : list of pyspark.pandas.frame.DataFrame
-        The DataFrames to create a temporary column name for
-
-    Returns
-    -------
-    str
-        String column name that looks like '_temp_x' for some integer x
-    """
-    i = 0
-    while True:
-        temp_column = f"_temp_{i}"
-        unique = True
-        for dataframe in dataframes:
-            if temp_column in dataframe.columns:
-                i += 1
-                unique = False
-        if unique:
-            return temp_column
 
 
 def calculate_max_diff(col_1, col_2):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -417,11 +417,11 @@ def test_mixed_column_with_ignore_spaces_and_case():
 def test_compare_df_setter_bad():
     df = pd.DataFrame([{"a": 1, "A": 2}, {"a": 2, "A": 2}])
     with raises(TypeError, match="df1 must be a pandas DataFrame"):
-        compare = datacompy.Compare("a", "a", ["a"])
+        datacompy.Compare("a", "a", ["a"])
     with raises(ValueError, match="df1 must have all columns from join_columns"):
-        compare = datacompy.Compare(df, df.copy(), ["b"])
+        datacompy.Compare(df, df.copy(), ["b"])
     with raises(ValueError, match="df1 must have unique column names"):
-        compare = datacompy.Compare(df, df.copy(), ["a"])
+        datacompy.Compare(df, df.copy(), ["a"])
     df_dupe = pd.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 3}])
     assert datacompy.Compare(df_dupe, df_dupe.copy(), ["a", "b"]).df1.equals(df_dupe)
 
@@ -450,15 +450,15 @@ def test_compare_df_setter_different_cases():
 def test_compare_df_setter_bad_index():
     df = pd.DataFrame([{"a": 1, "A": 2}, {"a": 2, "A": 2}])
     with raises(TypeError, match="df1 must be a pandas DataFrame"):
-        compare = datacompy.Compare("a", "a", on_index=True)
+        datacompy.Compare("a", "a", on_index=True)
     with raises(ValueError, match="df1 must have unique column names"):
-        compare = datacompy.Compare(df, df.copy(), on_index=True)
+        datacompy.Compare(df, df.copy(), on_index=True)
 
 
 def test_compare_on_index_and_join_columns():
     df = pd.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 2}])
     with raises(Exception, match="Only provide on_index or join_columns"):
-        compare = datacompy.Compare(df, df.copy(), on_index=True, join_columns=["a"])
+        datacompy.Compare(df, df.copy(), on_index=True, join_columns=["a"])
 
 
 def test_compare_df_setter_good_index():
@@ -647,7 +647,7 @@ def test_temp_column_name_one_has():
     assert actual == "_temp_1"
 
 
-def test_temp_column_name_both_have():
+def test_temp_column_name_both_have_temp_1():
     df1 = pd.DataFrame([{"_temp_0": "hi", "b": 2}, {"_temp_0": "bye", "b": 2}])
     df2 = pd.DataFrame(
         [
@@ -660,7 +660,7 @@ def test_temp_column_name_both_have():
     assert actual == "_temp_1"
 
 
-def test_temp_column_name_both_have():
+def test_temp_column_name_both_have_temp_2():
     df1 = pd.DataFrame([{"_temp_0": "hi", "b": 2}, {"_temp_0": "bye", "b": 2}])
     df2 = pd.DataFrame(
         [
@@ -693,7 +693,7 @@ def test_simple_dupes_one_field():
     compare = datacompy.Compare(df1, df2, join_columns=["a"])
     assert compare.matches()
     # Just render the report to make sure it renders.
-    t = compare.report()
+    compare.report()
 
 
 def test_simple_dupes_two_fields():
@@ -702,7 +702,7 @@ def test_simple_dupes_two_fields():
     compare = datacompy.Compare(df1, df2, join_columns=["a", "b"])
     assert compare.matches()
     # Just render the report to make sure it renders.
-    t = compare.report()
+    compare.report()
 
 
 def test_simple_dupes_index():
@@ -714,19 +714,19 @@ def test_simple_dupes_index():
     compare = datacompy.Compare(df1, df2, on_index=True)
     assert compare.matches()
     # Just render the report to make sure it renders.
-    t = compare.report()
+    compare.report()
 
 
-def test_simple_dupes_one_field_two_vals():
+def test_simple_dupes_one_field_two_vals_1():
     df1 = pd.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
     df2 = pd.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
     compare = datacompy.Compare(df1, df2, join_columns=["a"])
     assert compare.matches()
     # Just render the report to make sure it renders.
-    t = compare.report()
+    compare.report()
 
 
-def test_simple_dupes_one_field_two_vals():
+def test_simple_dupes_one_field_two_vals_2():
     df1 = pd.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
     df2 = pd.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
     compare = datacompy.Compare(df1, df2, join_columns=["a"])
@@ -735,7 +735,7 @@ def test_simple_dupes_one_field_two_vals():
     assert len(compare.df2_unq_rows) == 1
     assert len(compare.intersect_rows) == 1
     # Just render the report to make sure it renders.
-    t = compare.report()
+    compare.report()
 
 
 def test_simple_dupes_one_field_three_to_two_vals():
@@ -747,7 +747,7 @@ def test_simple_dupes_one_field_three_to_two_vals():
     assert len(compare.df2_unq_rows) == 0
     assert len(compare.intersect_rows) == 2
     # Just render the report to make sure it renders.
-    t = compare.report()
+    compare.report()
 
     assert "(First 1 Columns)" in compare.report(column_count=1)
     assert "(First 2 Columns)" in compare.report(column_count=2)
@@ -786,8 +786,8 @@ def test_dupes_from_real_data():
     )
     assert compare_unq.matches()
     # Just render the report to make sure it renders.
-    t = compare_acct.report()
-    r = compare_unq.report()
+    compare_acct.report()
+    compare_unq.report()
 
 
 def test_strings_with_joins_with_ignore_spaces():

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -16,6 +16,7 @@
 """
 Testing out the datacompy functionality
 """
+
 import io
 import logging
 import sys
@@ -29,12 +30,12 @@ from pytest import raises
 
 pytest.importorskip("polars")
 
-import polars as pl
-from polars.exceptions import ComputeError, DuplicateError
-from polars.testing import assert_series_equal
+import polars as pl  # noqa: E402
+from polars.exceptions import ComputeError, DuplicateError  # noqa: E402
+from polars.testing import assert_series_equal  # noqa: E402
 
-from datacompy import PolarsCompare
-from datacompy.polars import (
+from datacompy import PolarsCompare  # noqa: E402
+from datacompy.polars import (  # noqa: E402
     calculate_max_diff,
     columns_equal,
     generate_id_within_group,
@@ -383,11 +384,11 @@ def test_compare_df_setter_bad():
     df_same_col_names = pl.DataFrame([{"a": 1, "A": 2}, {"a": 2, "A": 2}])
     df_dupe = pl.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 3}])
     with raises(TypeError, match="df1 must be a Polars DataFrame"):
-        compare = PolarsCompare("a", "a", ["a"])
+        PolarsCompare("a", "a", ["a"])
     with raises(ValueError, match="df1 must have all columns from join_columns"):
-        compare = PolarsCompare(df, df.clone(), ["b"])
+        PolarsCompare(df, df.clone(), ["b"])
     with raises(DuplicateError, match="duplicate column names found"):
-        compare = PolarsCompare(df_same_col_names, df_same_col_names.clone(), ["a"])
+        PolarsCompare(df_same_col_names, df_same_col_names.clone(), ["a"])
     assert (
         PolarsCompare(df_dupe, df_dupe.clone(), ["a", "b"])
         .df1.drop("_merge_left")
@@ -419,9 +420,9 @@ def test_compare_df_setter_different_cases():
 def test_compare_df_setter_bad_index():
     df = pl.DataFrame([{"a": 1, "A": 2}, {"a": 2, "A": 2}])
     with raises(TypeError, match="df1 must be a Polars DataFrame"):
-        compare = PolarsCompare("a", "a", join_columns="a")
+        PolarsCompare("a", "a", join_columns="a")
     with raises(DuplicateError, match="duplicate column names found"):
-        compare = PolarsCompare(df, df.clone(), join_columns="a")
+        PolarsCompare(df, df.clone(), join_columns="a")
 
 
 def test_compare_df_setter_good_index():
@@ -535,7 +536,7 @@ def test_float_and_string_with_joins():
     df1 = pl.DataFrame([{"a": float("1"), "b": 2}, {"a": float("2"), "b": 2}])
     df2 = pl.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 2}])
     with raises(ComputeError):
-        compare = PolarsCompare(df1, df2, "a")
+        PolarsCompare(df1, df2, "a")
 
 
 def test_decimal_with_nulls():
@@ -576,7 +577,7 @@ def test_temp_column_name_one_has():
     assert actual == "_temp_1"
 
 
-def test_temp_column_name_both_have():
+def test_temp_column_name_both_have_temp_1():
     df1 = pl.DataFrame([{"_temp_0": "hi", "b": 2}, {"_temp_0": "bye", "b": 2}])
     df2 = pl.DataFrame(
         [
@@ -589,7 +590,7 @@ def test_temp_column_name_both_have():
     assert actual == "_temp_1"
 
 
-def test_temp_column_name_both_have():
+def test_temp_column_name_both_have_temp_2():
     df1 = pl.DataFrame([{"_temp_0": "hi", "b": 2}, {"_temp_0": "bye", "b": 2}])
     df2 = pl.DataFrame(
         [
@@ -622,7 +623,7 @@ def test_simple_dupes_one_field():
     compare = PolarsCompare(df1, df2, join_columns=["a"])
     assert compare.matches()
     # Just render the report to make sure it renders.
-    t = compare.report()
+    compare.report()
 
 
 def test_simple_dupes_two_fields():
@@ -631,19 +632,19 @@ def test_simple_dupes_two_fields():
     compare = PolarsCompare(df1, df2, join_columns=["a", "b"])
     assert compare.matches()
     # Just render the report to make sure it renders.
-    t = compare.report()
+    compare.report()
 
 
-def test_simple_dupes_one_field_two_vals():
+def test_simple_dupes_one_field_two_vals_1():
     df1 = pl.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
     df2 = pl.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
     compare = PolarsCompare(df1, df2, join_columns=["a"])
     assert compare.matches()
     # Just render the report to make sure it renders.
-    t = compare.report()
+    compare.report()
 
 
-def test_simple_dupes_one_field_two_vals():
+def test_simple_dupes_one_field_two_vals_2():
     df1 = pl.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
     df2 = pl.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
     compare = PolarsCompare(df1, df2, join_columns=["a"])
@@ -652,7 +653,7 @@ def test_simple_dupes_one_field_two_vals():
     assert len(compare.df2_unq_rows) == 1
     assert len(compare.intersect_rows) == 1
     # Just render the report to make sure it renders.
-    t = compare.report()
+    compare.report()
 
 
 def test_simple_dupes_one_field_three_to_two_vals():
@@ -664,7 +665,7 @@ def test_simple_dupes_one_field_three_to_two_vals():
     assert len(compare.df2_unq_rows) == 0
     assert len(compare.intersect_rows) == 2
     # Just render the report to make sure it renders.
-    t = compare.report()
+    compare.report()
 
     assert "(First 1 Columns)" in compare.report(column_count=1)
     assert "(First 2 Columns)" in compare.report(column_count=2)
@@ -703,8 +704,8 @@ def test_dupes_from_real_data():
     )
     assert compare_unq.matches()
     # Just render the report to make sure it renders.
-    t = compare_acct.report()
-    r = compare_unq.report()
+    compare_acct.report()
+    compare_unq.report()
 
 
 def test_strings_with_joins_with_ignore_spaces():

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -428,9 +428,9 @@ def test_infinity_and_beyond():
 def test_compare_df_setter_bad():
     df = ps.DataFrame([{"a": 1, "c": 2}, {"a": 2, "c": 2}])
     with raises(TypeError, match="df1 must be a pyspark.pandas.frame.DataFrame"):
-        compare = SparkCompare("a", "a", ["a"])
+        SparkCompare("a", "a", ["a"])
     with raises(ValueError, match="df1 must have all columns from join_columns"):
-        compare = SparkCompare(df, df.copy(), ["b"])
+        SparkCompare(df, df.copy(), ["b"])
     df_dupe = ps.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 3}])
     assert (
         SparkCompare(df_dupe, df_dupe.copy(), ["a", "b"])
@@ -624,7 +624,7 @@ def test_temp_column_name_one_has():
 
 
 @pandas_version
-def test_temp_column_name_both_have():
+def test_temp_column_name_both_have_temp_1():
     df1 = ps.DataFrame([{"_temp_0": "hi", "b": 2}, {"_temp_0": "bye", "b": 2}])
     df2 = ps.DataFrame(
         [
@@ -638,7 +638,7 @@ def test_temp_column_name_both_have():
 
 
 @pandas_version
-def test_temp_column_name_both_have():
+def test_temp_column_name_both_have_temp_2():
     df1 = ps.DataFrame([{"_temp_0": "hi", "b": 2}, {"_temp_0": "bye", "b": 2}])
     df2 = ps.DataFrame(
         [
@@ -673,7 +673,7 @@ def test_simple_dupes_one_field():
     compare = SparkCompare(df1, df2, join_columns=["a"])
     assert compare.matches()
     # Just render the report to make sure it renders.
-    t = compare.report()
+    compare.report()
 
 
 @pandas_version
@@ -683,7 +683,7 @@ def test_simple_dupes_two_fields():
     compare = SparkCompare(df1, df2, join_columns=["a", "b"])
     assert compare.matches()
     # Just render the report to make sure it renders.
-    t = compare.report()
+    compare.report()
 
 
 @pandas_version
@@ -693,7 +693,7 @@ def test_simple_dupes_one_field_two_vals_1():
     compare = SparkCompare(df1, df2, join_columns=["a"])
     assert compare.matches()
     # Just render the report to make sure it renders.
-    t = compare.report()
+    compare.report()
 
 
 @pandas_version
@@ -706,7 +706,7 @@ def test_simple_dupes_one_field_two_vals_2():
     assert len(compare.df2_unq_rows) == 1
     assert len(compare.intersect_rows) == 1
     # Just render the report to make sure it renders.
-    t = compare.report()
+    compare.report()
 
 
 @pandas_version
@@ -719,7 +719,7 @@ def test_simple_dupes_one_field_three_to_two_vals():
     assert len(compare.df2_unq_rows) == 0
     assert len(compare.intersect_rows) == 2
     # Just render the report to make sure it renders.
-    t = compare.report()
+    compare.report()
 
     assert "(First 1 Columns)" in compare.report(column_count=1)
     assert "(First 2 Columns)" in compare.report(column_count=2)
@@ -759,8 +759,8 @@ def test_dupes_from_real_data():
     )
     assert compare_unq.matches()
     # Just render the report to make sure it renders.
-    t = compare_acct.report()
-    r = compare_unq.report()
+    compare_acct.report()
+    compare_unq.report()
 
 
 @pandas_version
@@ -1321,4 +1321,4 @@ def test_unicode_columns():
     compare = SparkCompare(df1, df2, join_columns=["例"])
     assert compare.matches()
     # Just render the report to make sure it renders.
-    t = compare.report()
+    compare.report()


### PR DESCRIPTION
There seems to have been a hidden bug within `temp_column_name`. It scans for an existing column name pattern and will increment by 1 if it already exists. In some cases it would skip and increment by more than 1.

This should fix that issue and we can reuse `temp_column_name` across all the Compare types.

Also some general linting and cleanup.