### PR TITLE
Fix for github action publish docs

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         python-version: '3.9'
     - name: Install dependencies
-      run: python -m pip install .[dev]
+      run: python -m pip install -e .[dev]
     - name: Build
       run: make sphinx
       shell: bash


### PR DESCRIPTION
For some reason the docs build failed in the 0.13.0 release. Made it editable before running `make sphinx` seems to fix it.
Same namespace shenanigans 😓 