### PR TITLE
fixing missing spark submod

### DIFF
--- a/datacompy/__init__.py
+++ b/datacompy/__init__.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.13.0"
+__version__ = "0.13.1"
 
 import platform
 from warnings import warn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ requires = ["setuptools>=64.0.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
-packages = ["datacompy"]
+packages = ["datacompy", "datacompy.spark"]
 zip-safe = false
 include-package-data = true
 


### PR DESCRIPTION
Hotfix as the `spark` submodule wasn't included in the 0.13.0 release :face_exhaling: 