### PR TITLE
Release v0.13.1

### DIFF
--- a/datacompy/__init__.py
+++ b/datacompy/__init__.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.13.0"
+__version__ = "0.13.1"
 
 import platform
 from warnings import warn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ requires = ["setuptools>=64.0.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
-packages = ["datacompy"]
+packages = ["datacompy", "datacompy.spark"]
 zip-safe = false
 include-package-data = true
 


### PR DESCRIPTION
Release v0.13.1
----------------------

Hotfix for Release v0.13.0 issue where spark submodule was not being included in the wheel. #317  
