### PR TITLE
switching version check to spark session

### DIFF
--- a/datacompy/__init__.py
+++ b/datacompy/__init__.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.13.1"
+__version__ = "0.13.2"
 
 import platform
 from warnings import warn

--- a/datacompy/spark/sql.py
+++ b/datacompy/spark/sql.py
@@ -48,8 +48,6 @@ try:
         upper,
         when,
     )
-    from pyspark.version import __version__
-
 except ImportError:
     pass  # Let non-Spark people at least enjoy the loveliness of the spark sql datacompy functionality
 
@@ -210,7 +208,7 @@ class SparkSQLCompare(BaseCompare):
         """
         dataframe = getattr(self, index)
 
-        if __version__ >= "3.4.0":
+        if self.spark_session.version >= "3.4.0":
             import pyspark.sql.connect.dataframe
 
             instances = (pyspark.sql.DataFrame, pyspark.sql.connect.dataframe.DataFrame)


### PR DESCRIPTION
Fix for #320 

Seems like Databricks does something to the `pyspark.version.__version__`. Switching to the actual spark session for the check in this case.

@achrusciel FYI, in case you can try out this specific branch to make sure it works for you.