### PR TITLE
Ruff

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -13,6 +13,20 @@ permissions:
   contents: read
 
 jobs:
+  lint-and-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v5
+        with:
+            python-version: "3.9"
+      - name: Install dependencies
+        run: python -m pip install .[qa]
+      - name: Linting by ruff
+        run: ruff check
+      - name: Formatting by ruff
+        run: ruff format --check
   test-dev-install:
 
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,25 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: 23.3.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.7
     hooks:
-      - id: black
-        types: [file, python]
-        language_version: python3.10
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+      # Run the linter.
+      - id: ruff
+        args: [ --fix ]
+      # Run the formatter.
+      - id: ruff-format
+        types_or: [ python, jupyter ]
+  # # Mypy: Optional static type checking
+  # # https://github.com/pre-commit/mirrors-mypy
+  # - repo: https://github.com/pre-commit/mirrors-mypy
+  #   rev: v1.11.1
+  #   hooks:
+  #     - id: mypy
+  #       exclude: ^(docs|tests)\/
+  #       language_version: python3.9
+  #       args: [--namespace-packages, --explicit-package-bases, --ignore-missing-imports, --non-interactive, --install-types]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
     hooks:
-      - id: isort
-        name: isort (python)
+      - id: trailing-whitespace
+      - id: debug-statements
+      - id: end-of-file-fixer

--- a/datacompy/__init__.py
+++ b/datacompy/__init__.py
@@ -12,6 +12,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""DataComPy is a package to compare two Pandas DataFrames.
+
+Originally started to be something of a replacement for SAS's PROC COMPARE for Pandas DataFrames with some more functionality than just Pandas.DataFrame.equals(Pandas.DataFrame) (in that it prints out some stats, and lets you tweak how accurate matches have to be).
+Then extended to carry that functionality over to Spark Dataframes.
+"""
 
 __version__ = "0.13.2"
 

--- a/datacompy/__init__.py
+++ b/datacompy/__init__.py
@@ -18,8 +18,16 @@ __version__ = "0.13.2"
 import platform
 from warnings import warn
 
-from .core import *  # noqa: F403
-from .fugue import (  # noqa: F401
+from datacompy.core import (
+    Compare,
+    calculate_max_diff,
+    columns_equal,
+    compare_string_and_date_columns,
+    generate_id_within_group,
+    get_merged_columns,
+    render,
+)
+from datacompy.fugue import (
     all_columns_match,
     all_rows_overlap,
     count_matching_rows,
@@ -28,9 +36,29 @@ from .fugue import (  # noqa: F401
     report,
     unq_columns,
 )
-from .polars import PolarsCompare  # noqa: F401
-from .spark.pandas import SparkPandasCompare  # noqa: F401
-from .spark.sql import SparkSQLCompare  # noqa: F401
+from datacompy.polars import PolarsCompare
+from datacompy.spark.pandas import SparkPandasCompare
+from datacompy.spark.sql import SparkSQLCompare
+
+__all__ = [
+    "Compare",
+    "PolarsCompare",
+    "SparkPandasCompare",
+    "SparkSQLCompare",
+    "all_columns_match",
+    "all_rows_overlap",
+    "calculate_max_diff",
+    "columns_equal",
+    "compare_string_and_date_columns",
+    "count_matching_rows",
+    "generate_id_within_group",
+    "get_merged_columns",
+    "intersect_columns",
+    "is_match",
+    "render",
+    "report",
+    "unq_columns",
+]
 
 major = platform.python_version_tuple()[0]
 minor = platform.python_version_tuple()[1]

--- a/datacompy/__init__.py
+++ b/datacompy/__init__.py
@@ -23,6 +23,7 @@ __version__ = "0.13.2"
 import platform
 from warnings import warn
 
+from datacompy.base import BaseCompare, temp_column_name
 from datacompy.core import (
     Compare,
     calculate_max_diff,
@@ -46,6 +47,7 @@ from datacompy.spark.pandas import SparkPandasCompare
 from datacompy.spark.sql import SparkSQLCompare
 
 __all__ = [
+    "BaseCompare",
     "Compare",
     "PolarsCompare",
     "SparkPandasCompare",
@@ -62,6 +64,7 @@ __all__ = [
     "is_match",
     "render",
     "report",
+    "temp_column_name",
     "unq_columns",
 ]
 

--- a/datacompy/base.py
+++ b/datacompy/base.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 """
-Compare two Pandas DataFrames
+Compare two Pandas DataFrames.
 
 Originally this package was meant to provide similar functionality to
 PROC COMPARE in SAS - i.e. human-readable reporting on the difference between
@@ -38,7 +38,7 @@ class BaseCompare(ABC):
     @df1.setter
     @abstractmethod
     def df1(self, df1: Any) -> None:
-        """Check that it is a dataframe and has the join columns"""
+        """Check that it is a dataframe and has the join columns."""
         pass
 
     @property
@@ -48,14 +48,14 @@ class BaseCompare(ABC):
     @df2.setter
     @abstractmethod
     def df2(self, df2: Any) -> None:
-        """Check that it is a dataframe and has the join columns"""
+        """Check that it is a dataframe and has the join columns."""
         pass
 
     @abstractmethod
     def _validate_dataframe(
         self, index: str, cast_column_names_lower: bool = True
     ) -> None:
-        """Check that it is a dataframe and has the join columns"""
+        """Check that it is a dataframe and has the join columns."""
         pass
 
     @abstractmethod
@@ -70,23 +70,23 @@ class BaseCompare(ABC):
 
     @abstractmethod
     def df1_unq_columns(self) -> OrderedSet[str]:
-        """Get columns that are unique to df1"""
+        """Get columns that are unique to df1."""
         pass
 
     @abstractmethod
     def df2_unq_columns(self) -> OrderedSet[str]:
-        """Get columns that are unique to df2"""
+        """Get columns that are unique to df2."""
         pass
 
     @abstractmethod
     def intersect_columns(self) -> OrderedSet[str]:
-        """Get columns that are shared between the two dataframes"""
+        """Get columns that are shared between the two dataframes."""
         pass
 
     @abstractmethod
     def _dataframe_merge(self, ignore_spaces: bool) -> None:
         """Merge df1 to df2 on the join columns, to get df1 - df2, df2 - df1
-        and df1 & df2
+        and df1 & df2.
 
         If ``on_index`` is True, this will join on index values, otherwise it
         will join on the ``join_columns``.
@@ -142,7 +142,7 @@ class BaseCompare(ABC):
 
 
 def temp_column_name(*dataframes) -> str:
-    """Gets a temp column name that isn't included in columns of any dataframes
+    """Gets a temp column name that isn't included in columns of any dataframes.
 
     Parameters
     ----------

--- a/datacompy/base.py
+++ b/datacompy/base.py
@@ -31,8 +31,11 @@ LOG = logging.getLogger(__name__)
 
 
 class BaseCompare(ABC):
+    """Base comparison class."""
+
     @property
     def df1(self) -> Any:
+        """Get the first dataframe."""
         return self._df1  # type: ignore
 
     @df1.setter
@@ -43,6 +46,7 @@ class BaseCompare(ABC):
 
     @property
     def df2(self) -> Any:
+        """Get the second dataframe."""
         return self._df2  # type: ignore
 
     @df2.setter
@@ -60,7 +64,9 @@ class BaseCompare(ABC):
 
     @abstractmethod
     def _compare(self, ignore_spaces: bool, ignore_case: bool) -> None:
-        """Actually run the comparison.  This tries to run df1.equals(df2)
+        """Run the comparison.
+
+        This tries to run df1.equals(df2)
         first so that if they're truly equal we can tell.
 
         This method will log out information about what is different between
@@ -85,7 +91,9 @@ class BaseCompare(ABC):
 
     @abstractmethod
     def _dataframe_merge(self, ignore_spaces: bool) -> None:
-        """Merge df1 to df2 on the join columns, to get df1 - df2, df2 - df1
+        """Merge df1 to df2 on the join columns.
+
+        To get df1 - df2, df2 - df1
         and df1 & df2.
 
         If ``on_index`` is True, this will join on index values, otherwise it
@@ -95,40 +103,49 @@ class BaseCompare(ABC):
 
     @abstractmethod
     def _intersect_compare(self, ignore_spaces: bool, ignore_case: bool) -> None:
+        """Compare the intersection of the two dataframes."""
         pass
 
     @abstractmethod
     def all_columns_match(self) -> bool:
+        """Check if all columns match."""
         pass
 
     @abstractmethod
     def all_rows_overlap(self) -> bool:
+        """Check if all rows overlap."""
         pass
 
     @abstractmethod
     def count_matching_rows(self) -> int:
+        """Count the number of matchin grows."""
         pass
 
     @abstractmethod
     def intersect_rows_match(self) -> bool:
+        """Check if the intersection of rows match."""
         pass
 
     @abstractmethod
     def matches(self, ignore_extra_columns: bool = False) -> bool:
+        """Check if the dataframes match."""
         pass
 
     @abstractmethod
     def subset(self) -> bool:
+        """Check if one dataframe is a subset of the other."""
         pass
 
     @abstractmethod
     def sample_mismatch(
         self, column: str, sample_count: int = 10, for_display: bool = False
     ) -> Any:
+        """Get a sample of rows that mismatch."""
         pass
 
     @abstractmethod
     def all_mismatch(self, ignore_matching_cols: bool = False) -> Any:
+        """Get all rows that mismatch."""
         pass
 
     @abstractmethod
@@ -138,11 +155,12 @@ class BaseCompare(ABC):
         column_count: int = 10,
         html_file: Optional[str] = None,
     ) -> str:
+        """Return a string representation of a report."""
         pass
 
 
 def temp_column_name(*dataframes) -> str:
-    """Gets a temp column name that isn't included in columns of any dataframes.
+    """Get a temp column name that isn't included in columns of any dataframes.
 
     Parameters
     ----------

--- a/datacompy/core.py
+++ b/datacompy/core.py
@@ -431,11 +431,11 @@ class Compare(BaseCompare):
         bool
             True or False if the dataframes match.
         """
-        if not ignore_extra_columns and not self.all_columns_match():
-            return False
-        elif not self.all_rows_overlap():
-            return False
-        elif not self.intersect_rows_match():
+        if (
+            (not ignore_extra_columns and not self.all_columns_match())
+            or not self.all_rows_overlap()
+            or not self.intersect_rows_match()
+        ):
             return False
         else:
             return True
@@ -452,11 +452,11 @@ class Compare(BaseCompare):
         bool
             True if dataframe 2 is a subset of dataframe 1.
         """
-        if not self.df2_unq_columns() == set():
-            return False
-        elif not len(self.df2_unq_rows) == 0:
-            return False
-        elif not self.intersect_rows_match():
+        if (
+            self.df2_unq_columns() != set()
+            or len(self.df2_unq_rows) != 0
+            or not self.intersect_rows_match()
+        ):
             return False
         else:
             return True

--- a/datacompy/core.py
+++ b/datacompy/core.py
@@ -437,10 +437,10 @@ class Compare(BaseCompare):
         bool
             True or False if the dataframes match.
         """
-        return not (
-            (not ignore_extra_columns and not self.all_columns_match())
-            or not self.all_rows_overlap()
-            or not self.intersect_rows_match()
+        return (
+            (ignore_extra_columns or self.all_columns_match())
+            and self.all_rows_overlap()
+            and self.intersect_rows_match()
         )
 
     def subset(self) -> bool:

--- a/datacompy/core.py
+++ b/datacompy/core.py
@@ -455,10 +455,10 @@ class Compare(BaseCompare):
         bool
             True if dataframe 2 is a subset of dataframe 1.
         """
-        return not (
-            self.df2_unq_columns() != set()
-            or len(self.df2_unq_rows) != 0
-            or not self.intersect_rows_match()
+        return (
+            self.df2_unq_columns() == set()
+            and len(self.df2_unq_rows) == 0
+            and self.intersect_rows_match()
         )
 
     def sample_mismatch(

--- a/datacompy/core.py
+++ b/datacompy/core.py
@@ -131,6 +131,7 @@ class Compare(BaseCompare):
 
     @property
     def df1(self) -> pd.DataFrame:
+        """Get the first dataframe."""
         return self._df1
 
     @df1.setter
@@ -143,6 +144,7 @@ class Compare(BaseCompare):
 
     @property
     def df2(self) -> pd.DataFrame:
+        """Get the second dataframe."""
         return self._df2
 
     @df2.setter
@@ -192,7 +194,9 @@ class Compare(BaseCompare):
                 self._any_dupes = True
 
     def _compare(self, ignore_spaces: bool, ignore_case: bool) -> None:
-        """Actually run the comparison.  This tries to run df1.equals(df2)
+        """Run the comparison.
+
+        This tries to run df1.equals(df2)
         first so that if they're truly equal we can tell.
 
         This method will log out information about what is different between
@@ -240,7 +244,9 @@ class Compare(BaseCompare):
         return OrderedSet(self.df1.columns) & OrderedSet(self.df2.columns)
 
     def _dataframe_merge(self, ignore_spaces: bool) -> None:
-        """Merge df1 to df2 on the join columns, to get df1 - df2, df2 - df1
+        """Merge df1 to df2 on the join columns.
+
+        To get df1 - df2, df2 - df1
         and df1 & df2.
 
         If ``on_index`` is True, this will join on index values, otherwise it
@@ -458,7 +464,9 @@ class Compare(BaseCompare):
     def sample_mismatch(
         self, column: str, sample_count: int = 10, for_display: bool = False
     ) -> pd.DataFrame:
-        """Returns a sample sub-dataframe which contains the identifying
+        """Return sample mismatches.
+
+        Gets a sub-dataframe which contains the identifying
         columns, and df1 and df2 versions of the column.
 
         Parameters
@@ -500,7 +508,9 @@ class Compare(BaseCompare):
         return to_return
 
     def all_mismatch(self, ignore_matching_cols: bool = False) -> pd.DataFrame:
-        """All rows with any columns that have a mismatch. Returns all df1 and df2 versions of the columns and join
+        """Get all rows with any columns that have a mismatch.
+
+        Returns all df1 and df2 versions of the columns and join
         columns.
 
         Parameters
@@ -553,7 +563,9 @@ class Compare(BaseCompare):
         column_count: int = 10,
         html_file: Optional[str] = None,
     ) -> str:
-        """Returns a string representation of a report.  The representation can
+        """Return a string representation of a report.
+
+        The representation can
         then be printed or saved to a file.
 
         Parameters
@@ -714,7 +726,9 @@ class Compare(BaseCompare):
 
 
 def render(filename: str, *fields: Union[int, float, str]) -> str:
-    """Renders out an individual template.  This basically just reads in a
+    """Render out an individual template.
+
+    This basically just reads in a
     template file, and applies ``.format()`` on the fields.
 
     Parameters
@@ -743,7 +757,9 @@ def columns_equal(
     ignore_spaces: bool = False,
     ignore_case: bool = False,
 ) -> "pd.Series[bool]":
-    """Compares two columns from a dataframe, returning a True/False series,
+    """Compare two columns from a dataframe.
+
+    Returns a True/False series,
     with the same index as column 1.
 
     - Two nulls (np.nan) will evaluate to True.
@@ -821,7 +837,9 @@ def columns_equal(
 def compare_string_and_date_columns(
     col_1: "pd.Series[Any]", col_2: "pd.Series[Any]"
 ) -> "pd.Series[bool]":
-    """Compare a string column and date column, value-wise.  This tries to
+    """Compare a string column and date column, value-wise.
+
+    This tries to
     convert a string column to a date column and compare that way.
 
     Parameters
@@ -862,7 +880,7 @@ def compare_string_and_date_columns(
 def get_merged_columns(
     original_df: pd.DataFrame, merged_df: pd.DataFrame, suffix: str
 ) -> List[str]:
-    """Gets the columns from an original dataframe, in the new merged dataframe.
+    """Get the columns from an original dataframe, in the new merged dataframe.
 
     Parameters
     ----------
@@ -909,7 +927,9 @@ def calculate_max_diff(col_1: "pd.Series[Any]", col_2: "pd.Series[Any]") -> floa
 def generate_id_within_group(
     dataframe: pd.DataFrame, join_columns: List[str]
 ) -> "pd.Series[int]":
-    """Generate an ID column that can be used to deduplicate identical rows.  The series generated
+    """Generate an ID column that can be used to deduplicate identical rows.
+
+    The series generated
     is the order within a unique group, and it handles nulls.
 
     Parameters

--- a/datacompy/fugue.py
+++ b/datacompy/fugue.py
@@ -13,9 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Compare two DataFrames that are supported by Fugue
-"""
+"""Compare two DataFrames that are supported by Fugue."""
 
 import logging
 import pickle
@@ -29,14 +27,14 @@ from fugue import AnyDataFrame
 from ordered_set import OrderedSet
 from triad import Schema
 
-from .core import Compare, render
+from datacompy.core import Compare, render
 
 LOG = logging.getLogger(__name__)
 HASH_COL = "__datacompy__hash__"
 
 
 def unq_columns(df1: AnyDataFrame, df2: AnyDataFrame) -> OrderedSet[str]:
-    """Get columns that are unique to df1
+    """Get columns that are unique to df1.
 
     Parameters
     ----------
@@ -57,7 +55,7 @@ def unq_columns(df1: AnyDataFrame, df2: AnyDataFrame) -> OrderedSet[str]:
 
 
 def intersect_columns(df1: AnyDataFrame, df2: AnyDataFrame) -> OrderedSet[str]:
-    """Get columns that are shared between the two dataframes
+    """Get columns that are shared between the two dataframes.
 
     Parameters
     ----------
@@ -78,7 +76,7 @@ def intersect_columns(df1: AnyDataFrame, df2: AnyDataFrame) -> OrderedSet[str]:
 
 
 def all_columns_match(df1: AnyDataFrame, df2: AnyDataFrame) -> bool:
-    """Whether the columns all match in the dataframes
+    """Whether the columns all match in the dataframes.
 
     Parameters
     ----------
@@ -209,7 +207,7 @@ def all_rows_overlap(
     parallelism: Optional[int] = None,
     strict_schema: bool = False,
 ) -> bool:
-    """Check if the rows are all present in both dataframes
+    """Check if the rows are all present in both dataframes.
 
     Parameters
     ----------
@@ -305,7 +303,7 @@ def count_matching_rows(
     parallelism: Optional[int] = None,
     strict_schema: bool = False,
 ) -> int:
-    """Count the number of rows match (on overlapping fields)
+    """Count the number of rows match (on overlapping fields).
 
     Parameters
     ----------
@@ -559,7 +557,7 @@ def report(
         "column_comparison.txt",
         len([col for col in column_stats if col["unequal_cnt"] > 0]),
         len([col for col in column_stats if col["unequal_cnt"] == 0]),
-        sum([col["unequal_cnt"] for col in column_stats]),
+        sum(col["unequal_cnt"] for col in column_stats),
     )
 
     match_stats = []
@@ -652,7 +650,7 @@ def _distributed_compare(
     parallelism: Optional[int] = None,
     strict_schema: bool = False,
 ) -> List[Any]:
-    """Compare the data distributively using the core Compare class
+    """Compare the data distributively using the core Compare class.
 
     Both df1 and df2 should be dataframes containing all of the join_columns,
     with unique column names. Differences between values are compared to
@@ -715,9 +713,8 @@ def _distributed_compare(
         )
         hash_cols = [col.lower() for col in hash_cols]
 
-    if strict_schema:
-        if tdf1.schema != tdf2.schema:
-            raise _StrictSchemaError()
+    if strict_schema and tdf1.schema != tdf2.schema:
+        raise _StrictSchemaError()
 
     # check that hash columns exist
     assert hash_cols in tdf1.schema, f"{hash_cols} not found in {tdf1.schema}"
@@ -725,7 +722,7 @@ def _distributed_compare(
 
     df1_schema = tdf1.schema
     df2_schema = tdf2.schema
-    str_cols = set(f.name for f in tdf1.schema.fields if pa.types.is_string(f.type))
+    str_cols = {f.name for f in tdf1.schema.fields if pa.types.is_string(f.type)}
     bucket = (
         parallelism if parallelism is not None else fa.get_current_parallelism() * 2
     )
@@ -752,13 +749,13 @@ def _distributed_compare(
             tdf1,
             _serialize,
             schema="key:int,left:bool,data:binary",
-            params=dict(left=True),
+            params={"left": True},
         ),
         fa.transform(
             tdf2,
             _serialize,
             schema="key:int,left:bool,data:binary",
-            params=dict(left=False),
+            params={"left": False},
         ),
         distinct=False,
     )
@@ -813,7 +810,7 @@ def _distributed_compare(
 
     objs = fa.as_array(
         fa.transform(
-            ser, _comp, schema="obj:binary", partition=dict(by="key", num=bucket)
+            ser, _comp, schema="obj:binary", partition={"by": "key", "num": bucket}
         )
     )
     return [pickle.loads(row[0]) for row in objs]
@@ -824,11 +821,10 @@ def _get_compare_result(
 ) -> Dict[str, Any]:
     mismatch_samples: Dict[str, pd.DataFrame] = {}
     for column in compare.column_stats:
-        if not column["all_match"]:
-            if column["unequal_cnt"] > 0:
-                mismatch_samples[column["column"]] = compare.sample_mismatch(
-                    column["column"], sample_count, for_display=True
-                )
+        if not column["all_match"] and column["unequal_cnt"] > 0:
+            mismatch_samples[column["column"]] = compare.sample_mismatch(
+                column["column"], sample_count, for_display=True
+            )
 
     df1_unq_rows_sample: Any = None
     if min(sample_count, compare.df1_unq_rows.shape[0]) > 0:
@@ -915,6 +911,6 @@ def _sample(df: pd.DataFrame, sample_count: int) -> pd.DataFrame:
 
 
 class _StrictSchemaError(Exception):
-    """Exception raised when strict schema is enabled and the schemas do not match"""
+    """Exception raised when strict schema is enabled and the schemas do not match."""
 
     pass

--- a/datacompy/fugue.py
+++ b/datacompy/fugue.py
@@ -698,7 +698,6 @@ def _distributed_compare(
     List[Any]
         Returns the list of objects returned from the return_obj_func
     """
-
     tdf1 = fa.as_fugue_df(df1)
     tdf2 = fa.as_fugue_df(df2)
 

--- a/datacompy/fugue.py
+++ b/datacompy/fugue.py
@@ -400,7 +400,9 @@ def report(
     html_file: Optional[str] = None,
     parallelism: Optional[int] = None,
 ) -> str:
-    """Returns a string representation of a report.  The representation can
+    """Return a string representation of a report.
+
+    The representation can
     then be printed or saved to a file.
 
     Both df1 and df2 should be dataframes containing all of the join_columns,

--- a/datacompy/polars.py
+++ b/datacompy/polars.py
@@ -284,15 +284,11 @@ class PolarsCompare(BaseCompare):
 
         # process merge indicator
         outer_join = outer_join.with_columns(
-            pl.when(
-                (pl.col("_merge_left") == True) & (pl.col("_merge_right") == True)  # noqa: E712
-            )
+            pl.when(pl.col("_merge_left") & pl.col("_merge_right"))
             .then(pl.lit("both"))
-            .when((pl.col("_merge_left") is True) & (pl.col("_merge_right").is_null()))
+            .when(pl.col("_merge_left") & pl.col("_merge_right").is_null())
             .then(pl.lit("left_only"))
-            .when(
-                (pl.col("_merge_left").is_null()) & (pl.col("_merge_right") == True)  # noqa: E712
-            )
+            .when(pl.col("_merge_left").is_null() & pl.col("_merge_right"))
             .then(pl.lit("right_only"))
             .alias("_merge")
         )

--- a/datacompy/polars.py
+++ b/datacompy/polars.py
@@ -131,6 +131,7 @@ class PolarsCompare(BaseCompare):
 
     @property
     def df1(self) -> "pl.DataFrame":
+        """Get the first dataframe."""
         return self._df1
 
     @df1.setter
@@ -143,6 +144,7 @@ class PolarsCompare(BaseCompare):
 
     @property
     def df2(self) -> "pl.DataFrame":
+        """Get the second dataframe."""
         return self._df2
 
     @df2.setter
@@ -183,7 +185,9 @@ class PolarsCompare(BaseCompare):
             self._any_dupes = True
 
     def _compare(self, ignore_spaces: bool, ignore_case: bool) -> None:
-        """Actually run the comparison.  This tries to run df1.equals(df2)
+        """Run the comparison.
+
+        This tries to run df1.equals(df2)
         first so that if they're truly equal we can tell.
 
         This method will log out information about what is different between
@@ -231,7 +235,9 @@ class PolarsCompare(BaseCompare):
         return OrderedSet(self.df1.columns) & OrderedSet(self.df2.columns)
 
     def _dataframe_merge(self, ignore_spaces: bool) -> None:
-        """Merge df1 to df2 on the join columns, to get df1 - df2, df2 - df1
+        """Merge df1 to df2 on the join columns.
+
+        To get df1 - df2, df2 - df1
         and df1 & df2.
         """
         params: Dict[str, Any]
@@ -471,7 +477,9 @@ class PolarsCompare(BaseCompare):
     def sample_mismatch(
         self, column: str, sample_count: int = 10, for_display: bool = False
     ) -> "pl.DataFrame":
-        """Returns a sample sub-dataframe which contains the identifying
+        """Return sample mismatches.
+
+        Get a sub-dataframe which contains the identifying
         columns, and df1 and df2 versions of the column.
 
         Parameters
@@ -513,7 +521,9 @@ class PolarsCompare(BaseCompare):
         return to_return
 
     def all_mismatch(self, ignore_matching_cols: bool = False) -> "pl.DataFrame":
-        """All rows with any columns that have a mismatch. Returns all df1 and df2 versions of the columns and join
+        """Get all rows with any columns that have a mismatch.
+
+        Returns all df1 and df2 versions of the columns and join
         columns.
 
         Parameters
@@ -568,7 +578,9 @@ class PolarsCompare(BaseCompare):
         column_count: int = 10,
         html_file: Optional[str] = None,
     ) -> str:
-        """Returns a string representation of a report.  The representation can
+        """Return a string representation of a report.
+
+        The representation can
         then be printed or saved to a file.
 
         Parameters
@@ -728,7 +740,9 @@ class PolarsCompare(BaseCompare):
 
 
 def render(filename: str, *fields: Union[int, float, str]) -> str:
-    """Renders out an individual template.  This basically just reads in a
+    """Render out an individual template.
+
+    This basically just reads in a
     template file, and applies ``.format()`` on the fields.
 
     Parameters
@@ -757,7 +771,9 @@ def columns_equal(
     ignore_spaces: bool = False,
     ignore_case: bool = False,
 ) -> "pl.Series":
-    """Compares two columns from a dataframe, returning a True/False series,
+    """Compare two columns from a dataframe.
+
+    Returns a True/False series,
     with the same index as column 1.
 
     - Two nulls (np.nan) will evaluate to True.
@@ -841,7 +857,9 @@ def columns_equal(
 def compare_string_and_date_columns(
     col_1: "pl.Series", col_2: "pl.Series"
 ) -> "pl.Series":
-    """Compare a string column and date column, value-wise.  This tries to
+    """Compare a string column and date column, value-wise.
+
+    This tries to
     convert a string column to a date column and compare that way.
 
     Parameters
@@ -876,7 +894,7 @@ def compare_string_and_date_columns(
 def get_merged_columns(
     original_df: "pl.DataFrame", merged_df: "pl.DataFrame", suffix: str
 ) -> List[str]:
-    """Gets the columns from an original dataframe, in the new merged dataframe.
+    """Get the columns from an original dataframe, in the new merged dataframe.
 
     Parameters
     ----------
@@ -925,7 +943,9 @@ def calculate_max_diff(col_1: "pl.Series", col_2: "pl.Series") -> float:
 def generate_id_within_group(
     dataframe: "pl.DataFrame", join_columns: List[str]
 ) -> "pl.Series":
-    """Generate an ID column that can be used to deduplicate identical rows.  The series generated
+    """Generate an ID column that can be used to deduplicate identical rows.
+
+    The series generated
     is the order within a unique group, and it handles nulls.
 
     Parameters

--- a/datacompy/polars.py
+++ b/datacompy/polars.py
@@ -446,10 +446,10 @@ class PolarsCompare(BaseCompare):
         bool
             True or False if the dataframes match.
         """
-        return not (
-            (not ignore_extra_columns and not self.all_columns_match())
-            or not self.all_rows_overlap()
-            or not self.intersect_rows_match()
+        return (
+            (ignore_extra_columns or self.all_columns_match())
+            and self.all_rows_overlap()
+            and self.intersect_rows_match()
         )
 
     def subset(self) -> bool:

--- a/datacompy/polars.py
+++ b/datacompy/polars.py
@@ -464,10 +464,10 @@ class PolarsCompare(BaseCompare):
         bool
             True if dataframe 2 is a subset of dataframe 1.
         """
-        return not (
-            self.df2_unq_columns() != set()
-            or len(self.df2_unq_rows) != 0
-            or not self.intersect_rows_match()
+        return (
+            self.df2_unq_columns() == set()
+            and len(self.df2_unq_rows) == 0
+            and self.intersect_rows_match()
         )
 
     def sample_mismatch(

--- a/datacompy/polars.py
+++ b/datacompy/polars.py
@@ -123,9 +123,9 @@ class PolarsCompare(BaseCompare):
         self.rel_tol = rel_tol
         self.ignore_spaces = ignore_spaces
         self.ignore_case = ignore_case
-        self.df1_unq_rows: "pl.DataFrame"
-        self.df2_unq_rows: "pl.DataFrame"
-        self.intersect_rows: "pl.DataFrame"
+        self.df1_unq_rows: pl.DataFrame
+        self.df2_unq_rows: pl.DataFrame
+        self.intersect_rows: pl.DataFrame
         self.column_stats: List[Dict[str, Any]] = []
         self._compare(ignore_spaces=ignore_spaces, ignore_case=ignore_case)
 
@@ -279,18 +279,13 @@ class PolarsCompare(BaseCompare):
         # process merge indicator
         outer_join = outer_join.with_columns(
             pl.when(
-                (pl.col("_merge_left") == True)
-                & (pl.col("_merge_right") == True)  # noqa: E712
+                (pl.col("_merge_left") == True) & (pl.col("_merge_right") == True)  # noqa: E712
             )
             .then(pl.lit("both"))
-            .when(
-                (pl.col("_merge_left") == True)
-                & (pl.col("_merge_right").is_null())  # noqa: E712
-            )
+            .when((pl.col("_merge_left") == True) & (pl.col("_merge_right").is_null()))
             .then(pl.lit("left_only"))
             .when(
-                (pl.col("_merge_left").is_null())
-                & (pl.col("_merge_right") == True)  # noqa: E712
+                (pl.col("_merge_left").is_null()) & (pl.col("_merge_right") == True)  # noqa: E712
             )
             .then(pl.lit("right_only"))
             .alias("_merge")
@@ -449,11 +444,11 @@ class PolarsCompare(BaseCompare):
         bool
             True or False if the dataframes match.
         """
-        if not ignore_extra_columns and not self.all_columns_match():
-            return False
-        elif not self.all_rows_overlap():
-            return False
-        elif not self.intersect_rows_match():
+        if (
+            (not ignore_extra_columns and not self.all_columns_match())
+            or not self.all_rows_overlap()
+            or not self.intersect_rows_match()
+        ):
             return False
         else:
             return True
@@ -470,11 +465,11 @@ class PolarsCompare(BaseCompare):
         bool
             True if dataframe 2 is a subset of dataframe 1.
         """
-        if not self.df2_unq_columns() == set():
-            return False
-        elif not len(self.df2_unq_rows) == 0:
-            return False
-        elif not self.intersect_rows_match():
+        if (
+            self.df2_unq_columns() != set()
+            or len(self.df2_unq_rows) != 0
+            or not self.intersect_rows_match()
+        ):
             return False
         else:
             return True

--- a/datacompy/spark/__init__.py
+++ b/datacompy/spark/__init__.py
@@ -1,0 +1,1 @@
+"""Spark comparisons."""

--- a/datacompy/spark/legacy.py
+++ b/datacompy/spark/legacy.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Legacy spark comparison."""
 
 import sys
 from enum import Enum
@@ -34,11 +35,17 @@ warn(
 
 
 class MatchType(Enum):
+    """Types of matches."""
+
     MISMATCH, MATCH, KNOWN_DIFFERENCE = range(3)
 
 
-# Used for checking equality with decimal(X, Y) types. Otherwise treated as the string "decimal".
 def decimal_comparator() -> str:
+    """Check equality with decimal(X, Y) types.
+
+    Otherwise treated as the string "decimal".
+    """
+
     class DecimalComparator(str):
         def __eq__(self, other: str) -> bool:  # type: ignore[override]
             return len(other) >= 7 and other[0:7] == "decimal"
@@ -58,7 +65,8 @@ NUMERIC_SPARK_TYPES = [
 
 
 def _is_comparable(type1: str, type2: str) -> bool:
-    """Checks if two Spark data types can be safely compared.
+    """Check if two Spark data types can be safely compared.
+
     Two data types are considered comparable if any of the following apply:
         1. Both data types are the same
         2. Both data types are numeric.
@@ -229,8 +237,9 @@ class LegacySparkCompare:
 
     @property
     def columns_compared(self) -> List[str]:
-        """list[str]: Get columns to be compared in both dataframes (all
-        columns in both excluding the join key(s).
+        """Get columns to be compared in both dataframes.
+
+        All columns in both excluding the join key(s).
         """
         return [
             column
@@ -286,7 +295,7 @@ class LegacySparkCompare:
         )
 
     def _print_columns_summary(self, myfile: TextIO) -> None:
-        """Prints the column summary details."""
+        """Print the column summary details."""
         print("\n****** Column Summary ******", file=myfile)
         print(
             f"Number of columns in common with matching schemas: {len(self._columns_with_matching_schema())}",
@@ -306,7 +315,7 @@ class LegacySparkCompare:
         )
 
     def _print_only_columns(self, base_or_compare: str, myfile: TextIO) -> None:
-        """Prints the columns and data types only in either the base or compare datasets."""
+        """Print the columns and data types only in either the base or compare datasets."""
         if base_or_compare.upper() == "BASE":
             columns = self.columns_only_base
             df = self.base_df
@@ -334,7 +343,7 @@ class LegacySparkCompare:
             print((format_pattern + "  {:13s}").format(column, col_type), file=myfile)
 
     def _columns_with_matching_schema(self) -> Dict[str, str]:
-        """This function will identify the columns which has matching schema."""
+        """Identify the columns which has matching schema."""
         col_schema_match = {}
         base_columns_dict = dict(self.base_df.dtypes)
         compare_columns_dict = dict(self.compare_df.dtypes)
@@ -348,7 +357,7 @@ class LegacySparkCompare:
         return col_schema_match
 
     def _columns_with_schemadiff(self) -> Dict[str, Dict[str, str]]:
-        """This function will identify the columns which has different schema."""
+        """Identify the columns which has different schema."""
         col_schema_diff = {}
         base_columns_dict = dict(self.base_df.dtypes)
         compare_columns_dict = dict(self.compare_df.dtypes)
@@ -427,7 +436,7 @@ class LegacySparkCompare:
         return self._rows_only_compare
 
     def _generate_select_statement(self, match_data: bool = True) -> str:
-        """This function is to generate the select statement to be used later in the query."""
+        """Generate the select statement to be used later in the query."""
         base_only = list(set(self.base_df.columns) - set(self.compare_df.columns))
         compare_only = list(set(self.compare_df.columns) - set(self.base_df.columns))
         sorted_list = sorted(chain(base_only, compare_only, self.columns_in_both))
@@ -468,7 +477,7 @@ class LegacySparkCompare:
         return select_statement
 
     def _merge_dataframes(self) -> None:
-        """Merges the two dataframes and creates self._all_matched_rows and self._all_rows_mismatched."""
+        """Merge the two dataframes and creates self._all_matched_rows and self._all_rows_mismatched."""
         full_joined_dataframe = self._get_or_create_joined_dataframe()
         full_joined_dataframe.createOrReplaceTempView("full_matched_table")
 
@@ -543,7 +552,8 @@ class LegacySparkCompare:
         print(f"Number of rows with all columns equal: {matched_rows}", file=myfile)
 
     def _populate_columns_match_dict(self) -> None:
-        """
+        """Populate the dictionary of matches in a dataframe.
+
         side effects:
             columns_match_dict assigned to { column -> match_type_counts }
                 where:
@@ -707,8 +717,10 @@ class LegacySparkCompare:
             )
 
     def _base_to_compare_name(self, base_name: str) -> str:
-        """Translates a column name in the base dataframe to its counterpart in the
-        compare dataframe, if they are different.
+        """Translate a column name.
+
+        Translates a column in the base dataframe to its counterpart in the
+        compare dataframe if they are different.
         """
         if base_name in self.column_mapping:
             return self.column_mapping[base_name]
@@ -880,8 +892,9 @@ class LegacySparkCompare:
 
     # noinspection PyUnresolvedReferences
     def report(self, file: TextIO = sys.stdout) -> None:
-        """Creates a comparison report and prints it to the file specified
-        (stdout by default).
+        """Create a comparison report and print it to the file specified.
+
+        Prints to stdout by default.
 
         Parameters
         ----------

--- a/datacompy/spark/legacy.py
+++ b/datacompy/spark/legacy.py
@@ -61,7 +61,7 @@ def _is_comparable(type1: str, type2: str) -> bool:
     """Checks if two Spark data types can be safely compared.
     Two data types are considered comparable if any of the following apply:
         1. Both data types are the same
-        2. Both data types are numeric
+        2. Both data types are numeric.
 
     Parameters
     ----------
@@ -224,13 +224,13 @@ class LegacySparkCompare:
 
     @property
     def columns_in_both(self) -> Set[str]:
-        """set[str]: Get columns in both dataframes"""
+        """set[str]: Get columns in both dataframes."""
         return set(self.base_df.columns) & set(self.compare_df.columns)
 
     @property
     def columns_compared(self) -> List[str]:
         """list[str]: Get columns to be compared in both dataframes (all
-        columns in both excluding the join key(s)
+        columns in both excluding the join key(s).
         """
         return [
             column
@@ -240,17 +240,17 @@ class LegacySparkCompare:
 
     @property
     def columns_only_base(self) -> Set[str]:
-        """set[str]: Get columns that are unique to the base dataframe"""
+        """set[str]: Get columns that are unique to the base dataframe."""
         return set(self.base_df.columns) - set(self.compare_df.columns)
 
     @property
     def columns_only_compare(self) -> Set[str]:
-        """set[str]: Get columns that are unique to the compare dataframe"""
+        """set[str]: Get columns that are unique to the compare dataframe."""
         return set(self.compare_df.columns) - set(self.base_df.columns)
 
     @property
     def base_row_count(self) -> int:
-        """int: Get the count of rows in the de-duped base dataframe"""
+        """int: Get the count of rows in the de-duped base dataframe."""
         if self._base_row_count is None:
             self._base_row_count = self.base_df.count()
 
@@ -258,7 +258,7 @@ class LegacySparkCompare:
 
     @property
     def compare_row_count(self) -> int:
-        """int: Get the count of rows in the de-duped compare dataframe"""
+        """int: Get the count of rows in the de-duped compare dataframe."""
         if self._compare_row_count is None:
             self._compare_row_count = self.compare_df.count()
 
@@ -266,7 +266,7 @@ class LegacySparkCompare:
 
     @property
     def common_row_count(self) -> int:
-        """int: Get the count of rows in common between base and compare dataframes"""
+        """int: Get the count of rows in common between base and compare dataframes."""
         if self._common_row_count is None:
             common_rows = self._get_or_create_joined_dataframe()
             self._common_row_count = common_rows.count()
@@ -274,19 +274,19 @@ class LegacySparkCompare:
         return self._common_row_count
 
     def _get_unq_base_rows(self) -> "pyspark.sql.DataFrame":
-        """Get the rows only from base data frame"""
+        """Get the rows only from base data frame."""
         return self.base_df.select(self._join_column_names).subtract(
             self.compare_df.select(self._join_column_names)
         )
 
     def _get_compare_rows(self) -> "pyspark.sql.DataFrame":
-        """Get the rows only from compare data frame"""
+        """Get the rows only from compare data frame."""
         return self.compare_df.select(self._join_column_names).subtract(
             self.base_df.select(self._join_column_names)
         )
 
     def _print_columns_summary(self, myfile: TextIO) -> None:
-        """Prints the column summary details"""
+        """Prints the column summary details."""
         print("\n****** Column Summary ******", file=myfile)
         print(
             f"Number of columns in common with matching schemas: {len(self._columns_with_matching_schema())}",
@@ -306,7 +306,7 @@ class LegacySparkCompare:
         )
 
     def _print_only_columns(self, base_or_compare: str, myfile: TextIO) -> None:
-        """Prints the columns and data types only in either the base or compare datasets"""
+        """Prints the columns and data types only in either the base or compare datasets."""
         if base_or_compare.upper() == "BASE":
             columns = self.columns_only_base
             df = self.base_df
@@ -334,7 +334,7 @@ class LegacySparkCompare:
             print((format_pattern + "  {:13s}").format(column, col_type), file=myfile)
 
     def _columns_with_matching_schema(self) -> Dict[str, str]:
-        """This function will identify the columns which has matching schema"""
+        """This function will identify the columns which has matching schema."""
         col_schema_match = {}
         base_columns_dict = dict(self.base_df.dtypes)
         compare_columns_dict = dict(self.compare_df.dtypes)
@@ -348,7 +348,7 @@ class LegacySparkCompare:
         return col_schema_match
 
     def _columns_with_schemadiff(self) -> Dict[str, Dict[str, str]]:
-        """This function will identify the columns which has different schema"""
+        """This function will identify the columns which has different schema."""
         col_schema_diff = {}
         base_columns_dict = dict(self.base_df.dtypes)
         compare_columns_dict = dict(self.compare_df.dtypes)
@@ -360,15 +360,15 @@ class LegacySparkCompare:
                     compare_column_type is not None
                     and base_type not in compare_column_type
                 ):
-                    col_schema_diff[base_row] = dict(
-                        base_type=base_type,
-                        compare_type=compare_column_type,
-                    )
+                    col_schema_diff[base_row] = {
+                        "base_type": base_type,
+                        "compare_type": compare_column_type,
+                    }
         return col_schema_diff
 
     @property
     def rows_both_mismatch(self) -> Optional["pyspark.sql.DataFrame"]:
-        """pyspark.sql.DataFrame: Returns all rows in both dataframes that have mismatches"""
+        """pyspark.sql.DataFrame: Returns all rows in both dataframes that have mismatches."""
         if self._all_rows_mismatched is None:
             self._merge_dataframes()
 
@@ -376,7 +376,7 @@ class LegacySparkCompare:
 
     @property
     def rows_both_all(self) -> Optional["pyspark.sql.DataFrame"]:
-        """pyspark.sql.DataFrame: Returns all rows in both dataframes"""
+        """pyspark.sql.DataFrame: Returns all rows in both dataframes."""
         if self._all_matched_rows is None:
             self._merge_dataframes()
 
@@ -384,7 +384,7 @@ class LegacySparkCompare:
 
     @property
     def rows_only_base(self) -> "pyspark.sql.DataFrame":
-        """pyspark.sql.DataFrame: Returns rows only in the base dataframe"""
+        """pyspark.sql.DataFrame: Returns rows only in the base dataframe."""
         if not self._rows_only_base:
             base_rows = self._get_unq_base_rows()
             base_rows.createOrReplaceTempView("baseRows")
@@ -407,7 +407,7 @@ class LegacySparkCompare:
 
     @property
     def rows_only_compare(self) -> Optional["pyspark.sql.DataFrame"]:
-        """pyspark.sql.DataFrame: Returns rows only in the compare dataframe"""
+        """pyspark.sql.DataFrame: Returns rows only in the compare dataframe."""
         if not self._rows_only_compare:
             compare_rows = self._get_compare_rows()
             compare_rows.createOrReplaceTempView("compareRows")
@@ -430,7 +430,7 @@ class LegacySparkCompare:
         """This function is to generate the select statement to be used later in the query."""
         base_only = list(set(self.base_df.columns) - set(self.compare_df.columns))
         compare_only = list(set(self.compare_df.columns) - set(self.base_df.columns))
-        sorted_list = sorted(list(chain(base_only, compare_only, self.columns_in_both)))
+        sorted_list = sorted(chain(base_only, compare_only, self.columns_in_both))
         select_statement = ""
 
         for column_name in sorted_list:
@@ -548,7 +548,7 @@ class LegacySparkCompare:
             columns_match_dict assigned to { column -> match_type_counts }
                 where:
                     column (string): Name of a column that exists in both the base and comparison columns
-                    match_type_counts (list of int with size = len(MatchType)): The number of each match type seen for this column (in order of the MatchType enum values)
+                    match_type_counts (list of int with size = len(MatchType)): The number of each match type seen for this column (in order of the MatchType enum values).
 
         returns: None
         """
@@ -586,41 +586,41 @@ class LegacySparkCompare:
             return f"A.`{name}_base`, A.`{name}_compare`, CASE WHEN (A.`{name}`={MatchType.MISMATCH.value})  THEN False ELSE True END AS `{name}_match` "
 
     def _create_case_statement(self, name: str) -> str:
-        equal_comparisons = ["(A.`{name}` IS NULL AND B.`{name}` IS NULL)"]
+        equal_comparisons = [f"(A.`{name}` IS NULL AND B.`{name}` IS NULL)"]
         known_diff_comparisons = ["(FALSE)"]
 
-        base_dtype = [d[1] for d in self.base_df.dtypes if d[0] == name][0]
-        compare_dtype = [d[1] for d in self.compare_df.dtypes if d[0] == name][0]
+        base_dtype = next(d[1] for d in self.base_df.dtypes if d[0] == name)
+        compare_dtype = next(d[1] for d in self.compare_df.dtypes if d[0] == name)
 
         if _is_comparable(base_dtype, compare_dtype):
             if (base_dtype in NUMERIC_SPARK_TYPES) and (
                 compare_dtype in NUMERIC_SPARK_TYPES
             ):  # numeric tolerance comparison
                 equal_comparisons.append(
-                    "((A.`{name}`=B.`{name}`) OR ((abs(A.`{name}`-B.`{name}`))<=("
+                    f"((A.`{name}`=B.`{name}`) OR ((abs(A.`{name}`-B.`{name}`))<=("
                     + str(self.abs_tol)
                     + "+("
                     + str(self.rel_tol)
-                    + "*abs(A.`{name}`)))))"
+                    + f"*abs(A.`{name}`)))))"
                 )
             else:  # non-numeric comparison
-                equal_comparisons.append("((A.`{name}`=B.`{name}`))")
+                equal_comparisons.append(f"((A.`{name}`=B.`{name}`))")
 
         if self._known_differences:
-            new_input = "B.`{name}`"
+            new_input = f"B.`{name}`"
             for kd in self._known_differences:
                 if compare_dtype in kd["types"]:
                     if "flags" in kd and "nullcheck" in kd["flags"]:
                         known_diff_comparisons.append(
                             "(("
                             + kd["transformation"].format(new_input, input=new_input)
-                            + ") is null AND A.`{name}` is null)"
+                            + f") is null AND A.`{name}` is null)"
                         )
                     else:
                         known_diff_comparisons.append(
                             "(("
                             + kd["transformation"].format(new_input, input=new_input)
-                            + ") = A.`{name}`)"
+                            + f") = A.`{name}`)"
                         )
 
         case_string = (
@@ -629,7 +629,7 @@ class LegacySparkCompare:
             + ") THEN {match_success} WHEN ("
             + " OR ".join(known_diff_comparisons)
             + ") THEN {match_known_difference} ELSE {match_failure} END) "
-            + "AS `{name}`, A.`{name}` AS `{name}_base`, B.`{name}` AS `{name}_compare`"
+            + f"AS `{name}`, A.`{name}` AS `{name}_base`, B.`{name}` AS `{name}_compare`"
         )
 
         return case_string.format(

--- a/datacompy/spark/pandas.py
+++ b/datacompy/spark/pandas.py
@@ -239,7 +239,6 @@ class SparkPandasCompare(BaseCompare):
         """Merge df1 to df2 on the join columns, to get df1 - df2, df2 - df1
         and df1 & df2
         """
-
         LOG.debug("Outer joining")
 
         df1 = self.df1.copy()
@@ -297,7 +296,7 @@ class SparkPandasCompare(BaseCompare):
             """
         SELECT * FROM
         {df1} df1 FULL OUTER JOIN {df2} df2
-        ON     
+        ON
         """
             + on,
             df1=df1,
@@ -491,11 +490,11 @@ class SparkPandasCompare(BaseCompare):
         ignore_extra_columns : bool
             Ignores any columns in one dataframe and not in the other.
         """
-        if not ignore_extra_columns and not self.all_columns_match():
-            return False
-        elif not self.all_rows_overlap():
-            return False
-        elif not self.intersect_rows_match():
+        if (
+            (not ignore_extra_columns and not self.all_columns_match())
+            or not self.all_rows_overlap()
+            or not self.intersect_rows_match()
+        ):
             return False
         else:
             return True
@@ -512,11 +511,11 @@ class SparkPandasCompare(BaseCompare):
         bool
             True if dataframe 2 is a subset of dataframe 1.
         """
-        if not self.df2_unq_columns() == set():
-            return False
-        elif not len(self.df2_unq_rows) == 0:
-            return False
-        elif not self.intersect_rows_match():
+        if (
+            self.df2_unq_columns() != set()
+            or len(self.df2_unq_rows) != 0
+            or not self.intersect_rows_match()
+        ):
             return False
         else:
             return True

--- a/datacompy/spark/pandas.py
+++ b/datacompy/spark/pandas.py
@@ -495,10 +495,10 @@ class SparkPandasCompare(BaseCompare):
         ignore_extra_columns : bool
             Ignores any columns in one dataframe and not in the other.
         """
-        return not (
-            (not ignore_extra_columns and not self.all_columns_match())
-            or not self.all_rows_overlap()
-            or not self.intersect_rows_match()
+        return (
+            (ignore_extra_columns or self.all_columns_match())
+            and self.all_rows_overlap()
+            and self.intersect_rows_match()
         )
 
     def subset(self) -> bool:

--- a/datacompy/spark/pandas.py
+++ b/datacompy/spark/pandas.py
@@ -131,6 +131,7 @@ class SparkPandasCompare(BaseCompare):
 
     @property
     def df1(self) -> "ps.DataFrame":
+        "Get the first dataframe."
         return self._df1
 
     @df1.setter
@@ -143,6 +144,7 @@ class SparkPandasCompare(BaseCompare):
 
     @property
     def df2(self) -> "ps.DataFrame":
+        """Get the second dataframe."""
         return self._df2
 
     @df2.setter
@@ -188,7 +190,9 @@ class SparkPandasCompare(BaseCompare):
             self._any_dupes = True
 
     def _compare(self, ignore_spaces: bool, ignore_case: bool) -> None:
-        """Actually run the comparison.  This tries to run df1.equals(df2)
+        """Run the comparison.
+
+        This tries to run df1.equals(df2)
         first so that if they're truly equal we can tell.
 
         This method will log out information about what is different between
@@ -236,8 +240,9 @@ class SparkPandasCompare(BaseCompare):
         return OrderedSet(self.df1.columns) & OrderedSet(self.df2.columns)
 
     def _dataframe_merge(self, ignore_spaces: bool) -> None:
-        """Merge df1 to df2 on the join columns, to get df1 - df2, df2 - df1
-        and df1 & df2.
+        """Merge df1 to df2 on the join columns.
+
+        Get df1 - df2, df2 - df1 and df1 & df2.
         """
         LOG.debug("Outer joining")
 
@@ -517,7 +522,9 @@ class SparkPandasCompare(BaseCompare):
     def sample_mismatch(
         self, column: str, sample_count: int = 10, for_display: bool = False
     ) -> "ps.DataFrame":
-        """Returns a sample sub-dataframe which contains the identifying
+        """Return sample mismatches.
+
+        Gets a sub-dataframe which contains the identifying
         columns, and df1 and df2 versions of the column.
 
         Parameters
@@ -561,7 +568,9 @@ class SparkPandasCompare(BaseCompare):
         return to_return
 
     def all_mismatch(self, ignore_matching_cols: bool = False) -> "ps.DataFrame":
-        """All rows with any columns that have a mismatch. Returns all df1 and df2 versions of the columns and join
+        """Get all rows with any columns that have a mismatch.
+
+        Returns all df1 and df2 versions of the columns and join
         columns.
 
         Parameters
@@ -620,7 +629,9 @@ class SparkPandasCompare(BaseCompare):
         column_count: int = 10,
         html_file: Optional[str] = None,
     ) -> str:
-        """Returns a string representation of a report.  The representation can
+        """Return a string representation of a report.
+
+        The representation can
         then be printed or saved to a file.
 
         Parameters
@@ -772,7 +783,9 @@ class SparkPandasCompare(BaseCompare):
 
 
 def render(filename: str, *fields: Union[int, float, str]) -> str:
-    """Renders out an individual template.  This basically just reads in a
+    """Render out an individual template.
+
+    This basically just reads in a
     template file, and applies ``.format()`` on the fields.
 
     Parameters
@@ -801,7 +814,9 @@ def columns_equal(
     ignore_spaces: bool = False,
     ignore_case: bool = False,
 ) -> "ps.Series":
-    """Compares two columns from a dataframe, returning a True/False series,
+    """Compare two columns from a dataframe.
+
+    Returns a True/False series,
     with the same index as column 1.
 
     - Two nulls (np.nan) will evaluate to True.
@@ -880,7 +895,9 @@ def columns_equal(
 def compare_string_and_date_columns(
     col_1: "ps.Series", col_2: "ps.Series"
 ) -> "ps.Series":
-    """Compare a string column and date column, value-wise.  This tries to
+    """Compare a string column and date column, value-wise.
+
+    This tries to
     convert a string column to a date column and compare that way.
 
     Parameters
@@ -920,7 +937,7 @@ def get_merged_columns(
     merged_df: "ps.DataFrame",
     suffix: str,
 ) -> List[str]:
-    """Gets the columns from an original dataframe, in the new merged dataframe.
+    """Get the columns from an original dataframe in the new merged dataframe.
 
     Parameters
     ----------
@@ -972,7 +989,9 @@ def calculate_max_diff(col_1: "ps.DataFrame", col_2: "ps.DataFrame") -> float:
 def generate_id_within_group(
     dataframe: "ps.DataFrame", join_columns: List[str]
 ) -> "ps.Series":
-    """Generate an ID column that can be used to deduplicate identical rows.  The series generated
+    """Generate an ID column that can be used to deduplicate identical rows.
+
+    The series generated
     is the order within a unique group, and it handles nulls.
 
     Parameters

--- a/datacompy/spark/pandas.py
+++ b/datacompy/spark/pandas.py
@@ -513,10 +513,10 @@ class SparkPandasCompare(BaseCompare):
         bool
             True if dataframe 2 is a subset of dataframe 1.
         """
-        return not (
-            self.df2_unq_columns() != set()
-            or len(self.df2_unq_rows) != 0
-            or not self.intersect_rows_match()
+        return (
+            self.df2_unq_columns() == set()
+            and len(self.df2_unq_rows) == 0
+            and self.intersect_rows_match()
         )
 
     def sample_mismatch(

--- a/datacompy/spark/sql.py
+++ b/datacompy/spark/sql.py
@@ -55,8 +55,12 @@ except ImportError:
 LOG = logging.getLogger(__name__)
 
 
-# Used for checking equality with decimal(X, Y) types. Otherwise treated as the string "decimal".
 def decimal_comparator():
+    """Check equality with decimal(X, Y) types.
+
+    Otherwise treated as the string "decimal".
+    """
+
     class DecimalComparator(str):
         def __eq__(self, other):
             return len(other) >= 7 and other[0:7] == "decimal"
@@ -168,6 +172,7 @@ class SparkSQLCompare(BaseCompare):
 
     @property
     def df1(self) -> "pyspark.sql.DataFrame":
+        """Get the first dataframe."""
         return self._df1
 
     @df1.setter
@@ -180,6 +185,7 @@ class SparkSQLCompare(BaseCompare):
 
     @property
     def df2(self) -> "pyspark.sql.DataFrame":
+        """Get the second dataframe."""
         return self._df2
 
     @df2.setter
@@ -247,7 +253,9 @@ class SparkSQLCompare(BaseCompare):
             self._any_dupes = True
 
     def _compare(self, ignore_spaces: bool, ignore_case: bool) -> None:
-        """Actually run the comparison.  This tries to run df1.equals(df2)
+        """Actually run the comparison.
+
+        This tries to run df1.equals(df2)
         first so that if they're truly equal we can tell.
 
         This method will log out information about what is different between
@@ -288,8 +296,9 @@ class SparkSQLCompare(BaseCompare):
         return OrderedSet(self.df1.columns) & OrderedSet(self.df2.columns)
 
     def _dataframe_merge(self, ignore_spaces: bool) -> None:
-        """Merge df1 to df2 on the join columns, to get df1 - df2, df2 - df1
-        and df1 & df2.
+        """Merge df1 to df2 on the join columns.
+
+        To get df1 - df2, df2 - df1 and df1 & df2.
         """
         LOG.debug("Outer joining")
 
@@ -585,7 +594,9 @@ class SparkSQLCompare(BaseCompare):
     def sample_mismatch(
         self, column: str, sample_count: int = 10, for_display: bool = False
     ) -> "pyspark.sql.DataFrame":
-        """Returns a sample sub-dataframe which contains the identifying
+        """Return sample mismatches.
+
+        Gets a sub-dataframe which contains the identifying
         columns, and df1 and df2 versions of the column.
 
         Parameters
@@ -640,7 +651,9 @@ class SparkSQLCompare(BaseCompare):
     def all_mismatch(
         self, ignore_matching_cols: bool = False
     ) -> "pyspark.sql.DataFrame":
-        """All rows with any columns that have a mismatch. Returns all df1 and df2 versions of the columns and join
+        """Get all rows with any columns that have a mismatch.
+
+        Returns all df1 and df2 versions of the columns and join
         columns.
 
         Parameters
@@ -705,7 +718,9 @@ class SparkSQLCompare(BaseCompare):
         column_count: int = 10,
         html_file: Optional[str] = None,
     ) -> str:
-        """Returns a string representation of a report.  The representation can
+        """Return a string representation of a report.
+
+        The representation can
         then be printed or saved to a file.
 
         Parameters
@@ -867,7 +882,9 @@ class SparkSQLCompare(BaseCompare):
 
 
 def render(filename: str, *fields: Union[int, float, str]) -> str:
-    """Renders out an individual template.  This basically just reads in a
+    """Render out an individual template.
+
+    This basically just reads in a
     template file, and applies ``.format()`` on the fields.
 
     Parameters
@@ -898,8 +915,9 @@ def columns_equal(
     ignore_spaces: bool = False,
     ignore_case: bool = False,
 ) -> "pyspark.sql.DataFrame":
-    """Compares two columns from a dataframe, returning a True/False series,
-    with the same index as column 1.
+    """Compare two columns from a dataframe.
+
+    Returns a True/False series with the same index as column 1.
 
     - Two nulls (np.nan) will evaluate to True.
     - A null and a non-null value will evaluate to False.
@@ -984,7 +1002,7 @@ def get_merged_columns(
     merged_df: "pyspark.sql.DataFrame",
     suffix: str,
 ) -> List[str]:
-    """Gets the columns from an original dataframe, in the new merged dataframe.
+    """Get the columns from an original dataframe, in the new merged dataframe.
 
     Parameters
     ----------
@@ -1094,7 +1112,9 @@ def calculate_null_diff(
 def _generate_id_within_group(
     dataframe: "pyspark.sql.DataFrame", join_columns: List[str], order_column_name: str
 ) -> "pyspark.sql.DataFrame":
-    """Generate an ID column that can be used to deduplicate identical rows.  The series generated
+    """Generate an ID column that can be used to deduplicate identical rows.
+
+    The series generated
     is the order within a unique group, and it handles nulls. Requires a ``__index`` column.
 
     Parameters
@@ -1171,7 +1191,7 @@ def _get_column_dtypes(
 
 
 def _is_comparable(type1: str, type2: str) -> bool:
-    """Checks if two Spark data types can be safely compared.
+    """Check if two Spark data types can be safely compared.
 
     Two data types are considered comparable if any of the following apply:
         1. Both data types are the same

--- a/datacompy/spark/sql.py
+++ b/datacompy/spark/sql.py
@@ -585,10 +585,10 @@ class SparkSQLCompare(BaseCompare):
         bool
             True if dataframe 2 is a subset of dataframe 1.
         """
-        return not (
-            self.df2_unq_columns() != set()
-            or self.df2_unq_rows.count() != 0
-            or not self.intersect_rows_match()
+        return (
+            self.df2_unq_columns() == set()
+            and self.df2_unq_rows.count() == 0
+            and self.intersect_rows_match()
         )
 
     def sample_mismatch(

--- a/datacompy/spark/sql.py
+++ b/datacompy/spark/sql.py
@@ -567,10 +567,10 @@ class SparkSQLCompare(BaseCompare):
         ignore_extra_columns : bool
             Ignores any columns in one dataframe and not in the other.
         """
-        return not (
-            (not ignore_extra_columns and not self.all_columns_match())
-            or not self.all_rows_overlap()
-            or not self.intersect_rows_match()
+        return (
+            (ignore_extra_columns or self.all_columns_match())
+            and self.all_rows_overlap()
+            and self.intersect_rows_match()
         )
 
     def subset(self) -> bool:

--- a/datacompy/spark/sql.py
+++ b/datacompy/spark/sql.py
@@ -160,9 +160,9 @@ class SparkSQLCompare(BaseCompare):
         self.rel_tol = rel_tol
         self.ignore_spaces = ignore_spaces
         self.ignore_case = ignore_case
-        self.df1_unq_rows: "pyspark.sql.DataFrame"
-        self.df2_unq_rows: "pyspark.sql.DataFrame"
-        self.intersect_rows: "pyspark.sql.DataFrame"
+        self.df1_unq_rows: pyspark.sql.DataFrame
+        self.df2_unq_rows: pyspark.sql.DataFrame
+        self.intersect_rows: pyspark.sql.DataFrame
         self.column_stats: List = []
         self._compare(ignore_spaces=ignore_spaces, ignore_case=ignore_case)
 
@@ -369,7 +369,7 @@ class SparkSQLCompare(BaseCompare):
             """
         SELECT * FROM
         df1 FULL OUTER JOIN df2
-        ON     
+        ON
         """
             + on
         )
@@ -556,11 +556,11 @@ class SparkSQLCompare(BaseCompare):
         ignore_extra_columns : bool
             Ignores any columns in one dataframe and not in the other.
         """
-        if not ignore_extra_columns and not self.all_columns_match():
-            return False
-        elif not self.all_rows_overlap():
-            return False
-        elif not self.intersect_rows_match():
+        if (
+            (not ignore_extra_columns and not self.all_columns_match())
+            or not self.all_rows_overlap()
+            or not self.intersect_rows_match()
+        ):
             return False
         else:
             return True
@@ -577,11 +577,11 @@ class SparkSQLCompare(BaseCompare):
         bool
             True if dataframe 2 is a subset of dataframe 1.
         """
-        if not self.df2_unq_columns() == set():
-            return False
-        elif not self.df2_unq_rows.count() == 0:
-            return False
-        elif not self.intersect_rows_match():
+        if (
+            self.df2_unq_columns() != set()
+            or self.df2_unq_rows.count() != 0
+            or not self.intersect_rows_match()
+        ):
             return False
         else:
             return True
@@ -976,9 +976,7 @@ def columns_equal(
             )
     else:
         LOG.debug(
-            "Skipping {}({}) and {}({}), columns are not comparable".format(
-                col_1, base_dtype, col_2, compare_dtype
-            )
+            f"Skipping {col_1}({base_dtype}) and {col_2}({compare_dtype}), columns are not comparable"
         )
         dataframe = dataframe.withColumn(col_match, lit(False))
     return dataframe

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,18 +62,63 @@ docs = ["sphinx", "furo", "myst-parser"]
 tests = ["pytest", "pytest-cov"]
 
 tests-spark = ["pytest", "pytest-cov", "pytest-spark"]
-qa = ["pre-commit", "black", "isort", "mypy", "pandas-stubs"]
+qa = ["pre-commit", "ruff==0.5.7", "mypy", "pandas-stubs"]
 build = ["build", "twine", "wheel"]
 edgetest = ["edgetest", "edgetest-conda"]
 dev = ["datacompy[duckdb]", "datacompy[spark]", "datacompy[docs]", "datacompy[tests]", "datacompy[tests-spark]", "datacompy[qa]", "datacompy[build]"]
 
-[tool.isort]
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-line_length = 88
-profile = "black"
+# Linters, formatters and type checkers
+[tool.ruff]
+extend-include = ["*.ipynb"]
+target-version = "py39"
+src = ["src"]
+
+[tool.ruff.lint]
+preview = true
+select = [
+    "E", # pycodestyle errors
+    "W", # pycodestyle warnings
+    "F", # pyflakes
+    "D", # pydocstyle
+    "I", # isort
+    "UP", # pyupgrade
+    "B", # flake8-bugbear
+    # "A", # flake8-builtins
+    "C4", # flake8-comprehensions
+    #"C901", # mccabe complexity
+    # "G", # flake8-logging-format
+    "T20", # flake8-print
+    "TID252", # flake8-tidy-imports ban relative imports
+    # "ARG", # flake8-unused-arguments
+    "SIM", # flake8-simplify
+    "NPY", # numpy rules
+    "LOG", # flake8-logging
+    "RUF", # Ruff errors
+]
+
+ignore = [
+    "E111",  # Check indentation level. Using formatter instead.
+    "E114",  # Check indentation level. Using formatter instead.
+    "E117",  # Check indentation level. Using formatter instead.
+    "E203",  # Check whitespace. Using formatter instead.
+    "E501",  # Line too long. Using formatter instead.
+    "D206",  # Docstring indentation. Using formatter instead.
+    "D300",  # Use triple single quotes. Using formatter instead.
+    "SIM108",  # Use ternary operator instead of if-else blocks.
+    "SIM105", # Use `contextlib.suppress(FileNotFoundError)` instead of `try`-`except`-`pass`
+    "UP035", # `typing.x` is deprecated, use `x` instead
+    "UP006", # `typing.x` is deprecated, use `x` instead
+]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["E402"]
+"**/{tests,docs}/*" = ["E402", "D", "F841", "ARG"]
+
+[tool.ruff.lint.flake8-tidy-imports]
+ban-relative-imports = "all"
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
 
 [tool.mypy]
 strict = true

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -16,6 +16,7 @@
 """
 Testing out the datacompy functionality
 """
+
 import io
 import logging
 import sys
@@ -23,13 +24,12 @@ from datetime import datetime
 from decimal import Decimal
 from unittest import mock
 
+import datacompy
 import numpy as np
 import pandas as pd
 import pytest
 from pandas.testing import assert_series_equal
 from pytest import raises
-
-import datacompy
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
@@ -686,7 +686,7 @@ def test_temp_column_name_one_already():
     assert actual == "_temp_0"
 
 
-### Duplicate testing!
+# Duplicate testing!
 def test_simple_dupes_one_field():
     df1 = pd.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 2}])
     df2 = pd.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 2}])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -509,7 +509,8 @@ def test_columns_maintain_order_through_set_operations():
 
 
 def test_10k_rows():
-    df1 = pd.DataFrame(np.random.randint(0, 100, size=(10000, 2)), columns=["b", "c"])
+    rng = np.random.default_rng()
+    df1 = pd.DataFrame(rng.integers(0, 100, size=(10000, 2)), columns=["b", "c"])
     df1.reset_index(inplace=True)
     df1.columns = ["a", "b", "c"]
     df2 = df1.copy()
@@ -552,7 +553,8 @@ def test_not_subset(caplog):
 
 
 def test_large_subset():
-    df1 = pd.DataFrame(np.random.randint(0, 100, size=(10000, 2)), columns=["b", "c"])
+    rng = np.random.default_rng()
+    df1 = pd.DataFrame(rng.integers(0, 100, size=(10000, 2)), columns=["b", "c"])
     df1.reset_index(inplace=True)
     df1.columns = ["a", "b", "c"]
     df2 = df1[["a", "b"]].sample(50).copy()

--- a/tests/test_fugue/conftest.py
+++ b/tests/test_fugue/conftest.py
@@ -5,13 +5,13 @@ import pytest
 
 @pytest.fixture
 def ref_df():
-    np.random.seed(0)
+    rng = np.random.default_rng(0)
 
     df1 = pd.DataFrame(
         {
-            "a": np.random.randint(0, 10, 100),
-            "b": np.random.rand(100),
-            "c": np.random.choice(["aaa", "b_c", "csd"], 100),
+            "a": rng.integers(0, 10, 100),
+            "b": rng.uniform(size=100),
+            "c": rng.choice(["aaa", "b_c", "csd"], 100),
         }
     )
     df1_copy = df1.copy()
@@ -19,9 +19,9 @@ def ref_df():
     df3 = df1.copy().drop(columns=["a", "b"])
     df4 = pd.DataFrame(
         {
-            "a": np.random.randint(1, 12, 100),  # shift the join col
-            "b": np.random.rand(100),
-            "c": np.random.choice(["aaa", "b_c", "csd"], 100),
+            "a": rng.integers(1, 12, 100),  # shift the join col
+            "b": rng.uniform(size=100),
+            "c": rng.choice(["aaa", "b_c", "csd"], 100),
         }
     )
     df5 = df1.sample(frac=0.1)
@@ -67,7 +67,6 @@ def simple_diff_df2():
 
 @pytest.fixture
 def no_intersection_diff_df1():
-    np.random.seed(0)
     return pd.DataFrame({"x": ["a"], "y": [0.1]}).convert_dtypes()
 
 
@@ -78,26 +77,25 @@ def no_intersection_diff_df2():
 
 @pytest.fixture
 def large_diff_df1():
-    np.random.seed(0)
-    data = np.random.randint(0, 7, size=10000)
+    rng = np.random.default_rng(0)
+    data = rng.integers(0, 7, size=10000)
     return pd.DataFrame({"x": data, "y": np.array([9] * 10000)}).convert_dtypes()
 
 
 @pytest.fixture
 def large_diff_df2():
-    np.random.seed(0)
-    data = np.random.randint(6, 11, size=10000)
+    rng = np.random.default_rng(0)
+    data = rng.integers(6, 11, size=10000)
     return pd.DataFrame({"x": data, "y": np.array([9] * 10000)}).convert_dtypes()
 
 
 @pytest.fixture
 def count_matching_rows_df():
-    np.random.seed(0)
     df1 = pd.DataFrame(
         {
             "a": np.arange(0, 100),
             "b": np.arange(0, 100),
         }
     )
-    df2 = df1.sample(frac=0.1)
+    df2 = df1.sample(frac=0.1, random_state=0)
     return [df1, df2]

--- a/tests/test_fugue/conftest.py
+++ b/tests/test_fugue/conftest.py
@@ -8,21 +8,21 @@ def ref_df():
     np.random.seed(0)
 
     df1 = pd.DataFrame(
-        dict(
-            a=np.random.randint(0, 10, 100),
-            b=np.random.rand(100),
-            c=np.random.choice(["aaa", "b_c", "csd"], 100),
-        )
+        {
+            "a": np.random.randint(0, 10, 100),
+            "b": np.random.rand(100),
+            "c": np.random.choice(["aaa", "b_c", "csd"], 100),
+        }
     )
     df1_copy = df1.copy()
     df2 = df1.copy().drop(columns=["c"])
     df3 = df1.copy().drop(columns=["a", "b"])
     df4 = pd.DataFrame(
-        dict(
-            a=np.random.randint(1, 12, 100),  # shift the join col
-            b=np.random.rand(100),
-            c=np.random.choice(["aaa", "b_c", "csd"], 100),
-        )
+        {
+            "a": np.random.randint(1, 12, 100),  # shift the join col
+            "b": np.random.rand(100),
+            "c": np.random.choice(["aaa", "b_c", "csd"], 100),
+        }
     )
     df5 = df1.sample(frac=0.1)
     return [df1, df1_copy, df2, df3, df4, df5]
@@ -55,25 +55,25 @@ def upper_col_df(shuffle_df):
 
 @pytest.fixture
 def simple_diff_df1():
-    return pd.DataFrame(dict(aa=[0, 1, 0], bb=[2.1, 3.1, 4.1])).convert_dtypes()
+    return pd.DataFrame({"aa": [0, 1, 0], "bb": [2.1, 3.1, 4.1]}).convert_dtypes()
 
 
 @pytest.fixture
 def simple_diff_df2():
     return pd.DataFrame(
-        dict(aa=[1, 0, 1], bb=[3.1, 4.1, 5.1], cc=["a", "b", "c"])
+        {"aa": [1, 0, 1], "bb": [3.1, 4.1, 5.1], "cc": ["a", "b", "c"]}
     ).convert_dtypes()
 
 
 @pytest.fixture
 def no_intersection_diff_df1():
     np.random.seed(0)
-    return pd.DataFrame(dict(x=["a"], y=[0.1])).convert_dtypes()
+    return pd.DataFrame({"x": ["a"], "y": [0.1]}).convert_dtypes()
 
 
 @pytest.fixture
 def no_intersection_diff_df2():
-    return pd.DataFrame(dict(x=["b"], y=[1.1])).convert_dtypes()
+    return pd.DataFrame({"x": ["b"], "y": [1.1]}).convert_dtypes()
 
 
 @pytest.fixture
@@ -94,10 +94,10 @@ def large_diff_df2():
 def count_matching_rows_df():
     np.random.seed(0)
     df1 = pd.DataFrame(
-        dict(
-            a=np.arange(0, 100),
-            b=np.arange(0, 100),
-        )
+        {
+            "a": np.arange(0, 100),
+            "b": np.arange(0, 100),
+        }
     )
     df2 = df1.sample(frac=0.1)
     return [df1, df2]

--- a/tests/test_fugue/test_duckdb.py
+++ b/tests/test_fugue/test_duckdb.py
@@ -13,10 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Test fugue functionality with duckdb."""
-import pytest
-from ordered_set import OrderedSet
-from pytest import raises
 
+import pytest
 from datacompy import (
     all_columns_match,
     all_rows_overlap,
@@ -25,6 +23,8 @@ from datacompy import (
     is_match,
     unq_columns,
 )
+from ordered_set import OrderedSet
+from pytest import raises
 
 duckdb = pytest.importorskip("duckdb")
 

--- a/tests/test_fugue/test_fugue_pandas.py
+++ b/tests/test_fugue/test_fugue_pandas.py
@@ -13,13 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Test the fugue functionality with pandas."""
+
 from io import StringIO
 
 import pandas as pd
-from ordered_set import OrderedSet
-from pytest import raises
-from test_fugue_helpers import _compare_report
-
 from datacompy import (
     Compare,
     all_columns_match,
@@ -30,6 +27,9 @@ from datacompy import (
     report,
     unq_columns,
 )
+from ordered_set import OrderedSet
+from pytest import raises
+from test_fugue_helpers import _compare_report
 
 
 def test_is_match_native(

--- a/tests/test_fugue/test_fugue_polars.py
+++ b/tests/test_fugue/test_fugue_polars.py
@@ -13,10 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Test fugue and polars."""
-import pytest
-from ordered_set import OrderedSet
-from pytest import raises
 
+import pytest
 from datacompy import (
     all_columns_match,
     all_rows_overlap,
@@ -25,6 +23,8 @@ from datacompy import (
     is_match,
     unq_columns,
 )
+from ordered_set import OrderedSet
+from pytest import raises
 
 pl = pytest.importorskip("polars")
 

--- a/tests/test_fugue/test_fugue_spark.py
+++ b/tests/test_fugue/test_fugue_spark.py
@@ -13,11 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Test fugue and spark."""
-import pytest
-from ordered_set import OrderedSet
-from pytest import raises
-from test_fugue_helpers import _compare_report
 
+import pytest
 from datacompy import (
     Compare,
     all_columns_match,
@@ -28,6 +25,9 @@ from datacompy import (
     report,
     unq_columns,
 )
+from ordered_set import OrderedSet
+from pytest import raises
+from test_fugue_helpers import _compare_report
 
 pyspark = pytest.importorskip("pyspark")
 

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -468,7 +468,8 @@ def test_columns_maintain_order_through_set_operations():
 
 
 def test_10k_rows():
-    df1 = pl.DataFrame(np.random.randint(0, 100, size=(10000, 2)), schema=["b", "c"])
+    rng = np.random.default_rng()
+    df1 = pl.DataFrame(rng.integers(0, 100, size=(10000, 2)), schema=["b", "c"])
     df1 = df1.with_row_index()
     df1.columns = ["a", "b", "c"]
     df2 = df1.clone()
@@ -511,7 +512,8 @@ def test_not_subset(caplog):
 
 
 def test_large_subset():
-    df1 = pl.DataFrame(np.random.randint(0, 100, size=(10000, 2)), schema=["b", "c"])
+    rng = np.random.default_rng()
+    df1 = pl.DataFrame(rng.integers(0, 100, size=(10000, 2)), schema=["b", "c"])
     df1 = df1.with_row_index()
     df1.columns = ["a", "b", "c"]
     df2 = df1[["a", "b"]].sample(50).clone()

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -30,17 +30,16 @@ from pytest import raises
 
 pytest.importorskip("polars")
 
-import polars as pl  # noqa: E402
-from polars.exceptions import ComputeError, DuplicateError  # noqa: E402
-from polars.testing import assert_series_equal  # noqa: E402
-
-from datacompy import PolarsCompare  # noqa: E402
-from datacompy.polars import (  # noqa: E402
+import polars as pl
+from datacompy import PolarsCompare
+from datacompy.polars import (
     calculate_max_diff,
     columns_equal,
     generate_id_within_group,
     temp_column_name,
 )
+from polars.exceptions import ComputeError, DuplicateError
+from polars.testing import assert_series_equal
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
@@ -612,7 +611,7 @@ def test_temp_column_name_one_already():
     assert actual == "_temp_0"
 
 
-### Duplicate testing!
+# Duplicate testing!
 def test_simple_dupes_one_field():
     df1 = pl.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 2}])
     df2 = pl.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 2}])
@@ -855,7 +854,7 @@ def test_sample_mismatch():
 
     output = compare.sample_mismatch(column="name", sample_count=3)
     assert output.shape[0] == 2
-    assert (["name_df1"] != output["name_df2"]).all()
+    assert (output["name_df2"] != ["name_df1"]).all()
 
 
 def test_all_mismatch_not_ignore_matching_cols_no_cols_matching():

--- a/tests/test_spark/test_legacy_spark.py
+++ b/tests/test_spark/test_legacy_spark.py
@@ -23,8 +23,13 @@ import pytest
 
 pytest.importorskip("pyspark")
 
-from pyspark.sql import Row  # noqa: E402
-from pyspark.sql.types import (  # noqa: E402
+from datacompy.spark.legacy import (
+    NUMERIC_SPARK_TYPES,
+    LegacySparkCompare,
+    _is_comparable,
+)
+from pyspark.sql import Row
+from pyspark.sql.types import (
     DateType,
     DecimalType,
     DoubleType,
@@ -32,12 +37,6 @@ from pyspark.sql.types import (  # noqa: E402
     StringType,
     StructField,
     StructType,
-)
-
-from datacompy.spark.legacy import (  # noqa: E402
-    NUMERIC_SPARK_TYPES,
-    LegacySparkCompare,
-    _is_comparable,
 )
 
 # Turn off py4j debug messages for all tests in this module

--- a/tests/test_spark/test_pandas_spark.py
+++ b/tests/test_spark/test_pandas_spark.py
@@ -506,7 +506,8 @@ def test_columns_maintain_order_through_set_operations():
 
 @pandas_version
 def test_10k_rows():
-    df1 = ps.DataFrame(np.random.randint(0, 100, size=(10000, 2)), columns=["b", "c"])
+    rng = np.random.default_rng()
+    df1 = ps.DataFrame(rng.integers(0, 100, size=(10000, 2)), columns=["b", "c"])
     df1.reset_index(inplace=True)
     df1.columns = ["a", "b", "c"]
     df2 = df1.copy()
@@ -552,7 +553,8 @@ def test_not_subset(caplog):
 
 @pandas_version
 def test_large_subset():
-    df1 = ps.DataFrame(np.random.randint(0, 100, size=(10000, 2)), columns=["b", "c"])
+    rng = np.random.default_rng()
+    df1 = ps.DataFrame(rng.integers(0, 100, size=(10000, 2)), columns=["b", "c"])
     df1.reset_index(inplace=True)
     df1.columns = ["a", "b", "c"]
     df2 = df1[["a", "b"]].head(50).copy()
@@ -1303,9 +1305,11 @@ def test_pandas_version():
     expected_message = "It seems like you are running Pandas 2+. Please note that Pandas 2+ will only be supported in Spark 4+. See: https://issues.apache.org/jira/browse/SPARK-44101. If you need to use Spark DataFrame with Pandas 2+ then consider using Fugue otherwise downgrade to Pandas 1.5.3"
     df1 = ps.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 2}])
     df2 = ps.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 2}])
-    with mock.patch("pandas.__version__", "2.0.0"):
-        with raises(Exception, match=re.escape(expected_message)):
-            SparkPandasCompare(df1, df2, join_columns=["a"])
+    with (
+        mock.patch("pandas.__version__", "2.0.0"),
+        raises(Exception, match=re.escape(expected_message)),
+    ):
+        SparkPandasCompare(df1, df2, join_columns=["a"])
 
     with mock.patch("pandas.__version__", "1.5.3"):
         SparkPandasCompare(df1, df2, join_columns=["a"])

--- a/tests/test_spark/test_pandas_spark.py
+++ b/tests/test_spark/test_pandas_spark.py
@@ -32,16 +32,15 @@ from pytest import raises
 
 pytest.importorskip("pyspark")
 
-import pyspark.pandas as ps  # noqa: E402
-from pandas.testing import assert_series_equal  # noqa: E402
-
-from datacompy.spark.pandas import (  # noqa: E402
+import pyspark.pandas as ps
+from datacompy.spark.pandas import (
     SparkPandasCompare,
     calculate_max_diff,
     columns_equal,
     generate_id_within_group,
     temp_column_name,
 )
+from pandas.testing import assert_series_equal
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
@@ -665,7 +664,7 @@ def test_temp_column_name_one_already():
     assert actual == "_temp_0"
 
 
-### Duplicate testing!
+# Duplicate testing!
 @pandas_version
 def test_simple_dupes_one_field():
     df1 = ps.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 2}])
@@ -1315,10 +1314,16 @@ def test_pandas_version():
 @pandas_version
 def test_unicode_columns():
     df1 = ps.DataFrame(
-        [{"a": 1, "例": 2, "予測対象日": "test"}, {"a": 1, "例": 3, "予測対象日": "test"}]
+        [
+            {"a": 1, "例": 2, "予測対象日": "test"},
+            {"a": 1, "例": 3, "予測対象日": "test"},
+        ]
     )
     df2 = ps.DataFrame(
-        [{"a": 1, "例": 2, "予測対象日": "test"}, {"a": 1, "例": 3, "予測対象日": "test"}]
+        [
+            {"a": 1, "例": 2, "予測対象日": "test"},
+            {"a": 1, "例": 3, "予測対象日": "test"},
+        ]
     )
     compare = SparkPandasCompare(df1, df2, join_columns=["例"])
     assert compare.matches()

--- a/tests/test_spark/test_sql_spark.py
+++ b/tests/test_spark/test_sql_spark.py
@@ -19,7 +19,6 @@ Testing out the datacompy functionality
 
 import io
 import logging
-import re
 import sys
 from datetime import datetime
 from decimal import Decimal
@@ -33,15 +32,14 @@ from pytest import raises
 
 pytest.importorskip("pyspark")
 
-from pandas.testing import assert_series_equal  # noqa: E402
-
-from datacompy.spark.sql import (  # noqa: E402
+from datacompy.spark.sql import (
     SparkSQLCompare,
     _generate_id_within_group,
     calculate_max_diff,
     columns_equal,
     temp_column_name,
 )
+from pandas.testing import assert_series_equal
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
@@ -662,7 +660,7 @@ def test_temp_column_name_one_already(spark_session):
     assert actual == "_temp_0"
 
 
-### Duplicate testing!
+# Duplicate testing!
 
 
 def test_simple_dupes_one_field(spark_session):

--- a/tests/test_spark/test_sql_spark.py
+++ b/tests/test_spark/test_sql_spark.py
@@ -491,7 +491,8 @@ def test_columns_maintain_order_through_set_operations(spark_session):
 
 
 def test_10k_rows(spark_session):
-    pdf = pd.DataFrame(np.random.randint(0, 100, size=(10000, 2)), columns=["b", "c"])
+    rng = np.random.default_rng()
+    pdf = pd.DataFrame(rng.integers(0, 100, size=(10000, 2)), columns=["b", "c"])
     pdf.reset_index(inplace=True)
     pdf.columns = ["a", "b", "c"]
     pdf2 = pdf.copy()
@@ -541,7 +542,8 @@ def test_not_subset(spark_session, caplog):
 
 
 def test_large_subset(spark_session):
-    pdf = pd.DataFrame(np.random.randint(0, 100, size=(10000, 2)), columns=["b", "c"])
+    rng = np.random.default_rng()
+    pdf = pd.DataFrame(rng.integers(0, 100, size=(10000, 2)), columns=["b", "c"])
     pdf.reset_index(inplace=True)
     pdf.columns = ["a", "b", "c"]
     pdf2 = pdf[["a", "b"]].head(50).copy()


### PR DESCRIPTION
I have added ruff as our linter and formatter, made corresponding changes to code and added ruff to pre-commit and GH workflows. In this process, I have enabled the numpy rules which prepares datacompy to upgrade to numpy 2.0. Unfortunately, due to compatibility issues with pyspark.pandas and numpy 2.0, some further changes to the imports/guarding will be required to allow numpy 2.0 to be installed alongside datacompy