### PR TITLE
Add diff for join columns

### DIFF
--- a/datacompy/core.py
+++ b/datacompy/core.py
@@ -179,7 +179,10 @@ class Compare(BaseCompare):
             dataframe.columns = pd.Index([str(col) for col in dataframe.columns])
         # Check if join_columns are present in the dataframe
         if not set(self.join_columns).issubset(set(dataframe.columns)):
-            raise ValueError(f"{index} must have all columns from join_columns")
+            missing_cols = set(self.join_columns) - set(dataframe.columns)
+            raise ValueError(
+                f"{index} must have all columns from join_columns: {missing_cols}"
+            )
 
         if len(set(dataframe.columns)) < len(dataframe.columns):
             raise ValueError(f"{index} must have unique column names")

--- a/datacompy/polars.py
+++ b/datacompy/polars.py
@@ -176,7 +176,10 @@ class PolarsCompare(BaseCompare):
 
         # Check if join_columns are present in the dataframe
         if not set(self.join_columns).issubset(set(dataframe.columns)):
-            raise ValueError(f"{index} must have all columns from join_columns")
+            missing_cols = set(self.join_columns) - set(dataframe.columns)
+            raise ValueError(
+                f"{index} must have all columns from join_columns: {missing_cols}"
+            )
 
         if len(set(dataframe.columns)) < len(dataframe.columns):
             raise ValueError(f"{index} must have unique column names")

--- a/datacompy/spark/pandas.py
+++ b/datacompy/spark/pandas.py
@@ -181,7 +181,10 @@ class SparkPandasCompare(BaseCompare):
             dataframe.columns = [str(col) for col in dataframe.columns]
         # Check if join_columns are present in the dataframe
         if not set(self.join_columns).issubset(set(dataframe.columns)):
-            raise ValueError(f"{index} must have all columns from join_columns")
+            missing_cols = set(self.join_columns) - set(dataframe.columns)
+            raise ValueError(
+                f"{index} must have all columns from join_columns: {missing_cols}"
+            )
 
         if len(set(dataframe.columns)) < len(dataframe.columns):
             raise ValueError(f"{index} must have unique column names")

--- a/datacompy/spark/sql.py
+++ b/datacompy/spark/sql.py
@@ -241,7 +241,10 @@ class SparkSQLCompare(BaseCompare):
         # Check if join_columns are present in the dataframe
         dataframe = getattr(self, index)  # refresh
         if not set(self.join_columns).issubset(set(dataframe.columns)):
-            raise ValueError(f"{index} must have all columns from join_columns")
+            missing_cols = set(self.join_columns) - set(dataframe.columns)
+            raise ValueError(
+                f"{index} must have all columns from join_columns: {missing_cols}"
+            )
 
         if len(set(dataframe.columns)) < len(dataframe.columns):
             raise ValueError(f"{index} must have unique column names")


### PR DESCRIPTION
Small QoL change - sometimes its not immediately obvious which columns in the join_columns are not in the compared dataframes (especially if upper-casing/lower-casing is involved). This should make it more obvious.