### PR TITLE
 Fix compariosn report when one column is all NAs

### DIFF
--- a/datacompy/core.py
+++ b/datacompy/core.py
@@ -490,7 +490,7 @@ class Compare(BaseCompare):
             column.
         """
         row_cnt = self.intersect_rows.shape[0]
-        col_match = self.intersect_rows[column + "_match"]
+        col_match = self.intersect_rows[column + "_match"].fillna(False)
         match_cnt = col_match.sum()
         sample_count = min(sample_count, row_cnt - match_cnt)
         sample = self.intersect_rows[~col_match].sample(sample_count)


### PR DESCRIPTION
With situations when one of the column in the comparison was all NA's then this would break the reporting. For some reason when the matching (boolean) of the actual and expected columns happened when there was a categorical value compared to a NA, the result was NA, rather than False, as it would happen for the other elements in the cols compared.
    
This has now been addressed at the intersect rows level which doesn't seem to break the reporting anymore.