### PR TITLE
fixing polars test and bumping versions

### DIFF
--- a/datacompy/__init__.py
+++ b/datacompy/__init__.py
@@ -18,7 +18,7 @@ Originally started to be something of a replacement for SAS's PROC COMPARE for P
 Then extended to carry that functionality over to Spark Dataframes.
 """
 
-__version__ = "0.14.4"
+__version__ = "0.15.0"
 
 import platform
 from warnings import warn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ maintainers = [
   { name="Faisal Dosani", email="faisal.dosani@capitalone.com" }
 ]
 license = {text = "Apache Software License"}
-dependencies = ["pandas<=2.2.3,>=0.25.0", "numpy<=2.1.3,>=1.22.0", "ordered-set<=4.1.0,>=4.0.2", "polars[pandas]<=1.12.0,>=0.20.4"]
+dependencies = ["pandas<=2.2.3,>=0.25.0", "numpy<=2.2.0,>=1.22.0", "ordered-set<=4.1.0,>=4.0.2", "polars[pandas]<=1.17.1,>=0.20.4"]
 requires-python = ">=3.9.0"
 classifiers = [
     "Intended Audience :: Developers",

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -38,7 +38,7 @@ from datacompy.polars import (
     generate_id_within_group,
     temp_column_name,
 )
-from polars.exceptions import ComputeError, DuplicateError
+from polars.exceptions import ComputeError, DuplicateError, SchemaError
 from polars.testing import assert_series_equal
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
@@ -536,7 +536,7 @@ def test_string_joiner():
 def test_float_and_string_with_joins():
     df1 = pl.DataFrame([{"a": float("1"), "b": 2}, {"a": float("2"), "b": 2}])
     df2 = pl.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 2}])
-    with raises(ComputeError):
+    with raises((ComputeError, SchemaError)):
         PolarsCompare(df1, df2, "a")
 
 


### PR DESCRIPTION
Edgetest was failing due to some changes when joining columns of different types:
- Making sure we check for `SchemaError`
- Bumping versions to the latest deps.