### PR TITLE
adding check for pyarrow strings in columns_equal

### DIFF
--- a/datacompy/core.py
+++ b/datacompy/core.py
@@ -384,7 +384,7 @@ class Compare(BaseCompare):
                     if str(self.df1[column].dtype) == "string"
                     else str(self.df1[column].dtype),
                     "dtype2": str(self.df2[column].dtype.__repr__())
-                    if self.df2[column].dtype == "string"
+                    if str(self.df2[column].dtype) == "string"
                     else str(self.df2[column].dtype),
                     "all_match": all(
                         (

--- a/datacompy/core.py
+++ b/datacompy/core.py
@@ -380,8 +380,12 @@ class Compare(BaseCompare):
                     "match_column": col_match,
                     "match_cnt": match_cnt,
                     "unequal_cnt": row_cnt - match_cnt,
-                    "dtype1": str(self.df1[column].dtype),
-                    "dtype2": str(self.df2[column].dtype),
+                    "dtype1": str(self.df1[column].dtype.__repr__())
+                    if self.df1[column].dtype == "string"
+                    else str(self.df1[column].dtype),
+                    "dtype2": str(self.df2[column].dtype.__repr__())
+                    if self.df2[column].dtype == "string"
+                    else str(self.df2[column].dtype),
                     "all_match": all(
                         (
                             self.df1[column].dtype == self.df2[column].dtype,
@@ -847,8 +851,14 @@ def columns_equal(
                         | (col_1.isnull() & col_2.isnull())
                     )
             except Exception:
-                # Blanket exception should just return all False
-                compare = pd.Series(False, index=col_1.index)
+                # Check for string[pyarrow] and string[python]
+                if col_1.dtype in (
+                    "string[python]",
+                    "string[pyarrow]",
+                ) and col_2.dtype in ("string[python]", "string[pyarrow]"):
+                    compare = pd.Series(col_1.astype(str) == col_2.astype(str))
+                else:  # Blanket exception should just return all False
+                    compare = pd.Series(False, index=col_1.index)
     compare.index = col_1.index
     return compare
 

--- a/datacompy/core.py
+++ b/datacompy/core.py
@@ -381,7 +381,7 @@ class Compare(BaseCompare):
                     "match_cnt": match_cnt,
                     "unequal_cnt": row_cnt - match_cnt,
                     "dtype1": str(self.df1[column].dtype.__repr__())
-                    if self.df1[column].dtype == "string"
+                    if str(self.df1[column].dtype) == "string"
                     else str(self.df1[column].dtype),
                     "dtype2": str(self.df2[column].dtype.__repr__())
                     if self.df2[column].dtype == "string"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -62,6 +62,29 @@ NULL|NULL|True"""
     assert_series_equal(expect_out, actual_out, check_names=False)
 
 
+def test_string_pyarrow_columns_equal():
+    data = """a|b|expected
+Hi|Hi|True
+Yo|Yo|True
+Hey|Hey |False
+résumé|resume|False
+résumé|résumé|True
+💩|💩|True
+💩|🤔|False
+ | |True
+  | |False
+datacompy|DataComPy|False
+something||False
+|something|False
+||True"""
+    df = pd.read_csv(io.StringIO(data), sep="|")
+    actual_out = datacompy.columns_equal(
+        df.a.astype("string[python]"), df.b.astype("string[pyarrow]"), rel_tol=0.2
+    )
+    expect_out = df["expected"]
+    assert (actual_out == expect_out).all()
+
+
 def test_string_columns_equal():
     data = """a|b|expected
 Hi|Hi|True


### PR DESCRIPTION
Fixes #373 

- Will display `dtype.__repr__()` in `report`
- additional check for `string[pyarrow]` and `string[python]` as these should probably compare and return a value.