### PR TITLE
Update Snowflake Dataframe Naming

### DIFF
--- a/datacompy/__init__.py
+++ b/datacompy/__init__.py
@@ -18,7 +18,7 @@ Originally started to be something of a replacement for SAS's PROC COMPARE for P
 Then extended to carry that functionality over to Spark Dataframes.
 """
 
-__version__ = "0.16.2"
+__version__ = "0.16.3"
 
 import platform
 from warnings import warn

--- a/datacompy/snowflake.py
+++ b/datacompy/snowflake.py
@@ -163,7 +163,7 @@ class SnowflakeCompare(BaseCompare):
             if len(table_name) != 3:
                 errmsg = f"{df} is not a valid table name. Be sure to include the target db and schema."
                 raise ValueError(errmsg)
-            self.df1_name = df_name.upper() if df_name else table_name[2]
+            self.df1_name = df_name.upper() if df_name else "__".join(table_name)
             self._df1 = self.session.table(df)
         else:
             self._df1 = df
@@ -184,7 +184,7 @@ class SnowflakeCompare(BaseCompare):
             if len(table_name) != 3:
                 errmsg = f"{df} is not a valid table name. Be sure to include the target db and schema."
                 raise ValueError(errmsg)
-            self.df2_name = df_name.upper() if df_name else table_name[2]
+            self.df2_name = df_name.upper() if df_name else "__".join(table_name)
             self._df2 = self.session.table(df)
         else:
             self._df2 = df

--- a/docs/source/snowflake_usage.rst
+++ b/docs/source/snowflake_usage.rst
@@ -8,8 +8,8 @@ For ``SnowflakeCompare``
 - Compares ``snowflake.snowpark.DataFrame``, which can be provided as either raw Snowflake dataframes
   or as the names of full names of valid snowflake tables, which we will process into Snowpark dataframes.
 - Note that if Snowflake tables are provided, that dataframe names will default to the full name of their
-respective Snowflake tables. This can be overriden by setting the ``df1_name`` and ``df2_name`` connection_parameters
-in the Compare object initialization.
+respective Snowflake tables. This can be overriden by setting the ``df1_name`` and ``df2_name`` arguments
+when creating the Compare object.
 
 
 SnowflakeCompare setup

--- a/docs/source/snowflake_usage.rst
+++ b/docs/source/snowflake_usage.rst
@@ -7,6 +7,9 @@ For ``SnowflakeCompare``
 - Joining is done using ``EQUAL_NULL`` which is the equality test that is safe for null values.
 - Compares ``snowflake.snowpark.DataFrame``, which can be provided as either raw Snowflake dataframes
   or as the names of full names of valid snowflake tables, which we will process into Snowpark dataframes.
+- Note that if Snowflake tables are provided, that dataframe names will default to the full name of their
+respective Snowflake tables. This can be overriden by setting the ``df1_name`` and ``df2_name`` connection_parameters
+in the Compare object initialization.
 
 
 SnowflakeCompare setup
@@ -57,6 +60,8 @@ Provide Snowpark dataframes
         session,
         df_1,
         df_2,
+        #df1_name='original', # optional param for naming df1
+        #df2_name='new' # optional param for naming df2
         join_columns=['acct_id'],
         rel_tol=1e-03,
         abs_tol=1e-04,
@@ -80,6 +85,8 @@ Given the dataframes from the prior examples...
         session,
         f"{db}.{schema}.toy_table_1",
         f"{db}.{schema}.toy_table_2",
+        #df1_name='original', # optional param for naming df1
+        #df2_name='new' # optional param for naming df2
         join_columns=['acct_id'],
         rel_tol=1e-03,
         abs_tol=1e-04,

--- a/tests/test_snowflake.py
+++ b/tests/test_snowflake.py
@@ -356,6 +356,31 @@ def test_compare_table_setter_bad(snowpark_session):
         )
 
 
+@mock.patch(
+    "datacompy.snowflake.SnowflakeCompare._validate_dataframe", new=mock.MagicMock()
+)
+@mock.patch("datacompy.snowflake.SnowflakeCompare._compare", new=mock.MagicMock())
+def test_compare_table_unique_names(snowpark_session):
+    # Assert that two tables with the same name but from a different DB/Schema have unique names
+    # Same schema/name, different DB
+    compare = SnowflakeCompare(
+        snowpark_session,
+        "test_db1.test_schema.test_name",
+        "test_db2.test_schema.test_name",
+        ["A"],
+    )
+    assert compare.df1_name != compare.df2_name
+
+    # Same db/name, different schema
+    compare = SnowflakeCompare(
+        snowpark_session,
+        "test_db.test_schema1.test_name",
+        "test_db.test_schema2.test_name",
+        ["A"],
+    )
+    assert compare.df1_name != compare.df2_name
+
+
 def test_compare_table_setter_good(snowpark_session):
     data = """ACCT_ID,DOLLAR_AMT,NAME,FLOAT_FLD,DATE_FLD
     10000001234,123.4,George Michael Bluth,14530.155,


### PR DESCRIPTION
In order to allow for comparisons with similarly named tables across different schemas/dbs, the default naming convention for Snowpark DFs from Snowflake Tables has been updated.

Closes #381 

Snowflake tests passing locally