### PR TITLE
intersection of rows as the datasets have no mutual key/connection

### DIFF
--- a/datacompy/__init__.py
+++ b/datacompy/__init__.py
@@ -18,7 +18,7 @@ Originally started to be something of a replacement for SAS's PROC COMPARE for P
 Then extended to carry that functionality over to Spark Dataframes.
 """
 
-__version__ = "0.16.3"
+__version__ = "0.16.4"
 
 import platform
 from warnings import warn

--- a/datacompy/base.py
+++ b/datacompy/base.py
@@ -159,10 +159,10 @@ class BaseCompare(ABC):
         pass
 
     def only_join_columns(self) -> bool:
-        """Boolean on if the only common columns are the join columns."""
-        df1_compare_cols = set(self.df1.columns) - set(self.join_columns)
-        df2_compare_cols = set(self.df2.columns) - set(self.join_columns)
-        return df1_compare_cols.intersection(df2_compare_cols) == set()
+        """Boolean on if the only columns are the join columns."""
+        return (set(self.join_columns) == set(self.df1.columns)) & (
+            set(self.join_columns) == set(self.df2.columns)
+        )
 
 
 def temp_column_name(*dataframes) -> str:

--- a/datacompy/base.py
+++ b/datacompy/base.py
@@ -158,6 +158,12 @@ class BaseCompare(ABC):
         """Return a string representation of a report."""
         pass
 
+    def common_columns_strictly_join_columns(self) -> bool:
+        """Boolean on if the only common columns are the join columns."""
+        df1_compare_cols = set(self.df1.columns) - set(self.join_columns)
+        df2_compare_cols = set(self.df2.columns) - set(self.join_columns)
+        return df1_compare_cols.intersection(df2_compare_cols) == set()
+
 
 def temp_column_name(*dataframes) -> str:
     """Get a temp column name that isn't included in columns of any dataframes.

--- a/datacompy/base.py
+++ b/datacompy/base.py
@@ -158,7 +158,7 @@ class BaseCompare(ABC):
         """Return a string representation of a report."""
         pass
 
-    def common_columns_strictly_join_columns(self) -> bool:
+    def only_join_columns(self) -> bool:
         """Boolean on if the only common columns are the join columns."""
         df1_compare_cols = set(self.df1.columns) - set(self.join_columns)
         df2_compare_cols = set(self.df2.columns) - set(self.join_columns)

--- a/datacompy/base.py
+++ b/datacompy/base.py
@@ -160,9 +160,7 @@ class BaseCompare(ABC):
 
     def only_join_columns(self) -> bool:
         """Boolean on if the only columns are the join columns."""
-        return (set(self.join_columns) == set(self.df1.columns)) & (
-            set(self.join_columns) == set(self.df2.columns)
-        )
+        return set(self.join_columns) == set(self.df1.columns) == set(self.df2.columns)
 
 
 def temp_column_name(*dataframes) -> str:

--- a/datacompy/core.py
+++ b/datacompy/core.py
@@ -356,6 +356,7 @@ class Compare(BaseCompare):
                 max_diff = 0.0
                 null_diff = 0
             else:
+                row_cnt = len(self.intersect_rows)
                 col_1 = column + "_" + self.df1_name
                 col_2 = column + "_" + self.df2_name
                 col_match = column + "_match"

--- a/datacompy/core.py
+++ b/datacompy/core.py
@@ -602,6 +602,7 @@ class Compare(BaseCompare):
                         f"Column {orig_col_name} is equal in df1 and df2. It will not be added to the result."
                     )
         if len(match_list) == 0:
+            LOG.info("No match columns found, returning mismatches based on unq_rows")
             return pd.concat(
                 [
                     self.df1_unq_rows[self.join_columns],

--- a/datacompy/core.py
+++ b/datacompy/core.py
@@ -340,11 +340,19 @@ class Compare(BaseCompare):
         otherwise.
         """
         LOG.debug("Comparing intersection")
-        row_cnt = len(self.intersect_rows)
         for column in self.intersect_columns():
             if column in self.join_columns:
-                match_cnt = row_cnt
-                col_match = ""
+                col_match = column + "_match"
+                if not self.common_columns_strictly_join_columns():
+                    row_cnt = len(self.intersect_rows)
+                    match_cnt = len(self.intersect_rows[column])
+                else:
+                    row_cnt = (
+                        len(self.intersect_rows)
+                        + len(self.df1_unq_rows)
+                        + len(self.df2_unq_rows)
+                    )
+                    match_cnt = len(self.intersect_rows[column])
                 max_diff = 0.0
                 null_diff = 0
             else:
@@ -493,8 +501,16 @@ class Compare(BaseCompare):
             "pertinent" columns, for rows that don't match on the provided
             column.
         """
-        row_cnt = self.intersect_rows.shape[0]
-        col_match = self.intersect_rows[column + "_match"]
+        if not self.common_columns_strictly_join_columns():
+            row_cnt = self.intersect_rows.shape[0]
+            col_match = self.intersect_rows[column + "_match"]
+        else:
+            row_cnt = (
+                len(self.intersect_rows)
+                + len(self.df1_unq_rows)
+                + len(self.df2_unq_rows)
+            )
+            col_match = self.intersect_rows[column]
         match_cnt = col_match.sum()
         sample_count = min(sample_count, row_cnt - match_cnt)
         sample = self.intersect_rows[~col_match].sample(sample_count)

--- a/datacompy/core.py
+++ b/datacompy/core.py
@@ -481,7 +481,7 @@ class Compare(BaseCompare):
 
     def sample_mismatch(
         self, column: str, sample_count: int = 10, for_display: bool = False
-    ) -> pd.DataFrame:
+    ) -> pd.DataFrame | None:
         """Return sample mismatches.
 
         Gets a sub-dataframe which contains the identifying

--- a/datacompy/core.py
+++ b/datacompy/core.py
@@ -541,7 +541,7 @@ class Compare(BaseCompare):
                 + len(self.df2_unq_rows)
             )
             col_match = self.intersect_rows[column]
-            match_cnt = col_match.sum()
+            match_cnt = col_match.count()
             sample_count = min(sample_count, row_cnt - match_cnt)
             sample = pd.concat(
                 [self.df1_unq_rows[[column]], self.df2_unq_rows[[column]]]
@@ -601,6 +601,13 @@ class Compare(BaseCompare):
                     LOG.debug(
                         f"Column {orig_col_name} is equal in df1 and df2. It will not be added to the result."
                     )
+        if len(match_list) == 0:
+            return pd.concat(
+                [
+                    self.df1_unq_rows[self.join_columns],
+                    self.df2_unq_rows[self.join_columns],
+                ]
+            )
 
         mm_bool = self.intersect_rows[match_list].all(axis="columns")
         return self.intersect_rows[~mm_bool][self.join_columns + return_list]

--- a/datacompy/polars.py
+++ b/datacompy/polars.py
@@ -536,7 +536,7 @@ class PolarsCompare(BaseCompare):
                 + len(self.df2_unq_rows)
             )
             col_match = self.intersect_rows[column]
-            match_cnt = col_match.sum()
+            match_cnt = col_match.count()
             sample_count = min(sample_count, row_cnt - match_cnt)
             sample = pl.concat(
                 [self.df1_unq_rows[[column]], self.df2_unq_rows[[column]]]
@@ -600,12 +600,12 @@ class PolarsCompare(BaseCompare):
                     self.df2_unq_rows.select(self.join_columns),
                 ]
             )
-        else:
-            return (
-                self.intersect_rows.with_columns(__all=pl.all_horizontal(match_list))
-                .filter(pl.col("__all") != True)  # noqa: E712
-                .select(self.join_columns + return_list)
-            )
+
+        return (
+            self.intersect_rows.with_columns(__all=pl.all_horizontal(match_list))
+            .filter(pl.col("__all") != True)  # noqa: E712
+            .select(self.join_columns + return_list)
+        )
 
     def report(
         self,

--- a/datacompy/polars.py
+++ b/datacompy/polars.py
@@ -594,6 +594,7 @@ class PolarsCompare(BaseCompare):
                         f"Column {orig_col_name} is equal in df1 and df2. It will not be added to the result."
                     )
         if len(match_list) == 0:
+            LOG.info("No match columns found, returning mismatches based on unq_rows")
             return pl.concat(
                 [
                     self.df1_unq_rows.select(self.join_columns),

--- a/datacompy/polars.py
+++ b/datacompy/polars.py
@@ -83,8 +83,8 @@ class PolarsCompare(BaseCompare):
 
     def __init__(
         self,
-        df1: "pl.DataFrame",
-        df2: "pl.DataFrame",
+        df1: pl.DataFrame,
+        df2: pl.DataFrame,
         join_columns: List[str] | str,
         abs_tol: float = 0,
         rel_tol: float = 0,
@@ -126,12 +126,12 @@ class PolarsCompare(BaseCompare):
         self._compare(ignore_spaces=ignore_spaces, ignore_case=ignore_case)
 
     @property
-    def df1(self) -> "pl.DataFrame":
+    def df1(self) -> pl.DataFrame:
         """Get the first dataframe."""
         return self._df1
 
     @df1.setter
-    def df1(self, df1: "pl.DataFrame") -> None:
+    def df1(self, df1: pl.DataFrame) -> None:
         """Check that it is a dataframe and has the join columns."""
         self._df1 = df1
         self._validate_dataframe(
@@ -139,12 +139,12 @@ class PolarsCompare(BaseCompare):
         )
 
     @property
-    def df2(self) -> "pl.DataFrame":
+    def df2(self) -> pl.DataFrame:
         """Get the second dataframe."""
         return self._df2
 
     @df2.setter
-    def df2(self, df2: "pl.DataFrame") -> None:
+    def df2(self, df2: pl.DataFrame) -> None:
         """Check that it is a dataframe and has the join columns."""
         self._df2 = df2
         self._validate_dataframe(
@@ -331,14 +331,23 @@ class PolarsCompare(BaseCompare):
         null_diff: int | float
 
         LOG.debug("Comparing intersection")
-        row_cnt = len(self.intersect_rows)
         for column in self.intersect_columns():
             if column in self.join_columns:
-                match_cnt = row_cnt
-                col_match = ""
+                col_match = column + "_match"
+                if not self.only_join_columns():
+                    row_cnt = len(self.intersect_rows)
+                    match_cnt = len(self.intersect_rows[column])
+                else:
+                    row_cnt = (
+                        len(self.intersect_rows)
+                        + len(self.df1_unq_rows)
+                        + len(self.df2_unq_rows)
+                    )
+                    match_cnt = len(self.intersect_rows[column])
                 max_diff = 0.0
                 null_diff = 0
             else:
+                row_cnt = len(self.intersect_rows)
                 col_1 = column + "_" + self.df1_name
                 col_2 = column + "_" + self.df2_name
                 col_match = column + "_match"
@@ -429,6 +438,8 @@ class PolarsCompare(BaseCompare):
 
     def intersect_rows_match(self) -> bool:
         """Check whether the intersect rows all match."""
+        if self.intersect_rows.is_empty():
+            return False
         actual_length = self.intersect_rows.shape[0]
         return self.count_matching_rows() == actual_length
 
@@ -471,7 +482,7 @@ class PolarsCompare(BaseCompare):
 
     def sample_mismatch(
         self, column: str, sample_count: int = 10, for_display: bool = False
-    ) -> "pl.DataFrame":
+    ) -> pl.DataFrame | None:
         """Return sample mismatches.
 
         Get a sub-dataframe which contains the identifying
@@ -493,29 +504,46 @@ class PolarsCompare(BaseCompare):
             A sample of the intersection dataframe, containing only the
             "pertinent" columns, for rows that don't match on the provided
             column.
-        """
-        row_cnt = self.intersect_rows.shape[0]
-        col_match = self.intersect_rows[column + "_match"]
-        match_cnt = col_match.sum()
-        sample_count = min(sample_count, row_cnt - match_cnt)  # type: ignore
-        sample = self.intersect_rows.filter(
-            pl.col(column + "_match") != True  # noqa: E712
-        ).sample(sample_count)
-        return_cols = [
-            *self.join_columns,
-            column + "_" + self.df1_name,
-            column + "_" + self.df2_name,
-        ]
-        to_return = sample[return_cols]
-        if for_display:
-            to_return.columns = [
-                *self.join_columns,
-                column + " (" + self.df1_name + ")",
-                column + " (" + self.df2_name + ")",
-            ]
-        return to_return
 
-    def all_mismatch(self, ignore_matching_cols: bool = False) -> "pl.DataFrame":
+        None
+            When the column being requested is not an intersecting column between dataframes.
+        """
+        if not self.only_join_columns() and column not in self.join_columns:
+            row_cnt = self.intersect_rows.shape[0]
+            col_match = self.intersect_rows[column + "_match"]
+            match_cnt = col_match.sum()
+            sample_count = min(sample_count, row_cnt - match_cnt)  # type: ignore
+            sample = self.intersect_rows.filter(
+                pl.col(column + "_match") != True  # noqa: E712
+            ).sample(sample_count)
+            return_cols = [
+                *self.join_columns,
+                column + "_" + self.df1_name,
+                column + "_" + self.df2_name,
+            ]
+            to_return = sample[return_cols]
+            if for_display:
+                to_return.columns = [
+                    *self.join_columns,
+                    column + " (" + self.df1_name + ")",
+                    column + " (" + self.df2_name + ")",
+                ]
+            return to_return
+        else:
+            row_cnt = (
+                len(self.intersect_rows)
+                + len(self.df1_unq_rows)
+                + len(self.df2_unq_rows)
+            )
+            col_match = self.intersect_rows[column]
+            match_cnt = col_match.sum()
+            sample_count = min(sample_count, row_cnt - match_cnt)
+            sample = pl.concat(
+                [self.df1_unq_rows[[column]], self.df2_unq_rows[[column]]]
+            ).sample(sample_count)
+            return sample
+
+    def all_mismatch(self, ignore_matching_cols: bool = False) -> pl.DataFrame:
         """Get all rows with any columns that have a mismatch.
 
         Returns all df1 and df2 versions of the columns and join
@@ -533,6 +561,10 @@ class PolarsCompare(BaseCompare):
         """
         match_list = []
         return_list = []
+        if self.only_join_columns():
+            LOG.info("Only join keys in data, returning mismatches based on unq_rows")
+            return pl.concat([self.df1_unq_rows, self.df2_unq_rows])
+
         for col in self.intersect_rows.columns:
             if col.endswith("_match"):
                 orig_col_name = col[:-6]
@@ -561,11 +593,19 @@ class PolarsCompare(BaseCompare):
                     LOG.debug(
                         f"Column {orig_col_name} is equal in df1 and df2. It will not be added to the result."
                     )
-        return (
-            self.intersect_rows.with_columns(__all=pl.all_horizontal(match_list))
-            .filter(pl.col("__all") != True)  # noqa: E712
-            .select(self.join_columns + return_list)
-        )
+        if len(match_list) == 0:
+            return pl.concat(
+                [
+                    self.df1_unq_rows.select(self.join_columns),
+                    self.df2_unq_rows.select(self.join_columns),
+                ]
+            )
+        else:
+            return (
+                self.intersect_rows.with_columns(__all=pl.all_horizontal(match_list))
+                .filter(pl.col("__all") != True)  # noqa: E712
+                .select(self.join_columns + return_list)
+            )
 
     def report(
         self,
@@ -595,7 +635,7 @@ class PolarsCompare(BaseCompare):
             The report, formatted kinda nicely.
         """
 
-        def df_to_str(pdf: "pl.DataFrame") -> str:
+        def df_to_str(pdf: pl.DataFrame) -> str:
             return pdf.to_pandas().to_string()
 
         # Header
@@ -887,7 +927,7 @@ def compare_string_and_date_columns(
 
 
 def get_merged_columns(
-    original_df: "pl.DataFrame", merged_df: "pl.DataFrame", suffix: str
+    original_df: pl.DataFrame, merged_df: pl.DataFrame, suffix: str
 ) -> List[str]:
     """Get the columns from an original dataframe, in the new merged dataframe.
 
@@ -936,7 +976,7 @@ def calculate_max_diff(col_1: "pl.Series", col_2: "pl.Series") -> float:
 
 
 def generate_id_within_group(
-    dataframe: "pl.DataFrame", join_columns: List[str]
+    dataframe: pl.DataFrame, join_columns: List[str]
 ) -> "pl.Series":
     """Generate an ID column that can be used to deduplicate identical rows.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ maintainers = [
   { name="Raymond Haffar", email="raymond.haffar@capitalone.com" },
 ]
 license = {text = "Apache Software License"}
-dependencies = ["pandas<=2.2.3,>=0.25.0", "numpy<=2.2.3,>=1.22.0", "ordered-set<=4.1.0,>=4.0.2", "polars[pandas]<=1.22.0,>=0.20.4"]
+dependencies = ["pandas<=2.2.3,>=0.25.0", "numpy<=2.2.3,>=1.22.0", "ordered-set<=4.1.0,>=4.0.2", "polars[pandas]<=1.23.0,>=0.20.4"]
 requires-python = ">=3.10.0"
 classifiers = [
     "Intended Audience :: Developers",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1383,12 +1383,17 @@ def test_full_join_counts_no_matches():
     assert compare.count_matching_rows() == 0
     assert_frame_equal(
         compare.sample_mismatch(column="a").sort_index(),
-        pd.concat(
-            [compare.df1_unq_rows[["a"]], compare.df2_unq_rows[["a"]]]
-        ).sort_index(),
+        pd.DataFrame([1, 1, 1, 1], columns=["a"]),
     )
     assert_frame_equal(
-        compare.all_mismatch(), pd.concat([compare.df1_unq_rows, compare.df2_unq_rows])
+        compare.sample_mismatch(column="b").sort_index(),
+        pd.DataFrame([2, 3, 4, 5], columns=["b"]),
+    )
+    assert_frame_equal(
+        compare.all_mismatch(),
+        pd.DataFrame(
+            [{"a": 1, "b": 2}, {"a": 1, "b": 3}, {"a": 1, "b": 4}, {"a": 1, "b": 5}]
+        ),
     )
 
 
@@ -1402,13 +1407,21 @@ def test_full_join_counts_some_matches():
     assert compare.intersect_rows_match()
     assert compare.count_matching_rows() == 1
     assert_frame_equal(
-        compare.sample_mismatch(column="a").sort_index(),
-        pd.concat(
-            [compare.df1_unq_rows[["a"]], compare.df2_unq_rows[["a"]]]
-        ).sort_index(),
+        compare.sample_mismatch(column="a").sort_index().reset_index(drop=True),
+        pd.DataFrame([1, 1], columns=["a"]),
     )
     assert_frame_equal(
-        compare.all_mismatch(), pd.concat([compare.df1_unq_rows, compare.df2_unq_rows])
+        compare.sample_mismatch(column="b").sort_index().reset_index(drop=True),
+        pd.DataFrame([3, 5], columns=["b"]),
+    )
+    assert_frame_equal(
+        compare.all_mismatch().sort_index().reset_index(drop=True),
+        pd.DataFrame(
+            [
+                {"a": 1, "b": 3},
+                {"a": 1, "b": 5},
+            ]
+        ),
     )
 
 
@@ -1422,12 +1435,19 @@ def test_non_full_join_counts_no_matches():
     assert not compare.intersect_rows_match()
     assert compare.count_matching_rows() == 0
     assert_frame_equal(
-        compare.sample_mismatch(column="a").sort_index(),
-        pd.concat(
-            [compare.df1_unq_rows[["a"]], compare.df2_unq_rows[["a"]]]
-        ).sort_index(),
+        compare.sample_mismatch(column="a").sort_index().reset_index(drop=True),
+        pd.DataFrame([1, 1, 1, 1], columns=["a"]),
     )
-    assert compare.all_mismatch().empty  # all_mismatch should be empty
+    assert_frame_equal(
+        compare.sample_mismatch(column="b").sort_index().reset_index(drop=True),
+        pd.DataFrame([2, 3, 4, 5], columns=["b"]),
+    )
+    assert_frame_equal(
+        compare.all_mismatch().sort_index().reset_index(drop=True),
+        pd.DataFrame(
+            [{"a": 1, "b": 2}, {"a": 1, "b": 3}, {"a": 1, "b": 4}, {"a": 1, "b": 5}]
+        ),
+    )
 
 
 def test_non_full_join_counts_some_matches():
@@ -1440,9 +1460,19 @@ def test_non_full_join_counts_some_matches():
     assert compare.intersect_rows_match()
     assert compare.count_matching_rows() == 1
     assert_frame_equal(
-        compare.sample_mismatch(column="a").sort_index(),
-        pd.concat(
-            [compare.df1_unq_rows[["a"]], compare.df2_unq_rows[["a"]]]
-        ).sort_index(),
+        compare.sample_mismatch(column="a").sort_index().reset_index(drop=True),
+        pd.DataFrame([1, 1], columns=["a"]),
     )
-    assert compare.all_mismatch().empty  # all_mismatch should be empty
+    assert_frame_equal(
+        compare.sample_mismatch(column="b").sort_index().reset_index(drop=True),
+        pd.DataFrame([3, 5], columns=["b"]),
+    )
+    assert_frame_equal(
+        compare.all_mismatch().sort_index().reset_index(drop=True),
+        pd.DataFrame(
+            [
+                {"a": 1, "b": 3},
+                {"a": 1, "b": 5},
+            ]
+        ),
+    )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1379,7 +1379,7 @@ def test_full_join_counts_no_matches():
     assert not compare.matches()
     assert compare.all_columns_match()
     assert not compare.all_rows_overlap()
-    assert compare.intersect_rows_match()
+    assert not compare.intersect_rows_match()
     assert compare.count_matching_rows() == 0
     assert_frame_equal(
         compare.sample_mismatch(column="a").sort_index(),
@@ -1410,3 +1410,39 @@ def test_full_join_counts_some_matches():
     assert_frame_equal(
         compare.all_mismatch(), pd.concat([compare.df1_unq_rows, compare.df2_unq_rows])
     )
+
+
+def test_non_full_join_counts_no_matches():
+    df1 = pd.DataFrame([{"a": 1, "b": 2, "c": 4}, {"a": 1, "b": 3, "c": 4}])
+    df2 = pd.DataFrame([{"a": 1, "b": 4, "d": 5}, {"a": 1, "b": 5, "d": 5}])
+    compare = datacompy.Compare(df1, df2, ["a", "b"], ignore_spaces=False)
+    assert not compare.matches()
+    assert not compare.all_columns_match()
+    assert not compare.all_rows_overlap()
+    assert not compare.intersect_rows_match()
+    assert compare.count_matching_rows() == 0
+    assert_frame_equal(
+        compare.sample_mismatch(column="a").sort_index(),
+        pd.concat(
+            [compare.df1_unq_rows[["a"]], compare.df2_unq_rows[["a"]]]
+        ).sort_index(),
+    )
+    assert compare.all_mismatch().empty  # all_mismatch should be empty
+
+
+def test_non_full_join_counts_some_matches():
+    df1 = pd.DataFrame([{"a": 1, "b": 2, "c": 4}, {"a": 1, "b": 3, "c": 4}])
+    df2 = pd.DataFrame([{"a": 1, "b": 2, "d": 5}, {"a": 1, "b": 5, "d": 5}])
+    compare = datacompy.Compare(df1, df2, ["a", "b"], ignore_spaces=False)
+    assert not compare.matches()
+    assert not compare.all_columns_match()
+    assert not compare.all_rows_overlap()
+    assert compare.intersect_rows_match()
+    assert compare.count_matching_rows() == 1
+    assert_frame_equal(
+        compare.sample_mismatch(column="a").sort_index(),
+        pd.concat(
+            [compare.df1_unq_rows[["a"]], compare.df2_unq_rows[["a"]]]
+        ).sort_index(),
+    )
+    assert compare.all_mismatch().empty  # all_mismatch should be empty

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -28,7 +28,7 @@ import datacompy
 import numpy as np
 import pandas as pd
 import pytest
-from pandas.testing import assert_series_equal
+from pandas.testing import assert_frame_equal, assert_series_equal
 from pytest import raises
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
@@ -1370,3 +1370,43 @@ def test_save_html(mock_render):
         compare.report(html_file="test.html")
         assert mock_render.call_count == 4
         m.assert_called_with("test.html", "w")
+
+
+def test_full_join_counts_no_matches():
+    df1 = pd.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 3}])
+    df2 = pd.DataFrame([{"a": 1, "b": 4}, {"a": 1, "b": 5}])
+    compare = datacompy.Compare(df1, df2, ["a", "b"], ignore_spaces=False)
+    assert not compare.matches()
+    assert compare.all_columns_match()
+    assert not compare.all_rows_overlap()
+    assert compare.intersect_rows_match()
+    assert compare.count_matching_rows() == 0
+    assert_frame_equal(
+        compare.sample_mismatch(column="a").sort_index(),
+        pd.concat(
+            [compare.df1_unq_rows[["a"]], compare.df2_unq_rows[["a"]]]
+        ).sort_index(),
+    )
+    assert_frame_equal(
+        compare.all_mismatch(), pd.concat([compare.df1_unq_rows, compare.df2_unq_rows])
+    )
+
+
+def test_full_join_counts_some_matches():
+    df1 = pd.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 3}])
+    df2 = pd.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 5}])
+    compare = datacompy.Compare(df1, df2, ["a", "b"], ignore_spaces=False)
+    assert not compare.matches()
+    assert compare.all_columns_match()
+    assert not compare.all_rows_overlap()
+    assert compare.intersect_rows_match()
+    assert compare.count_matching_rows() == 1
+    assert_frame_equal(
+        compare.sample_mismatch(column="a").sort_index(),
+        pd.concat(
+            [compare.df1_unq_rows[["a"]], compare.df2_unq_rows[["a"]]]
+        ).sort_index(),
+    )
+    assert_frame_equal(
+        compare.all_mismatch(), pd.concat([compare.df1_unq_rows, compare.df2_unq_rows])
+    )

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -1343,11 +1343,18 @@ def test_full_join_counts_no_matches():
     assert not compare.intersect_rows_match()
     assert compare.count_matching_rows() == 0
     assert_frame_equal(
-        compare.sample_mismatch(column="a"),
-        pl.concat([compare.df1_unq_rows[["a"]], compare.df2_unq_rows[["a"]]]),
+        compare.sample_mismatch(column="a").sort("a"),
+        pl.DataFrame([1, 1, 1, 1], schema=["a"]),
     )
     assert_frame_equal(
-        compare.all_mismatch(), pl.concat([compare.df1_unq_rows, compare.df2_unq_rows])
+        compare.sample_mismatch(column="b").sort("b"),
+        pl.DataFrame([2, 3, 4, 5], schema=["b"]),
+    )
+    assert_frame_equal(
+        compare.all_mismatch().sort(["a", "b"]),
+        pl.DataFrame(
+            [{"a": 1, "b": 2}, {"a": 1, "b": 3}, {"a": 1, "b": 4}, {"a": 1, "b": 5}]
+        ),
     )
 
 
@@ -1361,11 +1368,21 @@ def test_full_join_counts_some_matches():
     assert compare.intersect_rows_match()
     assert compare.count_matching_rows() == 1
     assert_frame_equal(
-        compare.sample_mismatch(column="a"),
-        pl.concat([compare.df1_unq_rows[["a"]], compare.df2_unq_rows[["a"]]]),
+        compare.sample_mismatch(column="a").sort("a"),
+        pl.DataFrame([1, 1], schema=["a"]),
     )
     assert_frame_equal(
-        compare.all_mismatch(), pl.concat([compare.df1_unq_rows, compare.df2_unq_rows])
+        compare.sample_mismatch(column="b").sort("b"),
+        pl.DataFrame([3, 5], schema=["b"]),
+    )
+    assert_frame_equal(
+        compare.all_mismatch().sort(["a", "b"]),
+        pl.DataFrame(
+            [
+                {"a": 1, "b": 3},
+                {"a": 1, "b": 5},
+            ]
+        ),
     )
 
 
@@ -1379,12 +1396,18 @@ def test_non_full_join_counts_no_matches():
     assert not compare.intersect_rows_match()
     assert compare.count_matching_rows() == 0
     assert_frame_equal(
-        compare.sample_mismatch(column="a"),
-        pl.concat([compare.df1_unq_rows[["a"]], compare.df2_unq_rows[["a"]]]),
+        compare.sample_mismatch(column="a").sort("a"),
+        pl.DataFrame([1, 1, 1, 1], schema=["a"]),
     )
     assert_frame_equal(
-        compare.all_mismatch(),
-        pl.concat([compare.df1_unq_rows[["a", "b"]], compare.df2_unq_rows[["a", "b"]]]),
+        compare.sample_mismatch(column="b").sort("b"),
+        pl.DataFrame([2, 3, 4, 5], schema=["b"]),
+    )
+    assert_frame_equal(
+        compare.all_mismatch().sort(["a", "b"]),
+        pl.DataFrame(
+            [{"a": 1, "b": 2}, {"a": 1, "b": 3}, {"a": 1, "b": 4}, {"a": 1, "b": 5}]
+        ),
     )
 
 
@@ -1398,10 +1421,19 @@ def test_non_full_join_counts_some_matches():
     assert compare.intersect_rows_match()
     assert compare.count_matching_rows() == 1
     assert_frame_equal(
-        compare.sample_mismatch(column="a"),
-        pl.concat([compare.df1_unq_rows[["a"]], compare.df2_unq_rows[["a"]]]),
+        compare.sample_mismatch(column="a").sort("a"),
+        pl.DataFrame([1, 1], schema=["a"]),
     )
     assert_frame_equal(
-        compare.all_mismatch(),
-        pl.concat([compare.df1_unq_rows[["a", "b"]], compare.df2_unq_rows[["a", "b"]]]),
+        compare.sample_mismatch(column="b").sort("b"),
+        pl.DataFrame([3, 5], schema=["b"]),
+    )
+    assert_frame_equal(
+        compare.all_mismatch().sort(["a", "b"]),
+        pl.DataFrame(
+            [
+                {"a": 1, "b": 3},
+                {"a": 1, "b": 5},
+            ]
+        ),
     )


### PR DESCRIPTION
Changes in this PR are for Pandas and Polars only.

- addition of `only_join_columns` which indicates if all the columns are join columns. This is a specific corner case which prompted this PR.
- tweaks to `_intersect_compare` metrics (`row_cnt`, `match_cnt`)where `only_join_columns` corner case is present.
- `intersect_rows_match` should return `False` if the DataFrame is empty.
- `sample_mismatch` needs to account for the corner case situation rather than look for `column + "_match"`
- `all_mismatch` needs to account for the corner case situation rather than look for `column + "_match"`

@rhaffar I've made a couple of more tweaks after hitting some bugs here and there from the last time you checked. Would appreciate another set of eyes here. 

I'm hoping this covers all the weird corner cases where:
1. all columns are join columns
2. there are no intersecting columns to compare on (aside from the join columns. eg: df1: [a, b, c], df2: [a,b, d], join: [a, b])