### PR TITLE
Add analyze_join_columns / get_recommended_join_columns helper functions

### DIFF
--- a/datacompy/helper.py
+++ b/datacompy/helper.py
@@ -1,0 +1,127 @@
+"""
+Helper functions for DataComPy.
+
+This module contains standalone utility functions that can be used
+independently of the main comparison classes.
+"""
+
+import logging
+from typing import Any, Dict, List
+
+import pandas as pd
+
+LOG = logging.getLogger(__name__)
+
+
+def analyze_join_columns(
+    df1: pd.DataFrame, df2: pd.DataFrame, uniqueness_threshold=90, allow_nulls=False
+) -> List[Dict[str, Any]]:
+    """Get statistics for potential join columns to help select appropriate join keys.
+
+    Analyzes columns present in both DataFrames to help users select
+    appropriate join keys. Provides statistics about uniqueness and null
+    values, and recommends columns suitable for joining.
+
+    Parameters
+    ----------
+    df1 : pd.DataFrame
+        First DataFrame to compare
+    df2 : pd.DataFrame
+        Second DataFrame to compare
+    uniqueness_threshold : float, default=90
+        Minimum percentage of uniqueness required in both dataframes for a column
+        to be recommended as a join key
+    allow_nulls : bool, default=False
+        Whether to recommend columns containing null values
+
+    Returns
+    -------
+    List[Dict]
+        List of dictionaries containing column statistics:
+            - Column: Column name
+            - Type: Data type
+            - Unique Values: Count and percentage for both frames
+            - Nulls: Null counts
+            - Recommended: Indicator if column is recommended for joining
+              (high uniqueness, no nulls by default)
+    """
+    try:
+        if df1 is None or df2 is None:
+            LOG.warning("Cannot analyze join columns: one or both DataFrames are None")
+            return []
+
+        common_columns = sorted(set(df1.columns) & set(df2.columns))
+        df1_len = len(df1)
+        df2_len = len(df2)
+
+        join_stats = []
+        for col in common_columns:
+            unique_vals_base = df1[col].nunique()
+            unique_vals_compare = df2[col].nunique()
+
+            null_count_base = df1[col].isna().sum()
+            null_count_compare = df2[col].isna().sum()
+
+            uniqueness_base = (unique_vals_base / df1_len * 100) if df1_len > 0 else 0
+            uniqueness_compare = (
+                (unique_vals_compare / df2_len * 100) if df2_len > 0 else 0
+            )
+
+            is_good_key = (
+                uniqueness_base > uniqueness_threshold
+                and uniqueness_compare > uniqueness_threshold
+                and (allow_nulls or (null_count_base == 0 and null_count_compare == 0))
+            )
+
+            join_stats.append(
+                {
+                    "column": col,
+                    "type": str(df1[col].dtype),
+                    "unique_values_df1": f"{unique_vals_base:,} ({uniqueness_base:.1f}%)",
+                    "unique_values_df2": f"{unique_vals_compare:,} ({uniqueness_compare:.1f}%)",
+                    "nulls_df1": null_count_base,
+                    "nulls_df2": null_count_compare,
+                    "recommended": is_good_key,
+                    "uniqueness_score": min(uniqueness_base, uniqueness_compare),
+                }
+            )
+
+        join_stats.sort(key=lambda x: (-x["uniqueness_score"], x["column"]))
+
+        return [
+            {k: v for k, v in stat.items() if k != "uniqueness_score"}
+            for stat in join_stats
+        ]
+
+    except Exception as e:
+        LOG.error(f"Error analyzing join columns: {e}")
+        return []
+
+
+def get_recommended_join_columns(
+    df1: pd.DataFrame, df2: pd.DataFrame, uniqueness_threshold=90, allow_nulls=False
+) -> List[str]:
+    """Get a list of column names recommended for joining the DataFrames.
+
+    Returns columns that have high uniqueness and no null values
+    based on the analysis from analyze_join_columns().
+
+    Parameters
+    ----------
+    df1 : pd.DataFrame
+        First DataFrame to compare
+    df2 : pd.DataFrame
+        Second DataFrame to compare
+    uniqueness_threshold : float, default=90
+        Minimum percentage of uniqueness required in both dataframes for a column
+        to be recommended as a join key
+    allow_nulls : bool, default=False
+        Whether to recommend columns containing null values
+
+    Returns
+    -------
+    List[str]
+        List of column names recommended for joining
+    """
+    stats = analyze_join_columns(df1, df2, uniqueness_threshold, allow_nulls)
+    return [stat["column"] for stat in stats if stat["recommended"]]

--- a/datacompy/helper.py
+++ b/datacompy/helper.py
@@ -6,15 +6,23 @@ independently of the main comparison classes.
 """
 
 import logging
-from typing import Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict, List, Union
 
 import pandas as pd
+
+if TYPE_CHECKING:
+    import polars as pl
+    import pyspark.sql
+    import snowflake.snowpark as sp
 
 LOG = logging.getLogger(__name__)
 
 
 def analyze_join_columns(
-    df1: pd.DataFrame, df2: pd.DataFrame, uniqueness_threshold=90, allow_nulls=False
+    df1: Union[pd.DataFrame, "pl.DataFrame", "pyspark.sql.DataFrame", "sp.DataFrame"],
+    df2: Union[pd.DataFrame, "pl.DataFrame", "pyspark.sql.DataFrame", "sp.DataFrame"],
+    uniqueness_threshold=90,
+    allow_nulls=False,
 ) -> List[Dict[str, Any]]:
     """Get statistics for potential join columns to help select appropriate join keys.
 
@@ -24,10 +32,10 @@ def analyze_join_columns(
 
     Parameters
     ----------
-    df1 : pd.DataFrame
-        First DataFrame to compare
-    df2 : pd.DataFrame
-        Second DataFrame to compare
+    df1 : Union[pd.DataFrame, pl.DataFrame, pyspark.sql.DataFrame, sp.DataFrame]
+        First DataFrame to compare (pandas, polars, spark, or snowflake)
+    df2 : Union[pd.DataFrame, pl.DataFrame, pyspark.sql.DataFrame, sp.DataFrame]
+        Second DataFrame to compare (pandas, polars, spark, or snowflake)
     uniqueness_threshold : float, default=90
         Minimum percentage of uniqueness required in both dataframes for a column
         to be recommended as a join key
@@ -38,11 +46,13 @@ def analyze_join_columns(
     -------
     List[Dict]
         List of dictionaries containing column statistics:
-            - Column: Column name
-            - Type: Data type
-            - Unique Values: Count and percentage for both frames
-            - Nulls: Null counts
-            - Recommended: Indicator if column is recommended for joining
+            - column: Column name
+            - type: Data type
+            - unique_values_df1: Count and percentage for first DataFrame
+            - unique_values_df2: Count and percentage for second DataFrame
+            - nulls_df1: Null count in first DataFrame
+            - nulls_df2: Null count in second DataFrame
+            - recommended: Boolean indicating if column is recommended for joining
               (high uniqueness, no nulls by default)
     """
     try:
@@ -50,68 +60,259 @@ def analyze_join_columns(
             LOG.warning("Cannot analyze join columns: one or both DataFrames are None")
             return []
 
-        common_columns = sorted(set(df1.columns) & set(df2.columns))
-        df1_len = len(df1)
-        df2_len = len(df2)
+        df_type = _detect_dataframe_type(df1)
 
-        join_stats = []
-        for col in common_columns:
-            unique_vals_base = df1[col].nunique()
-            unique_vals_compare = df2[col].nunique()
-
-            null_count_base = df1[col].isna().sum()
-            null_count_compare = df2[col].isna().sum()
-
-            uniqueness_base = (unique_vals_base / df1_len * 100) if df1_len > 0 else 0
-            uniqueness_compare = (
-                (unique_vals_compare / df2_len * 100) if df2_len > 0 else 0
-            )
-
-            is_good_key = (
-                uniqueness_base > uniqueness_threshold
-                and uniqueness_compare > uniqueness_threshold
-                and (allow_nulls or (null_count_base == 0 and null_count_compare == 0))
-            )
-
-            join_stats.append(
-                {
-                    "column": col,
-                    "type": str(df1[col].dtype),
-                    "unique_values_df1": f"{unique_vals_base:,} ({uniqueness_base:.1f}%)",
-                    "unique_values_df2": f"{unique_vals_compare:,} ({uniqueness_compare:.1f}%)",
-                    "nulls_df1": null_count_base,
-                    "nulls_df2": null_count_compare,
-                    "recommended": is_good_key,
-                    "uniqueness_score": min(uniqueness_base, uniqueness_compare),
-                }
-            )
-
-        join_stats.sort(key=lambda x: (-x["uniqueness_score"], x["column"]))
-
-        return [
-            {k: v for k, v in stat.items() if k != "uniqueness_score"}
-            for stat in join_stats
-        ]
+        if df_type == "pandas":
+            return _analyze_join_columns_pandas(df1, df2, uniqueness_threshold, allow_nulls)
+        elif df_type == "polars":
+            return _analyze_join_columns_polars(df1, df2, uniqueness_threshold, allow_nulls)
+        elif df_type == "spark":
+            return _analyze_join_columns_spark(df1, df2, uniqueness_threshold, allow_nulls)
+        elif df_type == "snowflake":
+            return _analyze_join_columns_snowflake(df1, df2, uniqueness_threshold, allow_nulls)
+        else:
+            LOG.error(f"Unsupported DataFrame type: {df_type}")
+            return []
 
     except Exception as e:
         LOG.error(f"Error analyzing join columns: {e}")
         return []
 
 
-def get_recommended_join_columns(
-    df1: pd.DataFrame, df2: pd.DataFrame, uniqueness_threshold=90, allow_nulls=False
-) -> List[str]:
-    """Get a list of column names recommended for joining the DataFrames.
+def _detect_dataframe_type(df):
+    """Detect the type of DataFrame being used.
 
-    Returns columns that have high uniqueness and no null values
-    based on the analysis from analyze_join_columns().
+    Returns
+    -------
+        str: One of 'pandas', 'polars', 'spark', 'snowflake', or 'unknown'
+    """
+    df_type = type(df).__module__.split('.')[0]
+
+    type_map = {
+        "pandas": "pandas",
+        "polars": "polars",
+        "pyspark": "spark",
+        "snowflake": "snowflake"
+    }
+
+    return type_map.get(df_type, "unknown")
+
+
+def _analyze_join_columns_pandas(
+    df1: pd.DataFrame, df2: pd.DataFrame, uniqueness_threshold=90, allow_nulls=False
+) -> List[Dict[str, Any]]:
+    """Analyze potential join columns in pandas DataFrames."""
+    common_columns = sorted(set(df1.columns) & set(df2.columns))
+    df1_len = len(df1)
+    df2_len = len(df2)
+
+    join_stats = []
+    for col in common_columns:
+        unique_vals_base = df1[col].nunique()
+        unique_vals_compare = df2[col].nunique()
+
+        null_count_base = df1[col].isna().sum()
+        null_count_compare = df2[col].isna().sum()
+
+        uniqueness_base = (unique_vals_base / df1_len * 100) if df1_len > 0 else 0
+        uniqueness_compare = (
+            (unique_vals_compare / df2_len * 100) if df2_len > 0 else 0
+        )
+
+        is_good_key = (
+            uniqueness_base > uniqueness_threshold
+            and uniqueness_compare > uniqueness_threshold
+            and (allow_nulls or (null_count_base == 0 and null_count_compare == 0))
+        )
+
+        join_stats.append(
+            {
+                "column": col,
+                "type": str(df1[col].dtype),
+                "unique_values_df1": f"{unique_vals_base:,} ({uniqueness_base:.1f}%)",
+                "unique_values_df2": f"{unique_vals_compare:,} ({uniqueness_compare:.1f}%)",
+                "nulls_df1": null_count_base,
+                "nulls_df2": null_count_compare,
+                "recommended": is_good_key,
+                "uniqueness_score": min(uniqueness_base, uniqueness_compare),
+            }
+        )
+
+    join_stats.sort(key=lambda x: (-x["uniqueness_score"], x["column"]))
+
+    return [
+        {k: v for k, v in stat.items() if k != "uniqueness_score"}
+        for stat in join_stats
+    ]
+
+
+def _analyze_join_columns_polars(
+    df1, df2, uniqueness_threshold=90, allow_nulls=False
+) -> List[Dict[str, Any]]:
+    """Analyze potential join columns in polars DataFrames."""
+    common_columns = sorted(set(df1.columns) & set(df2.columns))
+    df1_len = len(df1)
+    df2_len = len(df2)
+
+    join_stats = []
+    for col in common_columns:
+        unique_vals_base = df1[col].n_unique()
+        unique_vals_compare = df2[col].n_unique()
+
+        null_count_base = df1[col].is_null().sum()
+        null_count_compare = df2[col].is_null().sum()
+
+        uniqueness_base = (unique_vals_base / df1_len * 100) if df1_len > 0 else 0
+        uniqueness_compare = (
+            (unique_vals_compare / df2_len * 100) if df2_len > 0 else 0
+        )
+
+        is_good_key = (
+            uniqueness_base > uniqueness_threshold
+            and uniqueness_compare > uniqueness_threshold
+            and (allow_nulls or (null_count_base == 0 and null_count_compare == 0))
+        )
+
+        join_stats.append(
+            {
+                "column": col,
+                "type": str(df1[col].dtype),
+                "unique_values_df1": f"{unique_vals_base:,} ({uniqueness_base:.1f}%)",
+                "unique_values_df2": f"{unique_vals_compare:,} ({uniqueness_compare:.1f}%)",
+                "nulls_df1": null_count_base,
+                "nulls_df2": null_count_compare,
+                "recommended": is_good_key,
+                "uniqueness_score": min(uniqueness_base, uniqueness_compare),
+            }
+        )
+
+    join_stats.sort(key=lambda x: (-x["uniqueness_score"], x["column"]))
+
+    return [
+        {k: v for k, v in stat.items() if k != "uniqueness_score"}
+        for stat in join_stats
+    ]
+
+
+def _analyze_join_columns_spark(
+    df1, df2, uniqueness_threshold=90, allow_nulls=False
+) -> List[Dict[str, Any]]:
+    """Analyze potential join columns in spark DataFrames."""
+    import pyspark.sql.functions as F
+
+    common_columns = sorted(set(df1.columns) & set(df2.columns))
+    df1_len = df1.count()
+    df2_len = df2.count()
+
+    join_stats = []
+    for col in common_columns:
+        unique_vals_base = df1.select(col).distinct().count()
+        unique_vals_compare = df2.select(col).distinct().count()
+
+        null_count_base = df1.filter(F.col(col).isNull()).count()
+        null_count_compare = df2.filter(F.col(col).isNull()).count()
+
+        uniqueness_base = (unique_vals_base / df1_len * 100) if df1_len > 0 else 0
+        uniqueness_compare = (
+            (unique_vals_compare / df2_len * 100) if df2_len > 0 else 0
+        )
+
+        is_good_key = (
+            uniqueness_base > uniqueness_threshold
+            and uniqueness_compare > uniqueness_threshold
+            and (allow_nulls or (null_count_base == 0 and null_count_compare == 0))
+        )
+
+        col_type = next(f.dataType for f in df1.schema.fields if f.name == col)
+
+        join_stats.append(
+            {
+                "column": col,
+                "type": str(col_type),
+                "unique_values_df1": f"{unique_vals_base:,} ({uniqueness_base:.1f}%)",
+                "unique_values_df2": f"{unique_vals_compare:,} ({uniqueness_compare:.1f}%)",
+                "nulls_df1": null_count_base,
+                "nulls_df2": null_count_compare,
+                "recommended": is_good_key,
+                "uniqueness_score": min(uniqueness_base, uniqueness_compare),
+            }
+        )
+
+    join_stats.sort(key=lambda x: (-x["uniqueness_score"], x["column"]))
+
+    return [
+        {k: v for k, v in stat.items() if k != "uniqueness_score"}
+        for stat in join_stats
+    ]
+
+
+def _analyze_join_columns_snowflake(
+    df1, df2, uniqueness_threshold=90, allow_nulls=False
+) -> List[Dict[str, Any]]:
+    """Analyze potential join columns in snowflake DataFrames."""
+    import snowflake.snowpark.functions as F
+
+    common_columns = sorted(set(df1.columns) & set(df2.columns))
+    df1_len = df1.count()
+    df2_len = df2.count()
+
+    join_stats = []
+    for col in common_columns:
+        unique_vals_base = df1.select(col).distinct().count()
+        unique_vals_compare = df2.select(col).distinct().count()
+
+        null_count_base = df1.filter(F.col(col).is_null()).count()
+        null_count_compare = df2.filter(F.col(col).is_null()).count()
+
+        uniqueness_base = (unique_vals_base / df1_len * 100) if df1_len > 0 else 0
+        uniqueness_compare = (
+            (unique_vals_compare / df2_len * 100) if df2_len > 0 else 0
+        )
+
+        is_good_key = (
+            uniqueness_base > uniqueness_threshold
+            and uniqueness_compare > uniqueness_threshold
+            and (allow_nulls or (null_count_base == 0 and null_count_compare == 0))
+        )
+
+        col_type = next(f.datatype for f in df1.schema.fields if f.name.upper() == col.upper())
+
+        join_stats.append(
+            {
+                "column": col,
+                "type": str(col_type),
+                "unique_values_df1": f"{unique_vals_base:,} ({uniqueness_base:.1f}%)",
+                "unique_values_df2": f"{unique_vals_compare:,} ({uniqueness_compare:.1f}%)",
+                "nulls_df1": null_count_base,
+                "nulls_df2": null_count_compare,
+                "recommended": is_good_key,
+                "uniqueness_score": min(uniqueness_base, uniqueness_compare),
+            }
+        )
+
+    join_stats.sort(key=lambda x: (-x["uniqueness_score"], x["column"]))
+
+    return [
+        {k: v for k, v in stat.items() if k != "uniqueness_score"}
+        for stat in join_stats
+    ]
+
+
+def get_recommended_join_columns(
+    df1: Union[pd.DataFrame, "pl.DataFrame", "pyspark.sql.DataFrame", "sp.DataFrame"],
+    df2: Union[pd.DataFrame, "pl.DataFrame", "pyspark.sql.DataFrame", "sp.DataFrame"],
+    uniqueness_threshold=90,
+    allow_nulls=False
+) -> List[str]:
+    """
+    Get a list of recommended join columns.
 
     Parameters
     ----------
-    df1 : pd.DataFrame
-        First DataFrame to compare
-    df2 : pd.DataFrame
-        Second DataFrame to compare
+    df1 : Union[pd.DataFrame, pl.DataFrame, pyspark.sql.DataFrame, sp.DataFrame]
+        First DataFrame to compare (pandas, polars, spark, or snowflake)
+    df2 : Union[pd.DataFrame, pl.DataFrame, pyspark.sql.DataFrame, sp.DataFrame]
+        Second DataFrame to compare (pandas, polars, spark, or snowflake)
     uniqueness_threshold : float, default=90
         Minimum percentage of uniqueness required in both dataframes for a column
         to be recommended as a join key
@@ -121,7 +322,7 @@ def get_recommended_join_columns(
     Returns
     -------
     List[str]
-        List of column names recommended for joining
+        List of column names that are recommended for joining
     """
     stats = analyze_join_columns(df1, df2, uniqueness_threshold, allow_nulls)
     return [stat["column"] for stat in stats if stat["recommended"]]

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -1,0 +1,184 @@
+"""Test the helper functions."""
+
+import pandas as pd
+from datacompy import Compare
+from datacompy.helper import analyze_join_columns, get_recommended_join_columns
+
+
+def test_analyze_join_columns():
+    df1 = pd.DataFrame({"id": [1, 2, 3, 4, 5], "name": ["a", "b", "c", "d", "e"]})
+    df2 = pd.DataFrame({"id": [1, 2, 3, 4, 5], "name": ["a", "b", "c", "d", "f"]})
+
+    stats = analyze_join_columns(df1, df2)
+    stats_by_column = {stat["column"]: stat for stat in stats}
+
+    assert stats_by_column["id"]["recommended"] == True  # noqa: E712
+    assert stats_by_column["name"]["recommended"] == True  # noqa: E712
+
+    df3 = pd.DataFrame({"id": [1, 1, 1, 1, 1], "name": ["a", "b", "c", "d", "e"]})
+    df4 = pd.DataFrame({"id": [1, 1, 1, 1, 1], "name": ["a", "b", "c", "d", "f"]})
+
+    stats = analyze_join_columns(df3, df4)
+    stats_by_column = {stat["column"]: stat for stat in stats}
+
+    assert stats_by_column["id"]["recommended"] == False  # noqa: E712
+    assert stats_by_column["name"]["recommended"] == True  # noqa: E712
+
+
+def test_analyze_join_columns_with_nulls():
+    # Need 11 rows to achieve >90% uniqueness with nulls
+    df1 = pd.DataFrame(
+        {
+            "id": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+            "name": ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"],
+            "with_nulls": [
+                None,
+                "b",
+                "c",
+                "d",
+                "e",
+                "f",
+                "g",
+                "h",
+                "i",
+                "j",
+                "k",
+            ],  # 10 unique values in 11 rows = 90.9% uniqueness
+        }
+    )
+    df2 = pd.DataFrame(
+        {
+            "id": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12],
+            "name": ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "l"],
+            "with_nulls": [
+                "a",
+                None,
+                "c",
+                "d",
+                "e",
+                "f",
+                "g",
+                "h",
+                "i",
+                "j",
+                "l",
+            ],  # 10 unique values in 11 rows = 90.9% uniqueness
+        }
+    )
+
+    stats = analyze_join_columns(df1, df2)
+    stats_by_column = {stat["column"]: stat for stat in stats}
+    assert stats_by_column["id"]["recommended"] == True  # noqa: E712
+    assert stats_by_column["name"]["recommended"] == True  # noqa: E712
+    assert stats_by_column["with_nulls"]["recommended"] == False  # noqa: E712  # Has nulls, so not recommended
+
+    stats = analyze_join_columns(df1, df2, allow_nulls=True)
+    stats_by_column = {stat["column"]: stat for stat in stats}
+    assert stats_by_column["id"]["recommended"] == True  # noqa: E712
+    assert stats_by_column["name"]["recommended"] == True  # noqa: E712
+    assert stats_by_column["with_nulls"]["recommended"] == True  # noqa: E712  # Allowing nulls, so it's recommended
+
+
+def test_analyze_join_columns_with_threshold():
+    df1 = pd.DataFrame({"id": [1, 2, 3, 1, 2], "name": ["a", "b", "c", "d", "e"]})
+    df2 = pd.DataFrame({"id": [1, 2, 3, 1, 4], "name": ["a", "b", "c", "d", "f"]})
+
+    stats = analyze_join_columns(df1, df2)
+    stats_by_column = {stat["column"]: stat for stat in stats}
+    assert stats_by_column["id"]["recommended"] == False  # noqa: E712
+    assert stats_by_column["name"]["recommended"] == True  # noqa: E712
+
+    stats = analyze_join_columns(df1, df2, uniqueness_threshold=50)
+    stats_by_column = {stat["column"]: stat for stat in stats}
+    assert stats_by_column["id"]["recommended"] == True  # noqa: E712
+    assert stats_by_column["name"]["recommended"] == True  # noqa: E712
+
+
+def test_analyze_join_columns_unique_in_only_one_df():
+    df1 = pd.DataFrame(
+        {
+            "id": [1, 2, 3, 4, 5],  # 100% unique
+            "value": [10, 20, 30, 40, 50],
+        }
+    )
+    df2 = pd.DataFrame(
+        {
+            "id": [1, 2, 3, 1, 2],  # 60% unique, below the default 90% threshold
+            "value": [11, 21, 31, 12, 22],
+        }
+    )
+
+    stats = analyze_join_columns(df1, df2)
+    stats_by_column = {stat["column"]: stat for stat in stats}
+
+    assert stats_by_column["id"]["recommended"] == False  # noqa: E712
+
+    # Using a lower threshold should recommend it
+    stats = analyze_join_columns(df1, df2, uniqueness_threshold=50)
+    stats_by_column = {stat["column"]: stat for stat in stats}
+    assert stats_by_column["id"]["recommended"] == True  # noqa: E712
+
+
+def test_get_recommended_join_columns():
+    df1 = pd.DataFrame(
+        {
+            "id": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+            "name": ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"],
+            "common": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+            "unique_60": [1, 2, 3, 1, 2, 5, 6, 7, 8, 9, 10],
+            "with_nulls": [None, "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"],
+        }
+    )
+    df2 = pd.DataFrame(
+        {
+            "id": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12],
+            "name": ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "l"],
+            "common": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+            "unique_60": [1, 2, 3, 1, 2, 5, 6, 7, 8, 9, 10],
+            "with_nulls": ["a", None, "c", "d", "e", "f", "g", "h", "i", "j", "l"],
+        }
+    )
+
+    recommended = get_recommended_join_columns(df1, df2)
+    assert "id" in recommended
+    assert "name" in recommended
+    assert "common" not in recommended
+    assert "with_nulls" not in recommended
+
+    recommended = get_recommended_join_columns(df1, df2, allow_nulls=True)
+    assert "id" in recommended
+    assert "name" in recommended
+    assert "common" not in recommended
+    assert "with_nulls" in recommended
+    assert "unique_60" not in recommended
+
+    recommended = get_recommended_join_columns(df1, df2, uniqueness_threshold=50)
+    assert "id" in recommended
+    assert "name" in recommended
+    assert "unique_60" in recommended
+    assert "common" not in recommended
+    assert "with_nulls" not in recommended
+
+
+def test_get_recommended_join_columns_directly_in_compare():
+    df1 = pd.DataFrame(
+        {
+            "id": [1, 2, 3, 4, 5],
+            "name": ["a", "b", "c", "d", "e"],
+            "value1": [10, 20, 30, 40, 50],
+        }
+    )
+    df2 = pd.DataFrame(
+        {
+            "id": [1, 2, 3, 4, 6],
+            "name": ["a", "b", "c", "d", "f"],
+            "value2": [11, 21, 31, 41, 61],
+        }
+    )
+
+    compare = Compare(df1, df2, join_columns=get_recommended_join_columns(df1, df2))
+
+    assert compare.df1_unq_rows is not None
+    assert compare.df2_unq_rows is not None
+    assert len(compare.df1_unq_rows) == 1
+    assert len(compare.df2_unq_rows) == 1

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -1,8 +1,18 @@
-"""Test the helper functions."""
+"""Test the helper functions with all supported DataFrame types."""
+
+import logging
+import sys
 
 import pandas as pd
+import pytest
 from datacompy import Compare
 from datacompy.helper import analyze_join_columns, get_recommended_join_columns
+
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+
+# =========================================================================
+# Basic pandas tests
+# =========================================================================
 
 
 def test_analyze_join_columns():
@@ -26,7 +36,6 @@ def test_analyze_join_columns():
 
 
 def test_analyze_join_columns_with_nulls():
-    # Need 11 rows to achieve >90% uniqueness with nulls
     df1 = pd.DataFrame(
         {
             "id": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
@@ -43,7 +52,7 @@ def test_analyze_join_columns_with_nulls():
                 "i",
                 "j",
                 "k",
-            ],  # 10 unique values in 11 rows = 90.9% uniqueness
+            ],
         }
     )
     df2 = pd.DataFrame(
@@ -62,7 +71,7 @@ def test_analyze_join_columns_with_nulls():
                 "i",
                 "j",
                 "l",
-            ],  # 10 unique values in 11 rows = 90.9% uniqueness
+            ],
         }
     )
 
@@ -70,13 +79,13 @@ def test_analyze_join_columns_with_nulls():
     stats_by_column = {stat["column"]: stat for stat in stats}
     assert stats_by_column["id"]["recommended"] == True  # noqa: E712
     assert stats_by_column["name"]["recommended"] == True  # noqa: E712
-    assert stats_by_column["with_nulls"]["recommended"] == False  # noqa: E712  # Has nulls, so not recommended
+    assert stats_by_column["with_nulls"]["recommended"] == False  # noqa: E712
 
     stats = analyze_join_columns(df1, df2, allow_nulls=True)
     stats_by_column = {stat["column"]: stat for stat in stats}
     assert stats_by_column["id"]["recommended"] == True  # noqa: E712
     assert stats_by_column["name"]["recommended"] == True  # noqa: E712
-    assert stats_by_column["with_nulls"]["recommended"] == True  # noqa: E712  # Allowing nulls, so it's recommended
+    assert stats_by_column["with_nulls"]["recommended"] == True  # noqa: E712
 
 
 def test_analyze_join_columns_with_threshold():
@@ -182,3 +191,348 @@ def test_get_recommended_join_columns_directly_in_compare():
     assert compare.df2_unq_rows is not None
     assert len(compare.df1_unq_rows) == 1
     assert len(compare.df2_unq_rows) == 1
+
+
+# =========================================================================
+# Polars tests
+# =========================================================================
+
+def test_analyze_join_columns_polars():
+    # Using try/except instead of importorskip to avoid skipping tests
+    try:
+        import polars as pl
+    except ImportError:
+        pytest.skip("Polars is not installed")
+
+    # Convert pandas DataFrames to polars
+    df1_pd = pd.DataFrame({"id": [1, 2, 3, 4, 5], "name": ["a", "b", "c", "d", "e"]})
+    df2_pd = pd.DataFrame({"id": [1, 2, 3, 4, 5], "name": ["a", "b", "c", "d", "f"]})
+
+    df1 = pl.from_pandas(df1_pd)
+    df2 = pl.from_pandas(df2_pd)
+
+    stats = analyze_join_columns(df1, df2)
+    stats_by_column = {stat["column"]: stat for stat in stats}
+
+    assert stats_by_column["id"]["recommended"] == True  # noqa: E712
+    assert stats_by_column["name"]["recommended"] == True  # noqa: E712
+
+    df3_pd = pd.DataFrame({"id": [1, 1, 1, 1, 1], "name": ["a", "b", "c", "d", "e"]})
+    df4_pd = pd.DataFrame({"id": [1, 1, 1, 1, 1], "name": ["a", "b", "c", "d", "f"]})
+
+    df3 = pl.from_pandas(df3_pd)
+    df4 = pl.from_pandas(df4_pd)
+
+    stats = analyze_join_columns(df3, df4)
+    stats_by_column = {stat["column"]: stat for stat in stats}
+
+    assert stats_by_column["id"]["recommended"] == False  # noqa: E712
+    assert stats_by_column["name"]["recommended"] == True  # noqa: E712
+
+
+def test_analyze_join_columns_with_nulls_polars():
+    # Using try/except instead of importorskip to avoid skipping tests
+    try:
+        import polars as pl
+    except ImportError:
+        pytest.skip("Polars is not installed")
+
+    df1_pd = pd.DataFrame({
+        "id": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+        "name": ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"],
+        "with_nulls": [None, "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"]
+    })
+    df2_pd = pd.DataFrame({
+        "id": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12],
+        "name": ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "l"],
+        "with_nulls": ["a", None, "c", "d", "e", "f", "g", "h", "i", "j", "l"]
+    })
+
+    df1 = pl.from_pandas(df1_pd)
+    df2 = pl.from_pandas(df2_pd)
+
+    stats = analyze_join_columns(df1, df2)
+    stats_by_column = {stat["column"]: stat for stat in stats}
+
+    assert stats_by_column["id"]["recommended"] == True  # noqa: E712
+    assert stats_by_column["name"]["recommended"] == True  # noqa: E712
+    assert stats_by_column["with_nulls"]["recommended"] == False  # noqa: E712
+
+    stats = analyze_join_columns(df1, df2, allow_nulls=True)
+    stats_by_column = {stat["column"]: stat for stat in stats}
+
+    assert stats_by_column["id"]["recommended"] == True  # noqa: E712
+    assert stats_by_column["name"]["recommended"] == True  # noqa: E712
+    assert stats_by_column["with_nulls"]["recommended"] == True  # noqa: E712
+
+
+def test_get_recommended_join_columns_polars():
+    # Using try/except instead of importorskip to avoid skipping tests
+    try:
+        import polars as pl
+    except ImportError:
+        pytest.skip("Polars is not installed")
+
+    df1_pd = pd.DataFrame({
+        "id": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+        "name": ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"],
+        "common": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+        "with_nulls": [None, "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"]
+    })
+    df2_pd = pd.DataFrame({
+        "id": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12],
+        "name": ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "l"],
+        "common": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+        "with_nulls": ["a", None, "c", "d", "e", "f", "g", "h", "i", "j", "l"]
+    })
+
+    df1 = pl.from_pandas(df1_pd)
+    df2 = pl.from_pandas(df2_pd)
+
+    recommended = get_recommended_join_columns(df1, df2)
+    assert "id" in recommended
+    assert "name" in recommended
+    assert "common" not in recommended
+    assert "with_nulls" not in recommended
+
+    recommended = get_recommended_join_columns(df1, df2, allow_nulls=True)
+    assert "id" in recommended
+    assert "name" in recommended
+    assert "common" not in recommended
+    assert "with_nulls" in recommended
+
+
+# =========================================================================
+# Spark tests
+# =========================================================================
+
+# Helper function to check if a module is installed
+def is_module_installed(module_name):
+    try:
+        __import__(module_name)
+        return True
+    except ImportError:
+        return False
+
+
+@pytest.mark.skipif(
+    not is_module_installed("pyspark"),
+    reason="PySpark is not installed"
+)
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12),
+    reason="unsupported python version"
+)
+def test_analyze_join_columns_spark(spark_session):
+    # Skip check removed since it's now at the decorator level
+
+    # Convert pandas DataFrames to Spark
+    df1_pd = pd.DataFrame({"id": [1, 2, 3, 4, 5], "name": ["a", "b", "c", "d", "e"]})
+    df2_pd = pd.DataFrame({"id": [1, 2, 3, 4, 5], "name": ["a", "b", "c", "d", "f"]})
+
+    df1 = spark_session.createDataFrame(df1_pd)
+    df2 = spark_session.createDataFrame(df2_pd)
+
+    stats = analyze_join_columns(df1, df2)
+    stats_by_column = {stat["column"]: stat for stat in stats}
+
+    assert stats_by_column["id"]["recommended"] == True  # noqa: E712
+    assert stats_by_column["name"]["recommended"] == True  # noqa: E712
+
+    df3_pd = pd.DataFrame({"id": [1, 1, 1, 1, 1], "name": ["a", "b", "c", "d", "e"]})
+    df4_pd = pd.DataFrame({"id": [1, 1, 1, 1, 1], "name": ["a", "b", "c", "d", "f"]})
+
+    df3 = spark_session.createDataFrame(df3_pd)
+    df4 = spark_session.createDataFrame(df4_pd)
+
+    stats = analyze_join_columns(df3, df4)
+    stats_by_column = {stat["column"]: stat for stat in stats}
+
+    assert stats_by_column["id"]["recommended"] == False  # noqa: E712
+    assert stats_by_column["name"]["recommended"] == True  # noqa: E712
+
+
+@pytest.mark.skipif(
+    not is_module_installed("pyspark"),
+    reason="PySpark is not installed"
+)
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12),
+    reason="unsupported python version"
+)
+def test_analyze_join_columns_with_nulls_spark(spark_session):
+    # Skip check removed since it's now at the decorator level
+
+    # Need 11 rows to achieve >90% uniqueness with nulls
+    df1_pd = pd.DataFrame({
+        "id": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+        "name": ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"],
+        "with_nulls": [None, "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"]
+    })
+    df2_pd = pd.DataFrame({
+        "id": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12],
+        "name": ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "l"],
+        "with_nulls": ["a", None, "c", "d", "e", "f", "g", "h", "i", "j", "l"]
+    })
+
+    df1 = spark_session.createDataFrame(df1_pd)
+    df2 = spark_session.createDataFrame(df2_pd)
+
+    stats = analyze_join_columns(df1, df2)
+    stats_by_column = {stat["column"]: stat for stat in stats}
+
+    assert stats_by_column["id"]["recommended"] == True  # noqa: E712
+    assert stats_by_column["name"]["recommended"] == True  # noqa: E712
+    assert stats_by_column["with_nulls"]["recommended"] == False  # noqa: E712
+
+    stats = analyze_join_columns(df1, df2, allow_nulls=True)
+    stats_by_column = {stat["column"]: stat for stat in stats}
+
+    assert stats_by_column["id"]["recommended"] == True  # noqa: E712
+    assert stats_by_column["name"]["recommended"] == True  # noqa: E712
+    assert stats_by_column["with_nulls"]["recommended"] == True  # noqa: E712
+
+
+@pytest.mark.skipif(
+    not is_module_installed("pyspark"),
+    reason="PySpark is not installed"
+)
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12),
+    reason="unsupported python version"
+)
+def test_get_recommended_join_columns_spark(spark_session):
+    df1_pd = pd.DataFrame({
+        "id": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+        "name": ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"],
+        "common": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+        "with_nulls": [None, "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"]
+    })
+    df2_pd = pd.DataFrame({
+        "id": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12],
+        "name": ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "l"],
+        "common": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+        "with_nulls": ["a", None, "c", "d", "e", "f", "g", "h", "i", "j", "l"]
+    })
+
+    df1 = spark_session.createDataFrame(df1_pd)
+    df2 = spark_session.createDataFrame(df2_pd)
+
+    recommended = get_recommended_join_columns(df1, df2)
+    assert "id" in recommended
+    assert "name" in recommended
+    assert "common" not in recommended
+    assert "with_nulls" not in recommended
+
+    recommended = get_recommended_join_columns(df1, df2, allow_nulls=True)
+    assert "id" in recommended
+    assert "name" in recommended
+    assert "common" not in recommended
+    assert "with_nulls" in recommended
+
+
+# =========================================================================
+# Snowflake tests
+# =========================================================================
+
+@pytest.mark.skipif(
+    not is_module_installed("snowflake.snowpark"),
+    reason="Snowflake is not installed"
+)
+def test_analyze_join_columns_snowflake(snowpark_session):
+    # Convert pandas DataFrames to Snowflake
+    df1_pd = pd.DataFrame({"id": [1, 2, 3, 4, 5], "name": ["a", "b", "c", "d", "e"]})
+    df2_pd = pd.DataFrame({"id": [1, 2, 3, 4, 5], "name": ["a", "b", "c", "d", "f"]})
+
+    df1 = snowpark_session.createDataFrame(df1_pd)
+    df2 = snowpark_session.createDataFrame(df2_pd)
+
+    stats = analyze_join_columns(df1, df2)
+    stats_by_column = {stat["column"]: stat for stat in stats}
+
+    # In Snowflake, column names are uppercase by default
+    assert stats_by_column["ID"]["recommended"] == True  # noqa: E712
+    assert stats_by_column["NAME"]["recommended"] == True  # noqa: E712
+
+    df3_pd = pd.DataFrame({"id": [1, 1, 1, 1, 1], "name": ["a", "b", "c", "d", "e"]})
+    df4_pd = pd.DataFrame({"id": [1, 1, 1, 1, 1], "name": ["a", "b", "c", "d", "f"]})
+
+    df3 = snowpark_session.createDataFrame(df3_pd)
+    df4 = snowpark_session.createDataFrame(df4_pd)
+
+    stats = analyze_join_columns(df3, df4)
+    stats_by_column = {stat["column"]: stat for stat in stats}
+
+    assert stats_by_column["ID"]["recommended"] == False  # noqa: E712
+    assert stats_by_column["NAME"]["recommended"] == True  # noqa: E712
+
+
+@pytest.mark.skipif(
+    not is_module_installed("snowflake.snowpark"),
+    reason="Snowflake is not installed"
+)
+def test_analyze_join_columns_with_nulls_snowflake(snowpark_session):
+
+    df1_pd = pd.DataFrame({
+        "id": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+        "name": ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"],
+        "with_nulls": [None, "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"]
+    })
+    df2_pd = pd.DataFrame({
+        "id": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12],
+        "name": ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "l"],
+        "with_nulls": ["a", None, "c", "d", "e", "f", "g", "h", "i", "j", "l"]
+    })
+
+    df1 = snowpark_session.createDataFrame(df1_pd)
+    df2 = snowpark_session.createDataFrame(df2_pd)
+
+    stats = analyze_join_columns(df1, df2)
+    stats_by_column = {stat["column"]: stat for stat in stats}
+
+    assert stats_by_column["ID"]["recommended"] == True  # noqa: E712
+    assert stats_by_column["NAME"]["recommended"] == True  # noqa: E712
+    assert stats_by_column["WITH_NULLS"]["recommended"] == False  # noqa: E712
+
+    stats = analyze_join_columns(df1, df2, allow_nulls=True)
+    stats_by_column = {stat["column"]: stat for stat in stats}
+
+    assert stats_by_column["ID"]["recommended"] == True  # noqa: E712
+    assert stats_by_column["NAME"]["recommended"] == True  # noqa: E712
+    assert stats_by_column["WITH_NULLS"]["recommended"] == True  # noqa: E712
+
+
+@pytest.mark.skipif(
+    not is_module_installed("snowflake.snowpark"),
+    reason="Snowflake is not installed"
+)
+def test_get_recommended_join_columns_snowflake(snowpark_session):
+    # Skip check removed since it's now at the decorator level
+
+    df1_pd = pd.DataFrame({
+        "id": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+        "name": ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"],
+        "common": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+        "with_nulls": [None, "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"]
+    })
+    df2_pd = pd.DataFrame({
+        "id": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12],
+        "name": ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "l"],
+        "common": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+        "with_nulls": ["a", None, "c", "d", "e", "f", "g", "h", "i", "j", "l"]
+    })
+
+    df1 = snowpark_session.createDataFrame(df1_pd)
+    df2 = snowpark_session.createDataFrame(df2_pd)
+
+    recommended = get_recommended_join_columns(df1, df2)
+    assert "ID" in recommended
+    assert "NAME" in recommended
+    assert "COMMON" not in recommended
+    assert "WITH_NULLS" not in recommended
+
+    recommended = get_recommended_join_columns(df1, df2, allow_nulls=True)
+    assert "ID" in recommended
+    assert "NAME" in recommended
+    assert "COMMON" not in recommended
+    assert "WITH_NULLS" in recommended


### PR DESCRIPTION
We use datacompy for regression testing, and for our use-case it can be useful to try and programmatically work out join columns.

Further, when when prototyping a browser-based UI for datacompy, https://github.com/mahangu/datacompy-web-ui, we worked on a method to [recommend join columns](https://github.com/mahangu/datacompy-web-ui/blob/6ff90033b76ce2293a187e1adbcddbd09cbacbd9/src/datacompy_web_ui/core/comparison.py#L183). 

This PR attempts to bring some of that functionality into datacompy core, via two helper functions:

1. `analyze_join_columns`
2. `get_recommended_join_columns`