### PR TITLE
fix for categorical columns in Pandas and tests for Polars

### DIFF
--- a/datacompy/core.py
+++ b/datacompy/core.py
@@ -899,13 +899,9 @@ def columns_equal(
                         | (col_1.isnull() & col_2.isnull())
                     )
             except Exception:
-                # Check for string[pyarrow] and string[python]
-                if col_1.dtype in (
-                    "string[python]",
-                    "string[pyarrow]",
-                ) and col_2.dtype in ("string[python]", "string[pyarrow]"):
+                try:
                     compare = pd.Series(col_1.astype(str) == col_2.astype(str))
-                else:  # Blanket exception should just return all False
+                except Exception:  # Blanket exception should just return all False
                     compare = pd.Series(False, index=col_1.index)
     compare.index = col_1.index
     return compare

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -437,6 +437,27 @@ def test_mixed_column_with_ignore_spaces_and_case():
     assert_series_equal(expect_out, actual_out, check_names=False)
 
 
+def test_categorical_column():
+    df = pd.DataFrame(
+        {
+            "idx": [1, 2, 3],
+            "foo": ["A", "B", np.nan],
+            "bar": ["A", "B", np.nan],
+        }
+    )
+    for col in ("foo", "bar"):
+        df[col] = df[col].astype("category")
+        df[col] = df[col].astype("category")
+
+    actual_out = datacompy.columns_equal(
+        df.foo, df.bar, ignore_spaces=True, ignore_case=True
+    )
+    assert actual_out.all()
+    compare = datacompy.Compare(df, df, join_columns=["idx"])
+    assert compare.intersect_rows["foo_match"].all()
+    assert compare.intersect_rows["bar_match"].all()
+
+
 def test_compare_df_setter_bad():
     df = pd.DataFrame([{"a": 1, "A": 2}, {"a": 2, "A": 2}])
     with raises(TypeError, match="df1 must be a pandas DataFrame"):

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -1437,3 +1437,23 @@ def test_non_full_join_counts_some_matches():
             ]
         ),
     )
+
+
+def test_categorical_column():
+    df = pl.DataFrame(
+        {
+            "idx": [1, 2, 3],
+            "foo": ["A", "B", np.nan],
+            "bar": ["A", "B", np.nan],
+        },
+        strict=False,
+        schema={"idx": pl.Int32, "foo": pl.Categorical, "bar": pl.Categorical},
+    )
+
+    actual_out = columns_equal(
+        df["foo"], df["bar"], ignore_spaces=True, ignore_case=True
+    )
+    assert actual_out.all()
+    compare = PolarsCompare(df, df, join_columns=["idx"])
+    assert compare.intersect_rows["foo_match"].all()
+    assert compare.intersect_rows["bar_match"].all()


### PR DESCRIPTION
fix #391 
fix #389

- I've made some changes to the Pandas logic where we just try and convert to strings and compare instead of checking `"string[python]", "string[pyarrow]"`
- Also added some tests for Polars since categoricals exist there.

@epizut and @hanying528 if you have some time to check on your end with this branch it would be much appreciated.