### PR TITLE
fix: _dataframe_merge ignore spaces

### DIFF
--- a/datacompy/__init__.py
+++ b/datacompy/__init__.py
@@ -18,7 +18,7 @@ Originally started to be something of a replacement for SAS's PROC COMPARE for P
 Then extended to carry that functionality over to Spark Dataframes.
 """
 
-__version__ = "0.16.4"
+__version__ = "0.16.5"
 
 import platform
 from warnings import warn

--- a/datacompy/core.py
+++ b/datacompy/core.py
@@ -287,9 +287,13 @@ class Compare(BaseCompare):
 
         if ignore_spaces:
             for column in self.join_columns:
-                if self.df1[column].dtype.kind == "O":
+                if self.df1[column].dtype.kind == "O" and pd.api.types.is_string_dtype(
+                    self.df1[column]
+                ):
                     self.df1[column] = self.df1[column].str.strip()
-                if self.df2[column].dtype.kind == "O":
+                if self.df2[column].dtype.kind == "O" and pd.api.types.is_string_dtype(
+                    self.df2[column]
+                ):
                     self.df2[column] = self.df2[column].str.strip()
 
         outer_join = self.df1.merge(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -20,7 +20,7 @@ Testing out the datacompy functionality
 import io
 import logging
 import sys
-from datetime import datetime
+from datetime import date, datetime
 from decimal import Decimal
 from unittest import mock
 
@@ -1524,3 +1524,42 @@ def test_single_date_columns_equal_to_string():
     actual_out = datacompy.columns_equal(df.a, df.b, rel_tol=0.2, ignore_spaces=True)
     expect_out = df["expected"]
     assert_series_equal(expect_out, actual_out, check_names=False)
+
+
+def test_merge_date_ignore_spaces():
+    columns = ["text", "float", "int", "datetime"]
+
+    df1 = pd.DataFrame(
+        columns=columns,
+        data=[
+            ["A", 1.9834, 1, date(year=2025, month=1, day=1)],
+            ["B", 2.93843, 2, date(year=2025, month=1, day=2)],
+            ["C", 3.94733844, 3, date(year=2025, month=1, day=3)],
+            ["D", 462638.37472734, 4, date(year=2025, month=1, day=4)],
+        ],
+    )
+
+    df2 = pd.DataFrame(
+        columns=columns,
+        data=[
+            ["A", 1.98, 1, date(year=2025, month=1, day=1)],
+            ["B", 2.94, 2, date(year=2025, month=1, day=2)],
+            ["C", 3.95, 3, date(year=2025, month=1, day=3)],
+            ["D  ", 462638.37, 4, date(year=2025, month=1, day=4)],
+        ],
+    )
+    compare = datacompy.Compare(
+        df1=df1,
+        df2=df2,
+        df1_name="df1",
+        df2_name="df2",
+        join_columns=["text", "datetime"],
+        on_index=False,
+        abs_tol=0.005,
+        rel_tol=0,
+        ignore_spaces=True,
+        ignore_case=False,
+        cast_column_names_lower=True,
+    )
+    compare._dataframe_merge(ignore_spaces=True)
+    assert len(compare.intersect_rows) == 4


### PR DESCRIPTION
Fix for Pandas Compare's `_dataframe_merge` and the `ignore_spaces` check. Needed an extra condition for strings types in particular.
