### PR TITLE
Fix bug where ID gen fails if first col is not in index

### DIFF
--- a/datacompy/polars.py
+++ b/datacompy/polars.py
@@ -1014,7 +1014,7 @@ def generate_id_within_group(
             dataframe[join_columns]
             .cast(pl.String)
             .fill_null(default_value)
-            .select(rn=pl.col(dataframe.columns[0]).cum_count().over(join_columns))
+            .select(rn=pl.col(join_columns[0]).cum_count().over(join_columns))
             .to_series()
         )
     else:


### PR DESCRIPTION
If the first column in the dataframe does not appear in the index columns, this line currently crashes the comparison.

Switching to selecting the first of the index columns fixes the issue.