### PR TITLE
chore: normalize_string_column for polars and pandas

### DIFF
--- a/datacompy/core.py
+++ b/datacompy/core.py
@@ -66,9 +66,9 @@ class Compare(BaseCompare):
         A string name for the second dataframe
     ignore_spaces : bool, optional
         Flag to strip whitespace (including newlines) from string columns (including any join
-        columns)
+        columns). Excludes categoricals.
     ignore_case : bool, optional
-        Flag to ignore the case of string columns
+        Flag to ignore the case of string columns. Excludes categoricals.
     cast_column_names_lower: bool, optional
         Boolean indicator that controls of column names will be cast into lower case
 
@@ -1075,7 +1075,7 @@ def normalize_string_column(
     """
     if (column.dtype.kind == "O" and pd.api.types.infer_dtype(column) == "string") or (
         pd.api.types.is_string_dtype(column)
-        and not pd.api.types.is_categorical_dtype(column)
+        and not isinstance(column.dtype, pd.CategoricalDtype)
     ):
         column = column.str.strip() if ignore_spaces else column
         column = column.str.upper() if ignore_case else column

--- a/datacompy/core.py
+++ b/datacompy/core.py
@@ -1068,10 +1068,15 @@ def normalize_string_column(
     -------
     pd.Series
         The normalized column
+
+    Notes
+    -----
+    Will not operate on categorical columns.
     """
-    if (
-        column.dtype.kind == "O" and pd.api.types.infer_dtype(column) == "string"
-    ) or pd.api.types.is_string_dtype(column):
+    if (column.dtype.kind == "O" and pd.api.types.infer_dtype(column) == "string") or (
+        pd.api.types.is_string_dtype(column)
+        and not pd.api.types.is_categorical_dtype(column)
+    ):
         column = column.str.strip() if ignore_spaces else column
         column = column.str.upper() if ignore_case else column
     return column

--- a/datacompy/polars.py
+++ b/datacompy/polars.py
@@ -66,9 +66,9 @@ class PolarsCompare(BaseCompare):
         A string name for the second dataframe
     ignore_spaces : bool, optional
         Flag to strip whitespace (including newlines) from string columns (including any join
-        columns)
+        columns). Excludes categoricals.
     ignore_case : bool, optional
-        Flag to ignore the case of string columns
+        Flag to ignore the case of string columns. Excludes categoricals.
     cast_column_names_lower: bool, optional
         Boolean indicator that controls of column names will be cast into lower case
 
@@ -1046,6 +1046,10 @@ def normalize_string_column(
     -------
     pl.Series
         The normalized column
+
+    Notes
+    -----
+    Will not operate on categorical columns.
     """
     if str(column.dtype.base_type()) in STRING_TYPE:
         if ignore_spaces:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1679,3 +1679,126 @@ def test_columns_equal_lists():
     df2 = pd.DataFrame({"array_col": [[] for _ in range(10)]})
     actual = datacompy.columns_equal(df1.array_col, df2.array_col)
     assert actual.all()
+
+
+@pytest.mark.parametrize(
+    "data, ignore_spaces, ignore_case, expected",
+    [
+        # test case for mixed types
+        (
+            pd.Series(["1   ", 2.5, None, True]),
+            True,
+            True,
+            pd.Series(["1", 2.5, None, True]),
+        ),
+        # test case for integers
+        (pd.Series([1, 2, 3, 4]), True, True, pd.Series([1, 2, 3, 4])),
+        (pd.Series([1, 2, 3, 4]), True, False, pd.Series([1, 2, 3, 4])),
+        (pd.Series([1, 2, 3, 4]), False, True, pd.Series([1, 2, 3, 4])),
+        (pd.Series([1, 2, 3, 4]), False, False, pd.Series([1, 2, 3, 4])),
+        # test case for strings of object types
+        (
+            pd.Series(["  hello  ", "WORLD", "  Foo  ", None], dtype="object"),
+            True,
+            True,
+            pd.Series(["HELLO", "WORLD", "FOO", None], dtype="object"),
+        ),
+        (
+            pd.Series(["  hello  ", "WORLD", "  Foo  ", None], dtype="object"),
+            True,
+            False,
+            pd.Series(["hello", "WORLD", "Foo", None], dtype="object"),
+        ),
+        (
+            pd.Series(["  hello  ", "WORLD", "  Foo  ", None], dtype="object"),
+            False,
+            True,
+            pd.Series(["  HELLO  ", "WORLD", "  FOO  ", None], dtype="object"),
+        ),
+        (
+            pd.Series(["  hello  ", "WORLD", "  Foo  ", None], dtype="object"),
+            False,
+            False,
+            pd.Series(["  hello  ", "WORLD", "  Foo  ", None], dtype="object"),
+        ),
+        (
+            pd.Series(["👋", "🌍", "🍕", None], dtype="object"),
+            True,
+            True,
+            pd.Series(["👋", "🌍", "🍕", None], dtype="object"),
+        ),
+        (
+            pd.Series(["  👋  ", "🌍", "  🍕  ", None], dtype="object"),
+            False,
+            True,
+            pd.Series(["  👋  ", "🌍", "  🍕  ", None], dtype="object"),
+        ),
+        # tests for type string[python]
+        (
+            pd.Series(["  hello  ", "WORLD", "  Foo  ", None], dtype="string[python]"),
+            True,
+            True,
+            pd.Series(["HELLO", "WORLD", "FOO", None], dtype="string[python]"),
+        ),
+        (
+            pd.Series(["  hello  ", "WORLD", "  Foo  ", None], dtype="string[python]"),
+            True,
+            False,
+            pd.Series(["hello", "WORLD", "Foo", None], dtype="string[python]"),
+        ),
+        (
+            pd.Series(["👋", "🌍", "🍕", None], dtype="string[python]"),
+            True,
+            True,
+            pd.Series(["👋", "🌍", "🍕", None], dtype="string[python]"),
+        ),
+        (
+            pd.Series(["  👋  ", "🌍", "  🍕  ", None], dtype="string[python]"),
+            False,
+            True,
+            pd.Series(["  👋  ", "🌍", "  🍕  ", None], dtype="string[python]"),
+        ),
+        # tests for type string[pyarrow]
+        (
+            pd.Series(["  hello  ", "WORLD", "  Foo  ", None], dtype="string[pyarrow]"),
+            True,
+            True,
+            pd.Series(["HELLO", "WORLD", "FOO", None], dtype="string[pyarrow]"),
+        ),
+        (
+            pd.Series(["  hello  ", "WORLD", "  Foo  ", None], dtype="string[pyarrow]"),
+            True,
+            False,
+            pd.Series(["hello", "WORLD", "Foo", None], dtype="string[pyarrow]"),
+        ),
+        (
+            pd.Series(["  hello  ", "WORLD", "  Foo  ", None], dtype="string[pyarrow]"),
+            False,
+            True,
+            pd.Series(["  HELLO  ", "WORLD", "  FOO  ", None], dtype="string[pyarrow]"),
+        ),
+        (
+            pd.Series(["  hello  ", "WORLD", "  Foo  ", None], dtype="string[pyarrow]"),
+            False,
+            False,
+            pd.Series(["  hello  ", "WORLD", "  Foo  ", None], dtype="string[pyarrow]"),
+        ),
+        (
+            pd.Series(["👋", "🌍", "🍕", None], dtype="string[pyarrow]"),
+            True,
+            True,
+            pd.Series(["👋", "🌍", "🍕", None], dtype="string[pyarrow]"),
+        ),
+        (
+            pd.Series(["  👋  ", "🌍", "  🍕  ", None], dtype="string[pyarrow]"),
+            False,
+            True,
+            pd.Series(["  👋  ", "🌍", "  🍕  ", None], dtype="string[pyarrow]"),
+        ),
+    ],
+)
+def test_normalize_string_column(data, ignore_spaces, ignore_case, expected):
+    result = datacompy.core.normalize_string_column(
+        data, ignore_spaces=ignore_spaces, ignore_case=ignore_case
+    )
+    assert_series_equal(result, expected, check_names=False)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -457,7 +457,7 @@ def test_categorical_column():
     actual_out = datacompy.columns_equal(
         df.foo, df.foo_bad, ignore_spaces=True, ignore_case=True
     )
-    assert not actual_out.all()
+    assert list(actual_out) == [False, True, True]
 
     compare = datacompy.Compare(df, df, join_columns=["idx"])
     assert compare.intersect_rows["foo_match"].all()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1710,6 +1710,23 @@ def test_columns_equal_lists():
         (pd.Series([1, 2, 3, 4]), True, False, pd.Series([1, 2, 3, 4])),
         (pd.Series([1, 2, 3, 4]), False, True, pd.Series([1, 2, 3, 4])),
         (pd.Series([1, 2, 3, 4]), False, False, pd.Series([1, 2, 3, 4])),
+        # test case for floats
+        (pd.Series([1.1, 2.2, 3.3, 4.4]), True, True, pd.Series([1.1, 2.2, 3.3, 4.4])),
+        (pd.Series([1.1, 2.2, 3.3, 4.4]), True, False, pd.Series([1.1, 2.2, 3.3, 4.4])),
+        (pd.Series([1.1, 2.2, 3.3, 4.4]), False, True, pd.Series([1.1, 2.2, 3.3, 4.4])),
+        (
+            pd.Series([1.1, 2.2, 3.3, 4.4]),
+            False,
+            False,
+            pd.Series([1.1, 2.2, 3.3, 4.4]),
+        ),
+        # test case for list of strings should just passthrough
+        (
+            pd.Series([["  hello  ", "WORLD", "  Foo  ", None]]),
+            True,
+            True,
+            pd.Series([["  hello  ", "WORLD", "  Foo  ", None]]),
+        ),
         # test case for strings of object types
         (
             pd.Series(["  hello  ", "WORLD", "  Foo  ", None], dtype="object"),

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -1470,7 +1470,7 @@ def test_categorical_column():
     actual_out = columns_equal(
         df["foo"], df["foo_bad"], ignore_spaces=True, ignore_case=True
     )
-    assert not actual_out.all()
+    assert list(actual_out) == [False, True, True]
 
     compare = PolarsCompare(df, df, join_columns=["idx"])
     assert compare.intersect_rows["foo_match"].all()

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -36,6 +36,7 @@ from datacompy.polars import (
     calculate_max_diff,
     columns_equal,
     generate_id_within_group,
+    normalize_string_column,
     temp_column_name,
 )
 from polars.exceptions import ComputeError, DuplicateError, SchemaError
@@ -1450,15 +1451,27 @@ def test_categorical_column():
             "idx": [1, 2, 3],
             "foo": ["A", "B", np.nan],
             "bar": ["A", "B", np.nan],
+            "foo_bad": ["    A   ", "B", np.nan],
         },
         strict=False,
-        schema={"idx": pl.Int32, "foo": pl.Categorical, "bar": pl.Categorical},
+        schema={
+            "idx": pl.Int32,
+            "foo": pl.Categorical,
+            "bar": pl.Categorical,
+            "foo_bad": pl.Categorical,
+        },
     )
 
     actual_out = columns_equal(
         df["foo"], df["bar"], ignore_spaces=True, ignore_case=True
     )
     assert actual_out.all()
+
+    actual_out = columns_equal(
+        df["foo"], df["foo_bad"], ignore_spaces=True, ignore_case=True
+    )
+    assert not actual_out.all()
+
     compare = PolarsCompare(df, df, join_columns=["idx"])
     assert compare.intersect_rows["foo_match"].all()
     assert compare.intersect_rows["bar_match"].all()
@@ -1648,3 +1661,66 @@ def test_columns_equal_lists():
     )
     actual = columns_equal(df1["array_col"], df2["array_col"])
     assert actual.all()
+
+
+@pytest.mark.parametrize(
+    "input_data, ignore_spaces, ignore_case, expected",
+    [
+        (
+            pl.Series(["  hello  ", "WORLD", "  Foo  ", None]),
+            True,
+            True,
+            pl.Series(["HELLO", "WORLD", "FOO", None]),
+        ),
+        (
+            pl.Series(["  hello  ", "WORLD", "  Foo  ", None]),
+            True,
+            False,
+            pl.Series(["hello", "WORLD", "Foo", None]),
+        ),
+        (
+            pl.Series(["  hello  ", "WORLD", "  Foo  ", None]),
+            False,
+            True,
+            pl.Series(["  HELLO  ", "WORLD", "  FOO  ", None]),
+        ),
+        (
+            pl.Series(["  hello  ", "WORLD", "  Foo  ", None]),
+            False,
+            False,
+            pl.Series(["  hello  ", "WORLD", "  Foo  ", None]),
+        ),
+        (
+            pl.Series([1, 2, 3, None]),
+            True,
+            True,
+            pl.Series([1, 2, 3, None]),
+        ),
+        # emoji
+        (
+            pl.Series([" 😀 ", "😃 a", "😄", None]),
+            True,
+            True,
+            pl.Series(["😀", "😃 A", "😄", None]),
+        ),
+        # mixed types
+        (
+            pl.Series(["  hello  ", 1, 2.5, None], strict=False),
+            True,
+            True,
+            pl.Series(["HELLO", 1, 2.5, None], strict=False),
+        ),
+        # Categorical datatype should just passthough
+        (
+            pl.Series(["  cat  ", "dog", "  mouse  ", None], dtype=pl.Categorical),
+            True,
+            True,
+            pl.Series(["  cat  ", "dog", "  mouse  ", None], dtype=pl.Categorical),
+        ),
+    ],
+)
+def test_normalize_string_column(input_data, ignore_spaces, ignore_case, expected):
+    result = normalize_string_column(
+        input_data, ignore_spaces=ignore_spaces, ignore_case=ignore_case
+    )
+    assert_series_equal(result, expected, check_names=False)

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -1665,7 +1665,50 @@ def test_columns_equal_lists():
 
 @pytest.mark.parametrize(
     "input_data, ignore_spaces, ignore_case, expected",
-    [
+    [  # Categorical datatype should just passthough
+        (
+            pl.Series(["  cat  ", "dog", "  mouse  ", None], dtype=pl.Categorical),
+            True,
+            True,
+            pl.Series(["  cat  ", "dog", "  mouse  ", None], dtype=pl.Categorical),
+        ),
+        # mixed types
+        (
+            pl.Series(["  hello  ", 1, 2.5, None], strict=False),
+            True,
+            True,
+            pl.Series(["HELLO", 1, 2.5, None], strict=False),
+        ),
+        # test case for integers
+        (pl.Series([1, 2, 3, 4]), True, True, pl.Series([1, 2, 3, 4])),
+        (pl.Series([1, 2, 3, 4]), True, False, pl.Series([1, 2, 3, 4])),
+        (pl.Series([1, 2, 3, 4]), False, True, pl.Series([1, 2, 3, 4])),
+        (pl.Series([1, 2, 3, 4]), False, False, pl.Series([1, 2, 3, 4])),
+        # test case for floats
+        (pl.Series([1.1, 2.2, 3.3, 4.4]), True, True, pl.Series([1.1, 2.2, 3.3, 4.4])),
+        (pl.Series([1.1, 2.2, 3.3, 4.4]), True, False, pl.Series([1.1, 2.2, 3.3, 4.4])),
+        (pl.Series([1.1, 2.2, 3.3, 4.4]), False, True, pl.Series([1.1, 2.2, 3.3, 4.4])),
+        (
+            pl.Series([1.1, 2.2, 3.3, 4.4]),
+            False,
+            False,
+            pl.Series([1.1, 2.2, 3.3, 4.4]),
+        ),
+        # list of strings should just passthrough
+        (
+            pl.Series([["  hello  ", "WORLD", "  Foo  ", None]]),
+            True,
+            True,
+            pl.Series([["  hello  ", "WORLD", "  Foo  ", None]]),
+        ),
+        # array of strings should just passthrough
+        (
+            pl.Series([["  hello  ", "WORLD", "  Foo  ", None]]),
+            True,
+            True,
+            pl.Series([["  hello  ", "WORLD", "  Foo  ", None]]),
+        ),
+        # strings
         (
             pl.Series(["  hello  ", "WORLD", "  Foo  ", None]),
             True,
@@ -1690,32 +1733,18 @@ def test_columns_equal_lists():
             False,
             pl.Series(["  hello  ", "WORLD", "  Foo  ", None]),
         ),
-        (
-            pl.Series([1, 2, 3, None]),
-            True,
-            True,
-            pl.Series([1, 2, 3, None]),
-        ),
         # emoji
         (
-            pl.Series([" 😀 ", "😃 a", "😄", None]),
+            pl.Series(["👋", "🌍", "🍕", None]),
             True,
             True,
-            pl.Series(["😀", "😃 A", "😄", None]),
+            pl.Series(["👋", "🌍", "🍕", None]),
         ),
-        # mixed types
         (
-            pl.Series(["  hello  ", 1, 2.5, None], strict=False),
+            pl.Series(["  👋  ", "🌍", "  🍕  ", None]),
+            False,
             True,
-            True,
-            pl.Series(["HELLO", 1, 2.5, None], strict=False),
-        ),
-        # Categorical datatype should just passthough
-        (
-            pl.Series(["  cat  ", "dog", "  mouse  ", None], dtype=pl.Categorical),
-            True,
-            True,
-            pl.Series(["  cat  ", "dog", "  mouse  ", None], dtype=pl.Categorical),
+            pl.Series(["  👋  ", "🌍", "  🍕  ", None]),
         ),
     ],
 )


### PR DESCRIPTION
- adding in a util function `normalize_string_column` for both pandas and polars to reduce redundant code.
- some general cleanup of docstrings
- additional test cases for categoricals.
