### PR TITLE
bug: polars calculate_max_diff null handling fix

### DIFF
--- a/datacompy/__init__.py
+++ b/datacompy/__init__.py
@@ -18,7 +18,7 @@ Originally started to be something of a replacement for SAS's PROC COMPARE for P
 Then extended to carry that functionality over to Spark Dataframes.
 """
 
-__version__ = "0.18.0"
+__version__ = "0.18.1"
 
 import platform
 from warnings import warn

--- a/datacompy/polars.py
+++ b/datacompy/polars.py
@@ -1045,7 +1045,10 @@ def calculate_max_diff(col_1: pl.Series, col_2: pl.Series) -> float:
     """
     try:
         return cast(
-            float, (col_1.cast(pl.Float64) - col_2.cast(pl.Float64)).abs().max()
+            float,
+            (col_1.cast(pl.Float64).fill_null(0) - col_2.cast(pl.Float64).fill_null(0))
+            .abs()
+            .max(),
         )
     except Exception:
         return 0.0

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -1193,6 +1193,8 @@ MAX_DIFF_DF = pl.DataFrame(
         "strings": ["1", "1", "1", "1.1", "1"],
         "mixed_strings": ["1", "1", "1", "2", "some string"],
         "infinity": [1, 1, 1, 1, np.inf],
+        "nulls": [None, None, None, None, None],
+        "some_nulls": [10, 10, 10, None, None],
     },
     strict=False,
 )
@@ -1209,6 +1211,8 @@ MAX_DIFF_DF = pl.DataFrame(
         ("strings", 0.1),
         ("mixed_strings", 0),
         ("infinity", np.inf),
+        ("nulls", 1),
+        ("some_nulls", 9),
     ],
 )
 def test_calculate_max_diff(column, expected):


### PR DESCRIPTION
Fixes a `TypeError` that occurs when rendering a report if a column contains only null values. This was caused by the `calculate_max_diff` function returning `None` instead of a float, which is not handled by the report template.

The fix includes the following changes:
- null values are now replaced with 0 before calculating the maximum absolute difference. This ensures that the function always returns a float.

Fixes #441