### PR TITLE
Release v0.19.1

### DIFF
--- a/.github/workflows/edgetest.yml
+++ b/.github/workflows/edgetest.yml
@@ -18,11 +18,11 @@ jobs:
         with:
           ref: ${{ github.ref_name }}
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
-          python-version: '3.10'
+          python-version: '3.11'
           channels: conda-forge
 
       - name: Setup Java JDK

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -4,8 +4,6 @@
 name: Publish docs
 
 on:
-  release:
-    types: [created]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -4,8 +4,7 @@
 name: Publish
 
 on:
-  release:
-    types: [created]
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -5,9 +5,10 @@ name: Test package
 
 on:
   push:
-    branches: [develop, main]
+    branches: [develop, main, "release/*", "release-*", "support/*"]
   pull_request:
-    branches: [develop, main]
+    branches: [develop, main, "release/*", "release-*", "support/*"]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ and lets you tweak how accurate matches have to be). Supported types include:
 - Dask (via Fugue)
 - DuckDB (via Fugue)
 
+> [!IMPORTANT]
+> datacompy is progressing towards a `v1` release. During this transition, a `support/0.19.x` branch will be maintained solely for `v0.19.x` users.
+> This branch will only receive dependency updates and critical bug fixes; no new features will be added.
+> All new feature development should target the `v1` branches (`develop` and eventually `main`).
+
 
 ## Quick Installation
 

--- a/datacompy/__init__.py
+++ b/datacompy/__init__.py
@@ -18,4 +18,4 @@ Originally started to be something of a replacement for SAS's PROC COMPARE for P
 Then extended to carry that functionality over to Spark Dataframes.
 """
 
-__version__ = "0.19.0"
+__version__ = "0.19.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,10 +35,10 @@ dynamic = [ "version" ]
 
 dependencies = [
   "jinja2>=3",
-  "numpy>=1.26,<=2.3.4",
+  "numpy>=1.26,<=2.3.5",
   "ordered-set>=4.0.2,<=4.1",
   "pandas>=2.2,<=2.3.3",
-  "polars[pandas]>=0.20.4,<=1.35.2",
+  "polars[pandas]>=0.20.4,<=1.36.1",
 ]
 optional-dependencies.build = [ "build", "twine", "wheel" ]
 optional-dependencies.dev = [
@@ -96,7 +96,7 @@ version = { attr = "datacompy.__version__" }
 python-tag = "py3"
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py312"
 src = [ "src" ]
 
 extend-include = [ "*.ipynb" ]
@@ -154,7 +154,7 @@ module = "pyarrow"
 ignore_missing_imports = true
 
 [edgetest.envs.core]
-python_version = "3.10"
+python_version = "3.11"
 conda_install = [ "openjdk=8" ]
 extras = [ "dev" ]
 command = "pytest tests/ --ignore=tests/test_snowflake.py"

--- a/tests/test_fugue/test_fugue_spark.py
+++ b/tests/test_fugue/test_fugue_spark.py
@@ -34,7 +34,7 @@ from test_fugue_helpers import _compare_report
 pytest.importorskip("fugue")
 pyspark = pytest.importorskip("pyspark")
 
-if sys.version_info >= (3, 12):
+if sys.version_info >= (3, 12):  # noqa: UP036
     pytest.skip("unsupported python version", allow_module_level=True)
 
 

--- a/tests/test_spark/test_helper.py
+++ b/tests/test_spark/test_helper.py
@@ -23,7 +23,7 @@ import sys
 import pytest
 
 pytest.importorskip("pyspark")
-if sys.version_info >= (3, 12):
+if sys.version_info >= (3, 12):  # noqa: UP036
     pytest.skip("unsupported python version", allow_module_level=True)
 
 

--- a/tests/test_spark/test_sql_spark.py
+++ b/tests/test_spark/test_sql_spark.py
@@ -34,7 +34,7 @@ from pytest import raises
 
 pytest.importorskip("pyspark")
 
-if sys.version_info >= (3, 12):
+if sys.version_info >= (3, 12):  # noqa: UP036
     pytest.skip("unsupported python version", allow_module_level=True)
 
 from datacompy.spark.sql import (


### PR DESCRIPTION
Release v0.19.1
-----------------
This will be the starting off point for `support/0.19.x` as we transition to` v1.0` for datacompy in terms of development

Housekeeping updates:
- #466
- #452 