### PR TITLE
fix: update version to 1.0.0a3 and include comparator package in setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ test.html
 
 .coverage
 coverage.xml
+
+# benchmark data
+benchmarks/data/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.0
+    rev: v0.14.9
     hooks:
       # Run the linter.
       - id: ruff

--- a/datacompy/__init__.py
+++ b/datacompy/__init__.py
@@ -18,7 +18,7 @@ Originally started to be something of a replacement for SAS's PROC COMPARE for P
 Then extended to carry that functionality over to Spark Dataframes.
 """
 
-__version__ = "1.0.0a2"
+__version__ = "1.0.0a3"
 
 from datacompy.base import BaseCompare
 from datacompy.pandas import PandasCompare

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ optional-dependencies.dev = [
 ]
 optional-dependencies.docs = [ "furo", "myst-parser", "sphinx" ]
 optional-dependencies.edgetest = [ "edgetest", "edgetest-conda" ]
-optional-dependencies.qa = [ "mypy", "pandas-stubs", "pre-commit", "ruff==0.5.7" ]
+optional-dependencies.qa = [ "mypy", "pandas-stubs", "pre-commit", "ruff" ]
 optional-dependencies.snowflake = [ "snowflake-snowpark-python>=1.26,<=1.33" ]
 optional-dependencies.spark = [
   "pyspark[connect]>=3.5,<4; python_version<='3.11'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = [ "setuptools>=64" ]
 name = "datacompy"
 description = "Dataframe comparisons in Python"
 readme = "README.md"
-license = { text = "Apache Software License" }
+license-files = [ "LICENSE" ]
 maintainers = [
   { name = "Faisal Dosani", email = "faisal.dosani@capitalone.com" },
   { name = "Jacob Dawang", email = "jacob.dawang@capitalone.com" },
@@ -72,7 +72,7 @@ urls.Repository = "https://github.com/capitalone/datacompy.git"
 urls."Source Code" = "https://github.com/capitalone/datacompy"
 
 [tool.setuptools]
-packages = [ "datacompy", "datacompy.comparator" ]
+packages = [ "datacompy", "datacompy.comparator", "datacompy.templates" ]
 zip-safe = false
 include-package-data = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ urls.Repository = "https://github.com/capitalone/datacompy.git"
 urls."Source Code" = "https://github.com/capitalone/datacompy"
 
 [tool.setuptools]
-packages = [ "datacompy" ]
+packages = [ "datacompy", "datacompy.comparator" ]
 zip-safe = false
 include-package-data = true
 


### PR DESCRIPTION
- need to yank the previous alpha releases in favour for this one.
- the `comparators` module was not being included and causing import errors.