### PR TITLE
feat: add cache_intermediates option for SparkSQLCompare

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.9
+    rev: v0.14.13
     hooks:
       # Run the linter.
       - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,17 +29,16 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
-  "Programming Language :: Python :: 3.14",
 ]
 
 dynamic = [ "version" ]
 
 dependencies = [
   "jinja2>=3",
-  "numpy<=2.4.1,>=1.26.4",
-  "ordered-set<=4.1,>=4.0.2",
-  "pandas<=2.3.3,>=2.2",
-  "polars[pandas]<=1.37.1,>=0.20.4",
+  "numpy>=1.26.4,<=2.4.1",
+  "ordered-set>=4.0.2,<=4.1",
+  "pandas>=2.2,<=2.3.3",
+  "polars[pandas]>=0.20.4,<=1.37.1",
 ]
 optional-dependencies.build = [ "build", "twine", "wheel" ]
 optional-dependencies.dev = [
@@ -54,9 +53,9 @@ optional-dependencies.dev = [
 optional-dependencies.docs = [ "furo", "myst-parser", "sphinx" ]
 optional-dependencies.edgetest = [ "edgetest", "edgetest-conda" ]
 optional-dependencies.qa = [ "mypy", "pandas-stubs", "pre-commit", "ruff" ]
-optional-dependencies.snowflake = [ "snowflake-snowpark-python<=1.33,>=1.26" ]
+optional-dependencies.snowflake = [ "snowflake-snowpark-python>=1.26,<=1.33" ]
 optional-dependencies.spark = [
-  "pyspark[connect]!=4,<=4.1.1,>=3.5; python_version<='3.11'",
+  "pyspark[connect]>=3.5,!=4,<=4.1.1; python_version<='3.11'",
   "pyspark[connect]>=4; python_version>='3.12'",
 ]
 optional-dependencies.tests = [ "pytest", "pytest-cov" ]


### PR DESCRIPTION
Fixes #407 
- allows for `cache` to be optional so users can utilize databricks serverless.