### PR TITLE
feat: pandas 3 support

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -37,6 +37,9 @@ jobs:
         python-version: ["3.10", "3.11"]
         spark-version: [3.5.7]
         pandas-version: ["2.3.3", "3.0.0"]
+        exclude:
+          - python-version: "3.10"
+            pandas-version: "3.0.0"
 
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}
@@ -75,10 +78,15 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
         spark-version: [4.0.1]
+        pandas-version: ["2.3.3", "3.0.0"]
+        exclude:
+          - python-version: "3.10"
+            pandas-version: "3.0.0"
 
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}
       SPARK_VERSION: ${{ matrix.spark-version }}
+      PANDAS_VERSION: ${{ matrix.pandas-version }}
 
     steps:
       - uses: actions/checkout@v3
@@ -94,6 +102,9 @@ jobs:
       - name: Install pyspark
         run: |
           python -m pip install pyspark[connect]==${{ matrix.spark-version }}
+      - name: Install pandas
+        run: |
+          python -m pip install pandas==${{ matrix.pandas-version }}
       - name: Install datacompy
         run: |
           python -m pip install ."[spark, qa, tests, tests-spark]"

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -36,10 +36,12 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11"]
         spark-version: [3.5.7]
+        pandas-version: ["2.3.3", "3.0.0"]
 
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}
       SPARK_VERSION: ${{ matrix.spark-version }}
+      PANDAS_VERSION: ${{ matrix.pandas-version }}
 
     steps:
       - uses: actions/checkout@v3
@@ -50,11 +52,14 @@ jobs:
       - name: Setup Java JDK
         uses: actions/setup-java@v3
         with:
-          java-version: "8"
+          java-version: "17"
           distribution: "adopt"
       - name: Install pyspark
         run: |
           python -m pip install pyspark[connect]==${{ matrix.spark-version }}
+      - name: Install pandas
+        run: |
+          python -m pip install pandas==${{ matrix.pandas-version }}
       - name: Install datacompy
         run: |
           python -m pip install ."[spark, qa, tests, tests-spark]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
   "jinja2>=3",
   "numpy>=1.26.4,<=2.4.1",
   "ordered-set>=4.0.2,<=4.1",
-  "pandas>=2.2,<=2.3.3",
+  "pandas>=2.2,<=3",
   "polars[pandas]>=0.20.4,<=1.37.1",
 ]
 optional-dependencies.build = [ "build", "twine", "wheel" ]

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -2064,7 +2064,9 @@ def test_custom_comparator_pandas():
         """A custom comparator that matches strings based on length."""
 
         def compare(self, s1, s2, **kwargs):
-            if s1.dtype == "object" and s2.dtype == "object":
+            if (s1.dtype == "object" or pd.api.types.is_string_dtype(s1)) and (
+                s2.dtype == "object" or pd.api.types.is_string_dtype(s2)
+            ):
                 return s1.str.len() == s2.str.len()
             return None
 


### PR DESCRIPTION
In response to #484 

- changes to the actions matrix to test between pandas 2 and 3
- strings in pandas 3 have a critical bug fixed in them, noted here: https://pandas.pydata.org/docs/user_guide/migration-3-strings.html. 
- casting to a string in pandas 2 would also cast `NaN` as the string `nan`, this is now preserved in pandas 3, so there is new logic to account for this with additional use of `fillna(DEFAULT_VALUE)`
- If we cast to a `str` in pandas 2 we will get the string `nan` which will not be filled with the fillna (which is fine and behaves like before). In pandas 3 it will be a real `NaN` and will get filled by the default value which will allow the comparison to work as expected.