### PR TITLE
Pandas: Avoid multiple concat

### DIFF
--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -9,6 +9,16 @@ FOLDER = "data"
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 DATA_DIR = os.path.join(CURRENT_DIR, FOLDER)
 
+# Define test configurations: (size, num_columns)
+TEST_CONFIGS = [
+    (1000, 9),
+    (1000, 50),
+    (1000, 100),
+    (100000, 9),
+    (100000, 50),
+    (100000, 100),
+]
+
 
 def run_polars(base, compare):  # noqa: D103
     comp = datacompy.polars.PolarsCompare(base, compare, join_columns="id")
@@ -22,20 +32,17 @@ def run_pandas(base, compare):  # noqa: D103
     return None
 
 
-@pytest.mark.parametrize("size", [1000, 100000])
-def test_pandas(benchmark, size):  # noqa: D103
-    base = pd.read_parquet(f"{DATA_DIR}/{size}/base/")
-    compare = pd.read_parquet(f"{DATA_DIR}/{size}/compare/")
+@pytest.mark.parametrize("size,num_cols", TEST_CONFIGS)
+def test_pandas(benchmark, size, num_cols):  # noqa: D103
+    data_path = f"{DATA_DIR}/{size}_{num_cols}cols"
+    base = pd.read_parquet(f"{data_path}/base/")
+    compare = pd.read_parquet(f"{data_path}/compare/")
     benchmark.pedantic(target=run_pandas, args=[base, compare], iterations=1, rounds=5)
 
 
-@pytest.mark.parametrize("size", [1000, 100000])
-def test_polars(benchmark, size):  # noqa: D103
-    base = pl.read_parquet(f"{DATA_DIR}/{size}/base/*.parquet")
-    compare = pl.read_parquet(f"{DATA_DIR}/{size}/compare/*.parquet")
+@pytest.mark.parametrize("size,num_cols", TEST_CONFIGS)
+def test_polars(benchmark, size, num_cols):  # noqa: D103
+    data_path = f"{DATA_DIR}/{size}_{num_cols}cols"
+    base = pl.read_parquet(f"{data_path}/base/*.parquet")
+    compare = pl.read_parquet(f"{data_path}/compare/*.parquet")
     benchmark.pedantic(target=run_polars, args=[base, compare], iterations=1, rounds=5)
-
-
-if __name__ == "__main__":
-    # make sure to install pytest-benchmark
-    retcode = pytest.main(["benchmark.py"])

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -46,3 +46,8 @@ def test_polars(benchmark, size, num_cols):  # noqa: D103
     base = pl.read_parquet(f"{data_path}/base/*.parquet")
     compare = pl.read_parquet(f"{data_path}/compare/*.parquet")
     benchmark.pedantic(target=run_polars, args=[base, compare], iterations=1, rounds=5)
+
+
+if __name__ == "__main__":
+    # make sure to install pytest-benchmark
+    retcode = pytest.main(["benchmark.py"])

--- a/benchmarks/benchmark_spark.py
+++ b/benchmarks/benchmark_spark.py
@@ -8,6 +8,14 @@ FOLDER = "data"
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 DATA_DIR = os.path.join(CURRENT_DIR, FOLDER)
 
+# Define test configurations: (size, num_columns)
+TEST_CONFIGS = [
+    (1000, 9),
+    (1000, 50),
+    (100000, 9),
+    (100000, 50),
+]
+
 
 def run_spark(spark_session, base, compare):  # noqa: D103
     comp = datacompy.spark.SparkSQLCompare(
@@ -17,16 +25,17 @@ def run_spark(spark_session, base, compare):  # noqa: D103
     return None
 
 
-@pytest.mark.parametrize("size", [1000, 100000])
-def test_spark(benchmark, size):  # noqa: D103
+@pytest.mark.parametrize("size,num_cols", TEST_CONFIGS)
+def test_spark(benchmark, size, num_cols):  # noqa: D103
     spark = (
         SparkSession.builder.appName("datacompy-benchmark")
         .config("spark.sql.ansi.enabled", "false")
         .enableHiveSupport()
         .getOrCreate()
     )
-    base = spark.read.parquet(f"{DATA_DIR}/{size}/base/")
-    compare = spark.read.parquet(f"{DATA_DIR}/{size}/compare/")
+    data_path = f"{DATA_DIR}/{size}_{num_cols}cols"
+    base = spark.read.parquet(f"{data_path}/base/")
+    compare = spark.read.parquet(f"{data_path}/compare/")
     benchmark.pedantic(
         target=run_spark, args=[spark, base, compare], iterations=1, rounds=5
     )

--- a/benchmarks/generate_data.py
+++ b/benchmarks/generate_data.py
@@ -1,9 +1,14 @@
-import os  # noqa: D100
+"""Generate benchmark datasets of varying shapes using Polars LazyFrame and sink_parquet."""
+
+import logging
+import os
 import shutil
 import string
 
 import numpy as np
 import polars as pl
+
+logger = logging.getLogger(__name__)
 
 
 def generate_columns(num_columns: int, size: int, seed: int = 42) -> dict:
@@ -141,8 +146,14 @@ def generate_data(
     )
     pl.collect_all(sinks)
 
+
 # typically this is only needs to run once to generate the data
 if __name__ == "__main__":
+
+    logger.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+    )
     folder = "data"
     # delete and recreate the folder
     shutil.rmtree(folder, ignore_errors=True)
@@ -158,5 +169,5 @@ if __name__ == "__main__":
 
     for size in sizes:
         for config in column_configs:
-            print(f"Generating data: size={size}, columns={config['num_base_columns']}")
+            logger.info(f"Generating data: size={size}, columns={config['num_base_columns']}")
             generate_data(size=size, folder=folder, **config)

--- a/benchmarks/generate_data.py
+++ b/benchmarks/generate_data.py
@@ -1,80 +1,162 @@
 import os  # noqa: D100
 import shutil
+import string
 
 import numpy as np
 import polars as pl
-import pyarrow.dataset as ds
 
 
-def generate_data(size=1000, folder="data"):
+def generate_columns(num_columns: int, size: int, seed: int = 42) -> dict:
     """
-    Generate two datasets for benchmarking.
+    Generate a dictionary of column data for benchmarking.
 
-    :param size: dataset size to generate
+    Parameters
+    ----------
+    num_columns : int
+        Number of data columns to generate (excluding id column).
+    size : int
+        Number of rows to generate.
+    seed : int
+        Random seed for reproducibility.
+
+    Returns
+    -------
+    dict
+        Dictionary mapping column names to data arrays.
     """
-    rng = np.random.default_rng()
+    rng = np.random.default_rng(seed)
+    columns = {"id": np.arange(0, size)}
 
-    base = pl.DataFrame(
-        {
-            "id": np.arange(0, size),
-            "a": rng.integers(0, 10, size),
-            "b": rng.random(size),
-            "c": rng.choice(["aaa", "bbb", "ccc"], size),
-            "d": rng.integers(0, 10, size),
-            "e": rng.random(size),
-            "f": rng.choice(["aaa", "bbb", "ccc"], size),
-            "g": rng.integers(0, 10, size),
-            "h": rng.random(size),
-            "i": rng.choice(["aaa", "bbb", "ccc"], size),
-        }
-    ).to_arrow()
+    # Generate column names using alphabet letters, then aa, ab, etc.
+    col_names = list(string.ascii_lowercase)
+    for first in string.ascii_lowercase:
+        for second in string.ascii_lowercase:
+            col_names.append(first + second)
 
-    compare = pl.DataFrame(
-        {
-            "id": np.arange(0, size),
-            "d": rng.integers(0, 10, size),
-            "e": rng.random(size),
-            "f": rng.choice(["aaa", "bbb", "ccc"], size),
-            "g": rng.integers(0, 10, size),
-            "h": rng.random(size),
-            "i": rng.choice(["aaa", "bbb", "ccc"], size),
-            "j": rng.integers(0, 10, size),
-            "k": rng.random(size),
-            "l": rng.choice(["aaa", "bbb", "ccc"], size),
-        }
-    ).to_arrow()
+    for i in range(num_columns):
+        col_name = col_names[i]
+        col_type = i % 3  # Cycle through int, float, string
+        if col_type == 0:
+            columns[col_name] = rng.integers(0, 10, size)
+        elif col_type == 1:
+            columns[col_name] = rng.random(size)
+        else:
+            columns[col_name] = rng.choice(["aaa", "bbb", "ccc"], size)
 
-    # write out the datasets as parquet files
-    ds.write_dataset(
-        base,
-        f"{folder}/{size}/base/",
-        basename_template="{i}.parquet",
-        format="parquet",
-        max_rows_per_file=1_000_000,
-        max_rows_per_group=1_000_000,
-        existing_data_behavior="overwrite_or_ignore",
+    return columns
+
+
+def generate_data(
+    size: int = 1000,
+    folder: str = "data",
+    num_base_columns: int = 9,
+    num_compare_columns: int = 9,
+    overlap_columns: int = 6,
+) -> None:
+    """
+    Generate two datasets for benchmarking using Polars LazyFrame.
+
+    Parameters
+    ----------
+    size : int
+        Dataset size (number of rows) to generate.
+    folder : str
+        Output folder for parquet files.
+    num_base_columns : int
+        Number of data columns for base dataset (excluding id).
+    num_compare_columns : int
+        Number of data columns for compare dataset (excluding id).
+    overlap_columns : int
+        Number of columns that overlap between base and compare datasets.
+        These will be the last N columns of base and first N columns of compare.
+    """
+    # Ensure overlap doesn't exceed either dataset's column count
+    overlap_columns = min(overlap_columns, num_base_columns, num_compare_columns)
+
+    # Generate base columns
+    base_cols = generate_columns(num_base_columns, size, seed=42)
+
+    # Generate compare columns with overlapping names for the first overlap_columns
+    # The overlap columns share names but have different data
+    compare_cols = {"id": np.arange(0, size)}
+    rng = np.random.default_rng(123)  # Different seed for compare data
+
+    col_names = list(string.ascii_lowercase)
+    for first in string.ascii_lowercase:
+        for second in string.ascii_lowercase:
+            col_names.append(first + second)
+
+    # Start column naming from where overlap begins in base
+    base_col_names = list(base_cols.keys())[1:]  # Exclude 'id'
+    overlap_start = num_base_columns - overlap_columns
+    overlap_col_names = base_col_names[overlap_start:]
+
+    # Add overlapping columns (same names, different data)
+    for i, col_name in enumerate(overlap_col_names):
+        col_type = (overlap_start + i) % 3
+        if col_type == 0:
+            compare_cols[col_name] = rng.integers(0, 10, size)
+        elif col_type == 1:
+            compare_cols[col_name] = rng.random(size)
+        else:
+            compare_cols[col_name] = rng.choice(["aaa", "bbb", "ccc"], size)
+
+    # Add unique compare columns
+    unique_compare_cols = num_compare_columns - overlap_columns
+    next_col_idx = num_base_columns  # Start after base columns
+    for i in range(unique_compare_cols):
+        col_name = col_names[next_col_idx + i]
+        col_type = (next_col_idx + i) % 3
+        if col_type == 0:
+            compare_cols[col_name] = rng.integers(0, 10, size)
+        elif col_type == 1:
+            compare_cols[col_name] = rng.random(size)
+        else:
+            compare_cols[col_name] = rng.choice(["aaa", "bbb", "ccc"], size)
+
+    # Create output directories
+    base_path = f"{folder}/{size}_{num_base_columns}cols/base"
+    compare_path = f"{folder}/{size}_{num_base_columns}cols/compare"
+    os.makedirs(base_path, exist_ok=True)
+    os.makedirs(compare_path, exist_ok=True)
+
+    # Use LazyFrame and sink_parquet to write data
+    base_lf = pl.LazyFrame(base_cols)
+    compare_lf = pl.LazyFrame(compare_cols)
+
+    sinks = []
+    sinks.append(
+        base_lf.sink_parquet(
+            f"{base_path}/data.parquet",
+            row_group_size=1_000_000,
+            lazy=True
+        )
     )
-    ds.write_dataset(
-        compare,
-        f"{folder}/{size}/compare/",
-        basename_template="{i}.parquet",
-        format="parquet",
-        max_rows_per_file=1_000_000,
-        max_rows_per_group=1_000_000,
-        existing_data_behavior="overwrite_or_ignore",
+    sinks.append(
+        compare_lf.sink_parquet(
+            f"{compare_path}/data.parquet",
+            row_group_size=1_000_000,
+            lazy=True
+        )
     )
+    pl.collect_all(sinks)
 
-
-# typicall this is only needs to run once to generate the data
+# typically this is only needs to run once to generate the data
 if __name__ == "__main__":
     folder = "data"
     # delete and recreate the folder
     shutil.rmtree(folder, ignore_errors=True)
     os.makedirs(folder, exist_ok=True)
 
-    generate_data(size=1000, folder=folder)
-    generate_data(size=100_000, folder=folder)
-    generate_data(size=10_000_000, folder=folder)
-    generate_data(size=50_000_000, folder=folder)
-    generate_data(size=100_000_000, folder=folder)
-    generate_data(size=500_000_000, folder=folder)
+    # Generate datasets with different sizes and column counts
+    sizes = [1000, 100_000, 10_000_000]
+    column_configs = [
+        {"num_base_columns": 9, "num_compare_columns": 9, "overlap_columns": 6},
+        {"num_base_columns": 50, "num_compare_columns": 50, "overlap_columns": 40},
+        {"num_base_columns": 100, "num_compare_columns": 100, "overlap_columns": 80},
+    ]
+
+    for size in sizes:
+        for config in column_configs:
+            print(f"Generating data: size={size}, columns={config['num_base_columns']}")
+            generate_data(size=size, folder=folder, **config)

--- a/benchmarks/generate_data.py
+++ b/benchmarks/generate_data.py
@@ -132,16 +132,12 @@ def generate_data(
     sinks = []
     sinks.append(
         base_lf.sink_parquet(
-            f"{base_path}/data.parquet",
-            row_group_size=1_000_000,
-            lazy=True
+            f"{base_path}/data.parquet", row_group_size=1_000_000, lazy=True
         )
     )
     sinks.append(
         compare_lf.sink_parquet(
-            f"{compare_path}/data.parquet",
-            row_group_size=1_000_000,
-            lazy=True
+            f"{compare_path}/data.parquet", row_group_size=1_000_000, lazy=True
         )
     )
     pl.collect_all(sinks)
@@ -149,7 +145,6 @@ def generate_data(
 
 # typically this is only needs to run once to generate the data
 if __name__ == "__main__":
-
     logger.basicConfig(
         level=logging.INFO,
         format="%(asctime)s - %(levelname)s - %(message)s",
@@ -169,5 +164,7 @@ if __name__ == "__main__":
 
     for size in sizes:
         for config in column_configs:
-            logger.info(f"Generating data: size={size}, columns={config['num_base_columns']}")
+            logger.info(
+                f"Generating data: size={size}, columns={config['num_base_columns']}"
+            )
             generate_data(size=size, folder=folder, **config)

--- a/benchmarks/generate_data.py
+++ b/benchmarks/generate_data.py
@@ -11,6 +11,41 @@ import polars as pl
 
 logger = logging.getLogger(__name__)
 
+def write_partitioned_parquet(
+    df: pl.DataFrame,
+    output_path: str,
+    num_partitions: int = 20,
+) -> None:
+    """
+    Write a DataFrame to multiple parquet files, similar to Spark partitioning.
+
+    Parameters
+    ----------
+    df : pl.DataFrame
+        The DataFrame to write.
+    output_path : str
+        The output directory path.
+    num_partitions : int
+        Number of parquet files to create.
+    """
+    total_rows = df.height
+    rows_per_partition = max(1, total_rows // num_partitions)
+
+    for i in range(num_partitions):
+        start_idx = i * rows_per_partition
+        # Last partition gets remaining rows
+        if i == num_partitions - 1:
+            end_idx = total_rows
+        else:
+            end_idx = start_idx + rows_per_partition
+
+        if start_idx >= total_rows:
+            break
+
+        partition_df = df.slice(start_idx, end_idx - start_idx)
+        partition_file = f"{output_path}/part-{i:05d}.parquet"
+        partition_df.write_parquet(partition_file)
+ 
 
 def generate_base_and_compare_columns(
     size: int, num_base_columns, num_compare_columns, overlap_columns
@@ -108,9 +143,10 @@ def generate_data(
     num_base_columns: int = 9,
     num_compare_columns: int = 9,
     overlap_columns: int = 6,
+    num_partitions: int = 20,
 ) -> None:
     """
-    Generate two datasets for benchmarking using Polars LazyFrame.
+    Generate two datasets for benchmarking using Polars.
 
     Parameters
     ----------
@@ -124,6 +160,8 @@ def generate_data(
         Number of data columns for compare dataset (excluding id).
     overlap_columns : int
         Number of columns that overlap between base and compare datasets.
+    num_partitions : int
+        Number of parquet files to create per dataset (similar to Spark partitions).
     """
     base_columns, compare_columns = generate_base_and_compare_columns(
         size, num_base_columns, num_compare_columns, overlap_columns
@@ -134,22 +172,15 @@ def generate_data(
     os.makedirs(base_path, exist_ok=True)
     os.makedirs(compare_path, exist_ok=True)
 
-    # Use LazyFrame and sink_parquet to write data
-    base_lf = pl.LazyFrame(base_columns)
-    compare_lf = pl.LazyFrame(compare_columns)
+    # Collect and write parquet files with row_group_size for chunking
+    base_df = pl.DataFrame(base_columns)
+    compare_df = pl.DataFrame(compare_columns)
 
-    sinks = []
-    sinks.append(
-        base_lf.sink_parquet(
-            pl.PartitionBy(f"{base_path}/", max_rows_per_file=100_000), lazy=True
-        )
-    )
-    sinks.append(
-        compare_lf.sink_parquet(
-            pl.PartitionBy(f"{compare_path}/", max_rows_per_file=100_000), lazy=True
-        )
-    )
-    pl.collect_all(sinks)
+    # Adjust partitions for small datasets
+    effective_partitions = min(num_partitions, size)
+
+    write_partitioned_parquet(base_df, base_path, effective_partitions)
+    write_partitioned_parquet(compare_df, compare_path, effective_partitions)
 
 
 # typically this is only needs to run once to generate the data

--- a/benchmarks/generate_data.py
+++ b/benchmarks/generate_data.py
@@ -4,6 +4,7 @@ import logging
 import os
 import shutil
 import string
+from itertools import product
 
 import numpy as np
 import polars as pl
@@ -11,44 +12,94 @@ import polars as pl
 logger = logging.getLogger(__name__)
 
 
-def generate_columns(num_columns: int, size: int, seed: int = 42) -> dict:
+def generate_base_and_compare_columns(
+    size: int, num_base_columns, num_compare_columns, overlap_columns
+) -> tuple[dict, dict]:
     """
-    Generate a dictionary of column data for benchmarking.
+    Generate a tuple containing two dictionaries: one for base columns and one for compare columns.
 
     Parameters
     ----------
-    num_columns : int
-        Number of data columns to generate (excluding id column).
     size : int
-        Number of rows to generate.
-    seed : int
-        Random seed for reproducibility.
+        Number of rows for each column.
+    num_base_columns : int
+        Number of data columns for base dataset (excluding id).
+    num_compare_columns : int
+        Number of data columns for compare dataset (excluding id).
+    overlap_columns: int
+        Number of columns that overlap between base and compare datasets.
 
     Returns
     -------
-    dict
-        Dictionary mapping column names to data arrays.
+    tuple
+        A tuple containing:
+        - dict: Containing column names and their generator functions for the base dataset.
+        - dict: Containing column names and their generator functions for the compare dataset.
     """
-    rng = np.random.default_rng(seed)
-    columns = {"id": np.arange(0, size)}
+    # Ensure overlap doesn't exceed either dataset's column count
+    overlap_columns = min(overlap_columns, num_base_columns, num_compare_columns)
+    unique_compare_columns = num_compare_columns - overlap_columns
+
+    rng = np.random.default_rng(42)
+    base_columns = {"id": np.arange(0, size)}
 
     # Generate column names using alphabet letters, then aa, ab, etc.
-    col_names = list(string.ascii_lowercase)
-    for first in string.ascii_lowercase:
-        for second in string.ascii_lowercase:
-            col_names.append(first + second)
+    column_names = [
+        f"{x}{y}" for x, y in product(list(string.ascii_lowercase), repeat=2)
+    ]
 
-    for i in range(num_columns):
-        col_name = col_names[i]
-        col_type = i % 3  # Cycle through int, float, string
-        if col_type == 0:
-            columns[col_name] = rng.integers(0, 10, size)
-        elif col_type == 1:
-            columns[col_name] = rng.random(size)
-        else:
-            columns[col_name] = rng.choice(["aaa", "bbb", "ccc"], size)
+    generators = [
+        lambda: rng.integers(0, 10, size),
+        lambda: rng.random(size),
+        lambda: rng.choice(["aaa", "bbb", "ccc"], size),
+    ]
+    base_columns.update(
+        {column_names[i]: generators[i % 3]() for i in range(num_base_columns)}
+    )
 
-    return columns
+    # Generate compare columns with overlapping names for the first overlap_columns
+    # The overlap columns share names but have different data
+    compare_columns = {"id": np.arange(0, size)}
+    rng = np.random.default_rng(123)  # Different seed for compare data
+    compare_generators = [
+        lambda: rng.integers(0, 10, size),
+        lambda: rng.random(size),
+        lambda: rng.choice(["aaa", "bbb", "ccc"], size),
+    ]
+
+    # Start column naming from where overlap begins in base
+    base_column_names = list(base_columns.keys())[1:]  # Exclude 'id'
+    overlap_start = num_base_columns - overlap_columns
+    overlap_column_names = base_column_names[overlap_start:]
+
+    # Create overlapping columns (same names, different data)
+    compare_columns.update(
+        {
+            column_name: compare_generators[(overlap_start + i) % 3]()
+            for i, column_name in enumerate(overlap_column_names)
+        }
+    )
+
+    # Add unique compare columns
+    compare_columns.update(
+        {
+            column_names[num_base_columns + i]: compare_generators[
+                (num_base_columns + i) % 3
+            ]()
+            for i in range(unique_compare_columns)
+        }
+    )
+
+    assert len(base_columns) == len(compare_columns)
+    assert set(base_columns.keys()) & set(compare_columns.keys()) == set(
+        overlap_column_names
+    ) ^ {"id"}
+    assert (
+        len(set(base_columns.keys()) & set(compare_columns.keys()))
+        == overlap_columns + 1  # +1 for 'id'
+    )
+
+    return base_columns, compare_columns
 
 
 def generate_data(
@@ -73,71 +124,29 @@ def generate_data(
         Number of data columns for compare dataset (excluding id).
     overlap_columns : int
         Number of columns that overlap between base and compare datasets.
-        These will be the last N columns of base and first N columns of compare.
     """
-    # Ensure overlap doesn't exceed either dataset's column count
-    overlap_columns = min(overlap_columns, num_base_columns, num_compare_columns)
+    base_columns, compare_columns = generate_base_and_compare_columns(
+        size, num_base_columns, num_compare_columns, overlap_columns
+    )
 
-    # Generate base columns
-    base_cols = generate_columns(num_base_columns, size, seed=42)
-
-    # Generate compare columns with overlapping names for the first overlap_columns
-    # The overlap columns share names but have different data
-    compare_cols = {"id": np.arange(0, size)}
-    rng = np.random.default_rng(123)  # Different seed for compare data
-
-    col_names = list(string.ascii_lowercase)
-    for first in string.ascii_lowercase:
-        for second in string.ascii_lowercase:
-            col_names.append(first + second)
-
-    # Start column naming from where overlap begins in base
-    base_col_names = list(base_cols.keys())[1:]  # Exclude 'id'
-    overlap_start = num_base_columns - overlap_columns
-    overlap_col_names = base_col_names[overlap_start:]
-
-    # Add overlapping columns (same names, different data)
-    for i, col_name in enumerate(overlap_col_names):
-        col_type = (overlap_start + i) % 3
-        if col_type == 0:
-            compare_cols[col_name] = rng.integers(0, 10, size)
-        elif col_type == 1:
-            compare_cols[col_name] = rng.random(size)
-        else:
-            compare_cols[col_name] = rng.choice(["aaa", "bbb", "ccc"], size)
-
-    # Add unique compare columns
-    unique_compare_cols = num_compare_columns - overlap_columns
-    next_col_idx = num_base_columns  # Start after base columns
-    for i in range(unique_compare_cols):
-        col_name = col_names[next_col_idx + i]
-        col_type = (next_col_idx + i) % 3
-        if col_type == 0:
-            compare_cols[col_name] = rng.integers(0, 10, size)
-        elif col_type == 1:
-            compare_cols[col_name] = rng.random(size)
-        else:
-            compare_cols[col_name] = rng.choice(["aaa", "bbb", "ccc"], size)
-
-    # Create output directories
     base_path = f"{folder}/{size}_{num_base_columns}cols/base"
     compare_path = f"{folder}/{size}_{num_base_columns}cols/compare"
     os.makedirs(base_path, exist_ok=True)
     os.makedirs(compare_path, exist_ok=True)
 
     # Use LazyFrame and sink_parquet to write data
-    base_lf = pl.LazyFrame(base_cols)
-    compare_lf = pl.LazyFrame(compare_cols)
+    base_lf = pl.LazyFrame(base_columns)
+    compare_lf = pl.LazyFrame(compare_columns)
 
     sinks = []
     sinks.append(
         base_lf.sink_parquet(
-            f"{base_path}/data.parquet", row_group_size=1_000_000, lazy=True
+            pl.PartitionBy(f"{base_path}/", max_rows_per_file=100_000), lazy=True
         )
     )
     sinks.append(
         compare_lf.sink_parquet(
-            f"{compare_path}/data.parquet", row_group_size=1_000_000, lazy=True
+            pl.PartitionBy(f"{compare_path}/", max_rows_per_file=100_000), lazy=True
         )
     )
     pl.collect_all(sinks)
@@ -145,7 +154,7 @@ def generate_data(
 
 # typically this is only needs to run once to generate the data
 if __name__ == "__main__":
-    logger.basicConfig(
+    logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s - %(levelname)s - %(message)s",
     )

--- a/benchmarks/generate_data.py
+++ b/benchmarks/generate_data.py
@@ -11,6 +11,7 @@ import polars as pl
 
 logger = logging.getLogger(__name__)
 
+
 def write_partitioned_parquet(
     df: pl.DataFrame,
     output_path: str,
@@ -45,7 +46,7 @@ def write_partitioned_parquet(
         partition_df = df.slice(start_idx, end_idx - start_idx)
         partition_file = f"{output_path}/part-{i:05d}.parquet"
         partition_df.write_parquet(partition_file)
- 
+
 
 def generate_base_and_compare_columns(
     size: int, num_base_columns, num_compare_columns, overlap_columns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ optional-dependencies.spark = [
   "pyspark[connect]>=3.5,!=4,<=4.1.1; python_version<='3.11'",
   "pyspark[connect]>=4; python_version>='3.12'",
 ]
-optional-dependencies.tests = [ "pytest", "pytest-cov" ]
+optional-dependencies.tests = [ "pytest", "pytest-cov", "pytest-benchmark", "pytest-profiling" ]
 optional-dependencies.tests-spark = [ "pytest-spark" ]
 urls."Bug Tracker" = "https://github.com/capitalone/datacompy/issues"
 urls.Documentation = "https://capitalone.github.io/datacompy/"


### PR DESCRIPTION
Thanks for a great library!

I have been using the Pandas functionality to compare some DataFrames that have grown over time. I noticed that with a few hundred columns I was spending more time comparing the DataFrames than I was creating them. 😢 

Some profiling showed that `np.copy` was being called repeatedly due to `pd.concat` inside the loop in: https://github.com/capitalone/datacompy/blob/develop/datacompy/pandas.py#L377-L406

The proposed enhancement in `pandas.py` does the `pd.concat` once outside the loop instead.

To show the behavior I also made some tweaks to the benchmarking code to also produce test files with varying number of columns.
Additionally, I changed the code to use LazyFrames and sink_parquet to generate the test data. It still takes about 4-5 min to generate, but uses significantly less memory.

Here is a pytest benchmark comparing two runs (before the changes in `pandas.py` and after the changes),  showing that the large and wide DataFrame (100,000 x 100) went from 9.1s to 5.4s.

<img width="1551" height="278" alt="datacompy_comparison" src="https://github.com/user-attachments/assets/14c3e276-e656-440d-bee5-c3dcda60cf16" />

