### PR TITLE
feat: cols with mismatches

### DIFF
--- a/datacompy/base.py
+++ b/datacompy/base.py
@@ -186,6 +186,31 @@ class BaseCompare(ABC):
         """Boolean on if the only columns are the join columns."""
         return set(self.join_columns) == set(self.df1.columns) == set(self.df2.columns)
 
+    def columns_with_mismatches(self) -> list[str]:
+        """Return a list of column names where at least one row has a mismatch.
+
+        This method identifies columns that have differences between df1 and df2,
+        excluding the join columns. This is useful for identifying problematic
+        columns and potentially rerunning comparisons on a subset of the data.
+
+        Returns
+        -------
+        list[str]
+            A sorted list of column names that have at least one mismatch.
+
+        Examples
+        --------
+        >>> compare = PandasCompare(df1, df2, join_columns=['id'])
+        >>> mismatched_cols = compare.columns_with_mismatches()
+        >>> print(mismatched_cols)
+        ['col_a', 'col_b']
+        """
+        return [
+            col["column"]
+            for col in self.column_stats
+            if col["unequal_cnt"] > 0 and col["column"] not in self.join_columns
+        ]
+
 
 def _resolve_template_path(template_name: str) -> tuple[str, str]:
     """Resolve template path and return (template_dir, template_file).

--- a/datacompy/base.py
+++ b/datacompy/base.py
@@ -196,7 +196,7 @@ class BaseCompare(ABC):
         Returns
         -------
         list[str]
-            A sorted list of column names that have at least one mismatch.
+            A list of column names that have at least one mismatch.
 
         Examples
         --------

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -2171,3 +2171,139 @@ def test_array_comparator_pandas():
     mismatches = compare.all_mismatch().sort_values("id").reset_index(drop=True)
     assert len(mismatches) == 3
     assert list(mismatches["id"]) == [2, 5, 6]
+
+
+def test_columns_with_mismatches_single_column():
+    """Test columns_with_mismatches with a single mismatched column."""
+    df1 = pd.DataFrame(
+        {"id": [1, 2, 3], "name": ["Alice", "Bob", "Charlie"], "age": [25, 30, 35]}
+    )
+    df2 = pd.DataFrame(
+        {
+            "id": [1, 2, 3],
+            "name": ["Alice", "Bob", "Charlie"],
+            "age": [25, 31, 35],  # age differs for id=2
+        }
+    )
+    compare = PandasCompare(df1, df2, join_columns=["id"])
+    result = compare.columns_with_mismatches()
+    assert result == ["age"]
+
+
+def test_columns_with_mismatches_multiple_columns():
+    """Test columns_with_mismatches with multiple mismatched columns."""
+    df1 = pd.DataFrame(
+        {
+            "id": [1, 2, 3],
+            "name": ["Alice", "Bob", "Charlie"],
+            "age": [25, 30, 35],
+            "city": ["NYC", "LA", "Chicago"],
+        }
+    )
+    df2 = pd.DataFrame(
+        {
+            "id": [1, 2, 3],
+            "name": ["Alice", "Bob", "Charlie"],
+            "age": [25, 31, 35],  # age differs for id=2
+            "city": ["NYC", "LA", "Boston"],  # city differs for id=3
+        }
+    )
+    compare = PandasCompare(df1, df2, join_columns=["id"])
+    result = compare.columns_with_mismatches()
+    assert result == ["age", "city"]
+
+
+def test_columns_with_mismatches_no_mismatches():
+    """Test columns_with_mismatches when all columns match."""
+    df1 = pd.DataFrame(
+        {"id": [1, 2, 3], "name": ["Alice", "Bob", "Charlie"], "age": [25, 30, 35]}
+    )
+    df2 = pd.DataFrame(
+        {"id": [1, 2, 3], "name": ["Alice", "Bob", "Charlie"], "age": [25, 30, 35]}
+    )
+    compare = PandasCompare(df1, df2, join_columns=["id"])
+    result = compare.columns_with_mismatches()
+    assert result == []
+
+
+def test_columns_with_mismatches_excludes_join_columns():
+    """Test that join columns are excluded from the result."""
+    df1 = pd.DataFrame({"id": [1, 2, 3], "value": ["a", "b", "c"]})
+    df2 = pd.DataFrame(
+        {
+            "id": [1, 2, 4],  # id=3 missing, id=4 added
+            "value": ["a", "b", "d"],
+        }
+    )
+    compare = PandasCompare(df1, df2, join_columns=["id"])
+    result = compare.columns_with_mismatches()
+    # 'id' should not be in the result even though there are row mismatches
+    assert "id" not in result
+    # Result should be empty because 'value' matches for the intersecting rows
+    assert result == []
+
+
+def test_columns_with_mismatches_with_nulls():
+    """Test columns_with_mismatches with null values."""
+    df1 = pd.DataFrame({"id": [1, 2, 3], "value": ["a", None, "c"]})
+    df2 = pd.DataFrame(
+        {
+            "id": [1, 2, 3],
+            "value": ["a", "b", "c"],  # null differs to 'b' for id=2
+        }
+    )
+    compare = PandasCompare(df1, df2, join_columns=["id"])
+    result = compare.columns_with_mismatches()
+    assert result == ["value"]
+
+
+def test_columns_with_mismatches_multiple_join_columns():
+    """Test columns_with_mismatches with multiple join columns."""
+    df1 = pd.DataFrame(
+        {
+            "id1": [1, 1, 2, 2],
+            "id2": ["a", "b", "a", "b"],
+            "value1": [10, 20, 30, 40],
+            "value2": [100, 200, 300, 400],
+        }
+    )
+    df2 = pd.DataFrame(
+        {
+            "id1": [1, 1, 2, 2],
+            "id2": ["a", "b", "a", "b"],
+            "value1": [10, 25, 30, 40],  # value1 differs for (1, 'b')
+            "value2": [100, 200, 305, 400],  # value2 differs for (2, 'a')
+        }
+    )
+    compare = PandasCompare(df1, df2, join_columns=["id1", "id2"])
+    result = compare.columns_with_mismatches()
+    assert "id1" not in result
+    assert "id2" not in result
+    assert result == ["value1", "value2"]
+
+
+def test_columns_with_mismatches_empty_dataframes():
+    """Test columns_with_mismatches with empty dataframes."""
+    df1 = pd.DataFrame({"id": [], "value": []})
+    df2 = pd.DataFrame({"id": [], "value": []})
+    compare = PandasCompare(df1, df2, join_columns=["id"])
+    result = compare.columns_with_mismatches()
+    assert result == []
+
+
+def test_columns_with_mismatches_on_index():
+    """Test columns_with_mismatches when comparing on index."""
+    df1 = pd.DataFrame(
+        {"name": ["Alice", "Bob", "Charlie"], "age": [25, 30, 35]}, index=[1, 2, 3]
+    )
+    df2 = pd.DataFrame(
+        {
+            "name": ["Alice", "Bob", "Charlie"],
+            "age": [25, 31, 35],  # age differs for index=2
+        },
+        index=[1, 2, 3],
+    )
+    compare = PandasCompare(df1, df2, on_index=True)
+    result = compare.columns_with_mismatches()
+    # When on_index=True, join_columns is empty, so all mismatching columns should be returned
+    assert result == ["age"]

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -2210,7 +2210,7 @@ def test_columns_with_mismatches_multiple_columns():
     )
     compare = PandasCompare(df1, df2, join_columns=["id"])
     result = compare.columns_with_mismatches()
-    assert result == ["age", "city"]
+    assert sorted(result) == ["age", "city"]
 
 
 def test_columns_with_mismatches_no_mismatches():
@@ -2279,7 +2279,7 @@ def test_columns_with_mismatches_multiple_join_columns():
     result = compare.columns_with_mismatches()
     assert "id1" not in result
     assert "id2" not in result
-    assert result == ["value1", "value2"]
+    assert sorted(result) == ["value1", "value2"]
 
 
 def test_columns_with_mismatches_empty_dataframes():

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -2177,3 +2177,137 @@ def test_list_comparator_polars():
     )
     assert list_col_stats["unequal_cnt"] == 1
     assert list_col_stats["match_cnt"] == 2
+
+
+def test_columns_with_mismatches_single_column():
+    """Test columns_with_mismatches with a single mismatched column."""
+    df1 = pl.DataFrame(
+        {"id": [1, 2, 3], "name": ["Alice", "Bob", "Charlie"], "age": [25, 30, 35]}
+    )
+    df2 = pl.DataFrame(
+        {
+            "id": [1, 2, 3],
+            "name": ["Alice", "Bob", "Charlie"],
+            "age": [25, 31, 35],  # age differs for id=2
+        }
+    )
+    compare = PolarsCompare(df1, df2, join_columns=["id"])
+    result = compare.columns_with_mismatches()
+    assert result == ["age"]
+
+
+def test_columns_with_mismatches_multiple_columns():
+    """Test columns_with_mismatches with multiple mismatched columns."""
+    df1 = pl.DataFrame(
+        {
+            "id": [1, 2, 3],
+            "name": ["Alice", "Bob", "Charlie"],
+            "age": [25, 30, 35],
+            "city": ["NYC", "LA", "Chicago"],
+        }
+    )
+    df2 = pl.DataFrame(
+        {
+            "id": [1, 2, 3],
+            "name": ["Alice", "Bob", "Charlie"],
+            "age": [25, 31, 35],  # age differs for id=2
+            "city": ["NYC", "LA", "Boston"],  # city differs for id=3
+        }
+    )
+    compare = PolarsCompare(df1, df2, join_columns=["id"])
+    result = compare.columns_with_mismatches()
+    assert result == ["age", "city"]
+
+
+def test_columns_with_mismatches_no_mismatches():
+    """Test columns_with_mismatches when all columns match."""
+    df1 = pl.DataFrame(
+        {"id": [1, 2, 3], "name": ["Alice", "Bob", "Charlie"], "age": [25, 30, 35]}
+    )
+    df2 = pl.DataFrame(
+        {"id": [1, 2, 3], "name": ["Alice", "Bob", "Charlie"], "age": [25, 30, 35]}
+    )
+    compare = PolarsCompare(df1, df2, join_columns=["id"])
+    result = compare.columns_with_mismatches()
+    assert result == []
+
+
+def test_columns_with_mismatches_excludes_join_columns():
+    """Test that join columns are excluded from the result."""
+    df1 = pl.DataFrame({"id": [1, 2, 3], "value": ["a", "b", "c"]})
+    df2 = pl.DataFrame(
+        {
+            "id": [1, 2, 4],  # id=3 missing, id=4 added
+            "value": ["a", "b", "d"],
+        }
+    )
+    compare = PolarsCompare(df1, df2, join_columns=["id"])
+    result = compare.columns_with_mismatches()
+    # 'id' should not be in the result even though there are row mismatches
+    assert "id" not in result
+    # Result should be empty because 'value' matches for the intersecting rows
+    assert result == []
+
+
+def test_columns_with_mismatches_sorted():
+    """Test that columns_with_mismatches returns sorted column names."""
+    df1 = pl.DataFrame(
+        {
+            "id": [1, 2],
+            "zebra": [1, 2],
+            "apple": [1, 2],
+            "mango": [1, 3],  # mango differs
+        }
+    )
+    df2 = pl.DataFrame(
+        {
+            "id": [1, 2],
+            "zebra": [1, 2],
+            "apple": [1, 2],
+            "mango": [1, 4],  # mango differs
+        }
+    )
+    compare = PolarsCompare(df1, df2, join_columns=["id"])
+    result = compare.columns_with_mismatches()
+    # Should be sorted alphabetically even though 'mango' comes after 'zebra'
+    assert result == ["mango"]
+
+
+def test_columns_with_mismatches_with_nulls():
+    """Test columns_with_mismatches with null values."""
+    df1 = pl.DataFrame({"id": [1, 2, 3], "value": ["a", None, "c"]}, strict=False)
+    df2 = pl.DataFrame(
+        {
+            "id": [1, 2, 3],
+            "value": ["a", "b", "c"],  # null differs to 'b' for id=2
+        },
+        strict=False,
+    )
+    compare = PolarsCompare(df1, df2, join_columns=["id"])
+    result = compare.columns_with_mismatches()
+    assert result == ["value"]
+
+
+def test_columns_with_mismatches_multiple_join_columns():
+    """Test columns_with_mismatches with multiple join columns."""
+    df1 = pl.DataFrame(
+        {
+            "id1": [1, 1, 2, 2],
+            "id2": ["a", "b", "a", "b"],
+            "value1": [10, 20, 30, 40],
+            "value2": [100, 200, 300, 400],
+        }
+    )
+    df2 = pl.DataFrame(
+        {
+            "id1": [1, 1, 2, 2],
+            "id2": ["a", "b", "a", "b"],
+            "value1": [10, 25, 30, 40],  # value1 differs for (1, 'b')
+            "value2": [100, 200, 305, 400],  # value2 differs for (2, 'a')
+        }
+    )
+    compare = PolarsCompare(df1, df2, join_columns=["id1", "id2"])
+    result = compare.columns_with_mismatches()
+    assert "id1" not in result
+    assert "id2" not in result
+    assert result == ["value1", "value2"]

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -2216,7 +2216,7 @@ def test_columns_with_mismatches_multiple_columns():
     )
     compare = PolarsCompare(df1, df2, join_columns=["id"])
     result = compare.columns_with_mismatches()
-    assert result == ["age", "city"]
+    assert sorted(result) == ["age", "city"]
 
 
 def test_columns_with_mismatches_no_mismatches():
@@ -2247,30 +2247,6 @@ def test_columns_with_mismatches_excludes_join_columns():
     assert "id" not in result
     # Result should be empty because 'value' matches for the intersecting rows
     assert result == []
-
-
-def test_columns_with_mismatches_sorted():
-    """Test that columns_with_mismatches returns sorted column names."""
-    df1 = pl.DataFrame(
-        {
-            "id": [1, 2],
-            "zebra": [1, 2],
-            "apple": [1, 2],
-            "mango": [1, 3],  # mango differs
-        }
-    )
-    df2 = pl.DataFrame(
-        {
-            "id": [1, 2],
-            "zebra": [1, 2],
-            "apple": [1, 2],
-            "mango": [1, 4],  # mango differs
-        }
-    )
-    compare = PolarsCompare(df1, df2, join_columns=["id"])
-    result = compare.columns_with_mismatches()
-    # Should be sorted alphabetically even though 'mango' comes after 'zebra'
-    assert result == ["mango"]
 
 
 def test_columns_with_mismatches_with_nulls():
@@ -2310,4 +2286,4 @@ def test_columns_with_mismatches_multiple_join_columns():
     result = compare.columns_with_mismatches()
     assert "id1" not in result
     assert "id2" not in result
-    assert result == ["value1", "value2"]
+    assert sorted(result) == ["value1", "value2"]

--- a/tests/test_snowflake.py
+++ b/tests/test_snowflake.py
@@ -2099,7 +2099,7 @@ def test_columns_with_mismatches_multiple_columns(snowflake_session):
     )
     compare = SnowflakeCompare(snowflake_session, df1, df2, join_columns=["ID"])
     result = compare.columns_with_mismatches()
-    assert result == ["AGE", "CITY"]
+    assert sorted(result) == ["AGE", "CITY"]
 
 
 def test_columns_with_mismatches_no_mismatches(snowflake_session):
@@ -2173,4 +2173,4 @@ def test_columns_with_mismatches_multiple_join_columns(snowflake_session):
     result = compare.columns_with_mismatches()
     assert "ID1" not in result
     assert "ID2" not in result
-    assert result == ["VALUE1", "VALUE2"]
+    assert sorted(result) == ["VALUE1", "VALUE2"]

--- a/tests/test_snowflake.py
+++ b/tests/test_snowflake.py
@@ -2063,3 +2063,114 @@ def test_array_comparator_snowflake(snowflake_session):
     assert mismatch_df["ID"].iloc[2] == 6
     assert mismatch_df["ARRAY_COL_DF1"].iloc[2] == "[\n  1,\n  2\n]"
     assert mismatch_df["ARRAY_COL_DF2"].iloc[2] == "[\n  1,\n  2,\n  3\n]"
+
+
+def test_columns_with_mismatches_single_column(snowflake_session):
+    """Test columns_with_mismatches with a single mismatched column."""
+    df1 = snowflake_session.createDataFrame(
+        [(1, "Alice", 25), (2, "Bob", 30), (3, "Charlie", 35)], ["ID", "NAME", "AGE"]
+    )
+    df2 = snowflake_session.createDataFrame(
+        [
+            (1, "Alice", 25),
+            (2, "Bob", 31),  # age differs for id=2
+            (3, "Charlie", 35),
+        ],
+        ["ID", "NAME", "AGE"],
+    )
+    compare = SnowflakeCompare(snowflake_session, df1, df2, join_columns=["ID"])
+    result = compare.columns_with_mismatches()
+    assert result == ["AGE"]
+
+
+def test_columns_with_mismatches_multiple_columns(snowflake_session):
+    """Test columns_with_mismatches with multiple mismatched columns."""
+    df1 = snowflake_session.createDataFrame(
+        [(1, "Alice", 25, "NYC"), (2, "Bob", 30, "LA"), (3, "Charlie", 35, "Chicago")],
+        ["ID", "NAME", "AGE", "CITY"],
+    )
+    df2 = snowflake_session.createDataFrame(
+        [
+            (1, "Alice", 25, "NYC"),
+            (2, "Bob", 31, "LA"),  # age differs for id=2
+            (3, "Charlie", 35, "Boston"),  # city differs for id=3
+        ],
+        ["ID", "NAME", "AGE", "CITY"],
+    )
+    compare = SnowflakeCompare(snowflake_session, df1, df2, join_columns=["ID"])
+    result = compare.columns_with_mismatches()
+    assert result == ["AGE", "CITY"]
+
+
+def test_columns_with_mismatches_no_mismatches(snowflake_session):
+    """Test columns_with_mismatches when all columns match."""
+    df1 = snowflake_session.createDataFrame(
+        [(1, "Alice", 25), (2, "Bob", 30), (3, "Charlie", 35)], ["ID", "NAME", "AGE"]
+    )
+    df2 = snowflake_session.createDataFrame(
+        [(1, "Alice", 25), (2, "Bob", 30), (3, "Charlie", 35)], ["ID", "NAME", "AGE"]
+    )
+    compare = SnowflakeCompare(snowflake_session, df1, df2, join_columns=["ID"])
+    result = compare.columns_with_mismatches()
+    assert result == []
+
+
+def test_columns_with_mismatches_excludes_join_columns(snowflake_session):
+    """Test that join columns are excluded from the result."""
+    df1 = snowflake_session.createDataFrame(
+        [(1, "a"), (2, "b"), (3, "c")], ["ID", "VALUE"]
+    )
+    df2 = snowflake_session.createDataFrame(
+        [
+            (1, "a"),
+            (2, "b"),
+            (4, "d"),  # id=3 missing, id=4 added
+        ],
+        ["ID", "VALUE"],
+    )
+    compare = SnowflakeCompare(snowflake_session, df1, df2, join_columns=["ID"])
+    result = compare.columns_with_mismatches()
+    # 'ID' should not be in the result even though there are row mismatches
+    assert "ID" not in result
+    # Result should be empty because 'VALUE' matches for the intersecting rows
+    assert result == []
+
+
+def test_columns_with_mismatches_with_nulls(snowflake_session):
+    """Test columns_with_mismatches with null values."""
+    df1 = snowflake_session.createDataFrame(
+        [(1, "a"), (2, None), (3, "c")], ["ID", "VALUE"]
+    )
+    df2 = snowflake_session.createDataFrame(
+        [
+            (1, "a"),
+            (2, "b"),  # null differs to 'b' for id=2
+            (3, "c"),
+        ],
+        ["ID", "VALUE"],
+    )
+    compare = SnowflakeCompare(snowflake_session, df1, df2, join_columns=["ID"])
+    result = compare.columns_with_mismatches()
+    assert result == ["VALUE"]
+
+
+def test_columns_with_mismatches_multiple_join_columns(snowflake_session):
+    """Test columns_with_mismatches with multiple join columns."""
+    df1 = snowflake_session.createDataFrame(
+        [(1, "a", 10, 100), (1, "b", 20, 200), (2, "a", 30, 300), (2, "b", 40, 400)],
+        ["ID1", "ID2", "VALUE1", "VALUE2"],
+    )
+    df2 = snowflake_session.createDataFrame(
+        [
+            (1, "a", 10, 100),
+            (1, "b", 25, 200),  # value1 differs for (1, 'b')
+            (2, "a", 30, 305),  # value2 differs for (2, 'a')
+            (2, "b", 40, 400),
+        ],
+        ["ID1", "ID2", "VALUE1", "VALUE2"],
+    )
+    compare = SnowflakeCompare(snowflake_session, df1, df2, join_columns=["ID1", "ID2"])
+    result = compare.columns_with_mismatches()
+    assert "ID1" not in result
+    assert "ID2" not in result
+    assert result == ["VALUE1", "VALUE2"]

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -2360,7 +2360,7 @@ def test_columns_with_mismatches_multiple_columns(spark_session):
     )
     compare = SparkSQLCompare(spark_session, df1, df2, join_columns=["id"])
     result = compare.columns_with_mismatches()
-    assert result == ["age", "city"]
+    assert sorted(result) == ["age", "city"]
 
 
 def test_columns_with_mismatches_no_mismatches(spark_session):
@@ -2432,4 +2432,4 @@ def test_columns_with_mismatches_multiple_join_columns(spark_session):
     result = compare.columns_with_mismatches()
     assert "id1" not in result
     assert "id2" not in result
-    assert result == ["value1", "value2"]
+    assert sorted(result) == ["value1", "value2"]

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -2324,3 +2324,112 @@ def test_cache_intermediates_default_is_true(spark_session, caplog):
     assert compare.cache_intermediates is True
     assert "Caching intermediate dataframes" in caplog.text
     assert "Caching intersect_rows dataframe" in caplog.text
+
+
+def test_columns_with_mismatches_single_column(spark_session):
+    """Test columns_with_mismatches with a single mismatched column."""
+    df1 = spark_session.createDataFrame(
+        [(1, "Alice", 25), (2, "Bob", 30), (3, "Charlie", 35)], ["id", "name", "age"]
+    )
+    df2 = spark_session.createDataFrame(
+        [
+            (1, "Alice", 25),
+            (2, "Bob", 31),  # age differs for id=2
+            (3, "Charlie", 35),
+        ],
+        ["id", "name", "age"],
+    )
+    compare = SparkSQLCompare(spark_session, df1, df2, join_columns=["id"])
+    result = compare.columns_with_mismatches()
+    assert result == ["age"]
+
+
+def test_columns_with_mismatches_multiple_columns(spark_session):
+    """Test columns_with_mismatches with multiple mismatched columns."""
+    df1 = spark_session.createDataFrame(
+        [(1, "Alice", 25, "NYC"), (2, "Bob", 30, "LA"), (3, "Charlie", 35, "Chicago")],
+        ["id", "name", "age", "city"],
+    )
+    df2 = spark_session.createDataFrame(
+        [
+            (1, "Alice", 25, "NYC"),
+            (2, "Bob", 31, "LA"),  # age differs for id=2
+            (3, "Charlie", 35, "Boston"),  # city differs for id=3
+        ],
+        ["id", "name", "age", "city"],
+    )
+    compare = SparkSQLCompare(spark_session, df1, df2, join_columns=["id"])
+    result = compare.columns_with_mismatches()
+    assert result == ["age", "city"]
+
+
+def test_columns_with_mismatches_no_mismatches(spark_session):
+    """Test columns_with_mismatches when all columns match."""
+    df1 = spark_session.createDataFrame(
+        [(1, "Alice", 25), (2, "Bob", 30), (3, "Charlie", 35)], ["id", "name", "age"]
+    )
+    df2 = spark_session.createDataFrame(
+        [(1, "Alice", 25), (2, "Bob", 30), (3, "Charlie", 35)], ["id", "name", "age"]
+    )
+    compare = SparkSQLCompare(spark_session, df1, df2, join_columns=["id"])
+    result = compare.columns_with_mismatches()
+    assert result == []
+
+
+def test_columns_with_mismatches_excludes_join_columns(spark_session):
+    """Test that join columns are excluded from the result."""
+    df1 = spark_session.createDataFrame([(1, "a"), (2, "b"), (3, "c")], ["id", "value"])
+    df2 = spark_session.createDataFrame(
+        [
+            (1, "a"),
+            (2, "b"),
+            (4, "d"),  # id=3 missing, id=4 added
+        ],
+        ["id", "value"],
+    )
+    compare = SparkSQLCompare(spark_session, df1, df2, join_columns=["id"])
+    result = compare.columns_with_mismatches()
+    # 'id' should not be in the result even though there are row mismatches
+    assert "id" not in result
+    # Result should be empty because 'value' matches for the intersecting rows
+    assert result == []
+
+
+def test_columns_with_mismatches_with_nulls(spark_session):
+    """Test columns_with_mismatches with null values."""
+    df1 = spark_session.createDataFrame(
+        [(1, "a"), (2, None), (3, "c")], ["id", "value"]
+    )
+    df2 = spark_session.createDataFrame(
+        [
+            (1, "a"),
+            (2, "b"),  # null differs to 'b' for id=2
+            (3, "c"),
+        ],
+        ["id", "value"],
+    )
+    compare = SparkSQLCompare(spark_session, df1, df2, join_columns=["id"])
+    result = compare.columns_with_mismatches()
+    assert result == ["value"]
+
+
+def test_columns_with_mismatches_multiple_join_columns(spark_session):
+    """Test columns_with_mismatches with multiple join columns."""
+    df1 = spark_session.createDataFrame(
+        [(1, "a", 10, 100), (1, "b", 20, 200), (2, "a", 30, 300), (2, "b", 40, 400)],
+        ["id1", "id2", "value1", "value2"],
+    )
+    df2 = spark_session.createDataFrame(
+        [
+            (1, "a", 10, 100),
+            (1, "b", 25, 200),  # value1 differs for (1, 'b')
+            (2, "a", 30, 305),  # value2 differs for (2, 'a')
+            (2, "b", 40, 400),
+        ],
+        ["id1", "id2", "value1", "value2"],
+    )
+    compare = SparkSQLCompare(spark_session, df1, df2, join_columns=["id1", "id2"])
+    result = compare.columns_with_mismatches()
+    assert "id1" not in result
+    assert "id2" not in result
+    assert result == ["value1", "value2"]


### PR DESCRIPTION
Fixes #487 

Return a list of column names where at least one row has a mismatch between df1 and df2. This is useful for identifying problematic columns and potentially rerunning comparisons on a subset of the data.