### PR TITLE
feat: hash sensitive columns in PolarsCompare

### DIFF
--- a/datacompy/pandas.py
+++ b/datacompy/pandas.py
@@ -1037,15 +1037,6 @@ def columns_equal(
     - Non-numeric values (i.e. where np.isclose can't be used) will just trigger
       ``True`` on two nulls or exact matches.
 
-    Notes
-    -----
-    - As of version ``0.14.0`` If a column is of a mixed data type the compare
-      will default to returning ``False``.
-    - ``list`` and ``np.array`` types will be compared row wise using ``np.array_equal``.
-      Depending on the size of your data this might lead to performance issues.
-    - All the rows must be of the same type otherwise it is considered "mixed"
-      and will default to being ``False`` for everything.
-
     Parameters
     ----------
     col_1 : Pandas.Series
@@ -1070,6 +1061,15 @@ def columns_equal(
     pandas.Series
         A series of Boolean values.  True == the values match, False == the
         values don't match.
+
+    Notes
+    -----
+    - As of version ``0.14.0`` If a column is of a mixed data type the compare
+      will default to returning ``False``.
+    - ``list`` and ``np.array`` types will be compared row wise using ``np.array_equal``.
+      Depending on the size of your data this might lead to performance issues.
+    - All the rows must be of the same type otherwise it is considered "mixed"
+      and will default to being ``False`` for everything.
     """
     compare: pd.Series[bool] | None
 

--- a/datacompy/polars.py
+++ b/datacompy/polars.py
@@ -231,20 +231,24 @@ class PolarsCompare(BaseCompare):
             "dataframes with columns in sensitive_columns will be modified inplace."
         )
 
-        for df in (self.df1, self.df2):
+        for attr in ("df1", "df2"):
             # Process only the columns that actually exist in the current dataframe
+            df = getattr(self, attr)
             cols_to_hash = [c for c in self.sensitive_columns if c in df.columns]
 
             df = df.with_columns(
                 pl.col(cols_to_hash)
                 .cast(pl.String)
-                .map_elementsq(
+                .map_elements(
                     lambda v: hashlib.blake2b(
                         v.encode("utf-8"), digest_size=32
                     ).hexdigest(),
                     skip_nulls=True,
                 )
             )
+
+            # Polars df are immutable, must write back
+            setattr(self, attr, df)
 
     def _validate_dataframe(
         self, index: str, cast_column_names_lower: bool = True

--- a/datacompy/polars.py
+++ b/datacompy/polars.py
@@ -21,7 +21,9 @@ PROC COMPARE in SAS - i.e. human-readable reporting on the difference between
 two dataframes.
 """
 
+import hashlib
 import logging
+from collections import Counter
 from copy import deepcopy
 from typing import Any, Dict, List, cast
 
@@ -95,6 +97,10 @@ class PolarsCompare(BaseCompare):
         Boolean indicator that controls of column names will be cast into lower case
     custom_comparators : list of ``BaseComparator``, optional
         A list of custom comparator classes to use to compare columns.
+    sensitive_columns: list[str], optional
+        A list of the columns in df1 or df2 that should have their values hashed to mask sensitive data.
+        [WARNING]: dataframes with columns in sensitive_columns will be modified inplace, it is advised
+        to manually copy any columns that may need to be later restored prior to using this parameter.
     """
 
     def __init__(
@@ -110,9 +116,11 @@ class PolarsCompare(BaseCompare):
         ignore_case: bool = False,
         cast_column_names_lower: bool = True,
         custom_comparators: List[BaseComparator] | None = None,
+        sensitive_columns: List[str] | None = None,
     ) -> None:
         self.cast_column_names_lower = cast_column_names_lower
         self.custom_comparators = custom_comparators or []
+        self.sensitive_columns = sensitive_columns
 
         # Validate tolerance parameters first
         self._abs_tol_dict = validate_tolerance_parameter(
@@ -149,6 +157,7 @@ class PolarsCompare(BaseCompare):
         self.df2_unq_rows: pl.DataFrame
         self.intersect_rows: pl.DataFrame
         self.column_stats: List[Dict[str, Any]] = []
+        self._hash_sensitive_columns()
         self._compare(ignore_spaces=ignore_spaces, ignore_case=ignore_case)
 
     def _get_comparators(self) -> List[BaseComparator]:
@@ -183,6 +192,59 @@ class PolarsCompare(BaseCompare):
         self._validate_dataframe(
             "df2", cast_column_names_lower=self.cast_column_names_lower
         )
+
+    @property
+    def sensitive_columns(self) -> List[str] | None:
+        """Get the list of sensitive columns."""
+        return self._sensitive_columns
+
+    @sensitive_columns.setter
+    def sensitive_columns(self, sensitive_columns: List[str] | None) -> None:
+        """Set sensitive_columns and then validate if needed."""
+        self._sensitive_columns = sensitive_columns
+        if self._sensitive_columns:
+            self._validate_sensitive_columns()
+
+    def _validate_sensitive_columns(self) -> None:
+        """Validate sensitive columns, assumes self.sensitive_columns is a list."""
+        if not all(isinstance(c, str) for c in self.sensitive_columns):
+            raise TypeError("sensitive_columns must be a list of strings")
+
+        # Cast to lowercase if applicable
+        if self.cast_column_names_lower:
+            # Need to directly modify _sensitive_columns here otherwise it will
+            # infinitely recurse in @sensitive_columns.setter
+            self._sensitive_columns = [col.lower() for col in self.sensitive_columns]
+
+        # Check duplicates
+        duplicates = {c for c, n in Counter(self.sensitive_columns).items() if n > 1}
+        if duplicates:
+            raise ValueError(f"duplicate columns: {duplicates}")
+
+    def _hash_sensitive_columns(self) -> None:
+        """Hash sensitive columns in both dataframes."""
+        if not self.sensitive_columns:
+            return None
+
+        # Logs warning only if sensitive columns is set and validation passes
+        LOG.warning(
+            "dataframes with columns in sensitive_columns will be modified inplace."
+        )
+
+        for df in (self.df1, self.df2):
+            # Process only the columns that actually exist in the current dataframe
+            cols_to_hash = [c for c in self.sensitive_columns if c in df.columns]
+
+            df = df.with_columns(
+                pl.col(cols_to_hash)
+                .cast(pl.String)
+                .map_elementsq(
+                    lambda v: hashlib.blake2b(
+                        v.encode("utf-8"), digest_size=32
+                    ).hexdigest(),
+                    skip_nulls=True,
+                )
+            )
 
     def _validate_dataframe(
         self, index: str, cast_column_names_lower: bool = True

--- a/datacompy/polars.py
+++ b/datacompy/polars.py
@@ -99,8 +99,8 @@ class PolarsCompare(BaseCompare):
         A list of custom comparator classes to use to compare columns.
     sensitive_columns: list[str], optional
         A list of the columns in df1 or df2 that should have their values hashed to mask sensitive data.
-        [WARNING]: dataframes with columns in sensitive_columns will be modified inplace, it is advised
-        to manually copy any columns that may need to be later restored prior to using this parameter.
+        [WARNING]: Polars dataframes are immutable. Comparing large dataframes may cause significant
+        memory pressure due to internal copying required for hashing sensitive columns.
     """
 
     def __init__(
@@ -228,13 +228,17 @@ class PolarsCompare(BaseCompare):
 
         # Logs warning only if sensitive columns is set and validation passes
         LOG.warning(
-            "dataframes with columns in sensitive_columns will be modified inplace."
+            "dataframes with sensitive columns will be copied internally for hashing operations."
         )
 
         for attr in ("df1", "df2"):
             # Process only the columns that actually exist in the current dataframe
             df = getattr(self, attr)
             cols_to_hash = [c for c in self.sensitive_columns if c in df.columns]
+
+            # Don't create an internal copy of the dataframe if no columns to hash
+            if len(cols_to_hash) == 0:
+                continue
 
             df = df.with_columns(
                 pl.col(cols_to_hash)
@@ -247,7 +251,7 @@ class PolarsCompare(BaseCompare):
                 )
             )
 
-            # Polars df are immutable, must write back
+            # Polars dataframes are immutable, must write back a copy
             setattr(self, attr, df)
 
     def _validate_dataframe(

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -2287,3 +2287,141 @@ def test_columns_with_mismatches_multiple_join_columns():
     assert "id1" not in result
     assert "id2" not in result
     assert sorted(result) == ["value1", "value2"]
+
+
+def test_sensitive_columns():
+    df1 = pl.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = pl.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = PolarsCompare(df1, df2, join_columns=["a"], sensitive_columns=["b"])
+    assert compare.df1[0, "b"] != 2
+    assert compare.df1[1, "b"] != 0
+    assert len(compare.df1_unq_rows) == 1
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_null():
+    df1 = pl.DataFrame([{"a": 1, "b": "hello"}, {"a": 1, "b": None}])
+    df2 = pl.DataFrame([{"a": 1, "b": "hello"}, {"a": 2, "b": "yo"}])
+    compare = PolarsCompare(df1, df2, join_columns=["a"], sensitive_columns=["b"])
+    assert compare.df1[0, "b"] != "hello"
+    assert compare.df1[1, "b"] is None
+    assert len(compare.df1_unq_rows) == 1
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_nan():
+    df1 = pl.DataFrame(
+        {
+            "a": [1, 2],
+            "b": [1.1, float("nan")],
+            "c": [1.23, float("nan")],
+        }
+    )
+    df2 = pl.DataFrame(
+        {
+            "a": [1, 2],
+            "b": [1.2, float("nan")],
+            "c": [1.23, float("nan")],
+        }
+    )
+    compare = PolarsCompare(df1, df2, join_columns=["a"], sensitive_columns=["b"])
+    assert compare.df1[0, "b"] != 1.1
+    assert isinstance(compare.df1[1, "b"], str)
+    assert len(compare.df1[1, "b"]) == 64
+    assert compare.all_mismatch().select(pl.len()).item() == 1
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_cast_lower():
+    df1 = pl.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = pl.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = PolarsCompare(df1, df2, join_columns=["a"], sensitive_columns=["B"])
+    assert compare.df1[0, "b"] != 2
+    assert compare.df1[1, "b"] != 0
+    assert len(compare.df1_unq_rows) == 1
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_no_cast_lower():
+    df1 = pl.DataFrame([{"a": 1, "b": 2, "B": 2}, {"a": 1, "b": 0, "B": 0}])
+    df2 = pl.DataFrame([{"a": 1, "b": 2, "B": 2}, {"a": 2, "b": 0, "B": 0}])
+    compare = PolarsCompare(
+        df1,
+        df2,
+        join_columns=["a"],
+        sensitive_columns=["B"],
+        cast_column_names_lower=False,
+    )
+    assert compare.df1[0, "b"] == 2
+    assert compare.df1[1, "b"] == 0
+    assert compare.df1[0, "B"] != 2
+    assert compare.df1[1, "B"] != 0
+    assert len(compare.df1_unq_rows) == 1
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_as_join_columns():
+    df1 = pl.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = pl.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = PolarsCompare(df1, df2, join_columns=["a"], sensitive_columns=["a"])
+    assert compare.df1[0, "a"] != 1
+    assert compare.df1[1, "a"] != 1
+    assert len(compare.df1_unq_rows) == 1
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_missing():
+    df1 = pl.DataFrame([{"a": 1, "b": "hello", "c": 3}, {"a": 1, "b": "67", "c": 6}])
+    df2 = pl.DataFrame([{"a": 1, "b": "hello", "d": 4}, {"a": 2, "b": "yo", "d": 7}])
+    compare = PolarsCompare(df1, df2, join_columns=["a"], sensitive_columns=["b", "c"])
+    assert compare.df1[0, "b"] != "hello"
+    assert compare.df1[1, "b"] != "67"
+    assert compare.df1[0, "c"] != 3
+    assert compare.df1[1, "c"] != 6
+    assert compare.df2[0, "d"] == 4
+    assert compare.df2[1, "d"] == 7
+    assert len(compare.df1_unq_rows) == 1
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_setter():
+    df1 = pl.DataFrame([{"a": 1, "b": 2}])
+    df2 = pl.DataFrame([{"a": 1, "b": 2}])
+    compare = PolarsCompare(df1, df2, join_columns=["a"])
+
+    # Valid setter call
+    compare.sensitive_columns = ["b"]
+    assert compare.sensitive_columns == ["b"]
+
+    # Invalid setter call - not a list of strings
+    with pytest.raises(TypeError, match="sensitive_columns must be a list of strings"):
+        compare.sensitive_columns = [1, 2, 3]
+
+
+def test_sensitive_columns_duplicates():
+    df1 = pl.DataFrame([{"a": 1, "b": 2}])
+    df2 = pl.DataFrame([{"a": 1, "b": 2}])
+    # Duplicate columns should raise ValueError during init/hashing
+    with pytest.raises(ValueError, match=r"duplicate columns: {'b'}"):
+        PolarsCompare(df1, df2, join_columns=["a"], sensitive_columns=["b", "b"])
+
+
+def test_sensitive_columns_numeric_types():
+    """Verify that hashing works for different numeric types without LossySetitemError."""
+    df1 = pl.DataFrame({"a": [1, 2], "b": [10, 20], "c": [1.1, 2.2]})
+    df2 = pl.DataFrame({"a": [1, 2], "b": [10, 20], "c": [1.1, 2.2]})
+
+    compare = PolarsCompare(df1, df2, join_columns=["a"], sensitive_columns=["b", "c"])
+
+    assert isinstance(compare.df1[0, "b"], str)
+    assert isinstance(compare.df1[0, "c"], str)
+    # blake2b with digest_size=32 returns 64 hex characters
+    assert len(compare.df1[0, "b"]) == 64
+    assert len(compare.df1[0, "c"]) == 64

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -2327,7 +2327,8 @@ def test_sensitive_columns_nan():
         }
     )
     compare = PolarsCompare(df1, df2, join_columns=["a"], sensitive_columns=["b"])
-    assert compare.df1[0, "b"] != 1.1
+    assert isinstance(compare.df1[0, "b"], str)
+    assert len(compare.df1[0, "b"]) == 64
     assert isinstance(compare.df1[1, "b"], str)
     assert len(compare.df1[1, "b"]) == 64
     assert compare.all_mismatch().select(pl.len()).item() == 1


### PR DESCRIPTION
Add sensitive column hashing to PolarsCompare, similar functionality to the existing one in PandasCompare.

- New `sensitive_columns` parameter with same getter and setter implementation + column names validation.
- Polars dataframes are immutable, hashing columns will require an internal copy of the dataframes, warnings updated to reflect this change in behaviour.
- `Nulls` are skipped when hashing values, however polars distinguishes between `Null` and `NaN` values unlike in pandas.  As such, `NaN` values are cast to string and hashed in PolarsCompare.
- Same unit tests + 1 extra for `NaN`.