### PR TITLE
feat: hash sensitive columns in PandasCompare without modifying original dfs

### DIFF
--- a/datacompy/pandas.py
+++ b/datacompy/pandas.py
@@ -101,8 +101,8 @@ class PandasCompare(BaseCompare):
         A list of custom comparator classes to use to compare columns.
     sensitive_columns: list[str], optional
         A list of the columns in df1 or df2 that should have their values hashed to mask sensitive data.
-        [WARNING]: dataframes with columns in sensitive_columns will be modified inplace, it is advised
-        to manually copy any columns that may need to be later restored prior to using this parameter.
+        [Note]: columns in sensitive_columns will be hashed before comparing, meaning columns originally
+        containing floating point values will not adhere to tolerances and comparisons may be affected.
     """
 
     def __init__(

--- a/datacompy/pandas.py
+++ b/datacompy/pandas.py
@@ -101,8 +101,6 @@ class PandasCompare(BaseCompare):
         A list of custom comparator classes to use to compare columns.
     sensitive_columns: list[str], optional
         A list of the columns in df1 or df2 that should have their values hashed to mask sensitive data.
-        [Note]: columns in sensitive_columns will be hashed before comparing, meaning columns originally
-        containing floating point values will not adhere to tolerances and comparisons may be affected.
     """
 
     def __init__(
@@ -232,6 +230,31 @@ class PandasCompare(BaseCompare):
         if duplicates:
             raise ValueError(f"duplicate columns: {duplicates}")
 
+    def _hash_df_sensitive_columns(
+        self, df: pd.DataFrame, cols_to_hash: List[str]
+    ) -> None:
+        """Hash columns in cols_to_hash in df inplace."""
+        for col in cols_to_hash:
+            is_null = df[col].isnull()
+
+            # Convert the column to object type before hashing to allow
+            # assignment of strings and pd.NA regardless of the original dtype.
+            df[col] = df[col].astype(str)
+
+            # Only process if there are non-null values to hash
+            if not is_null.all():
+                # Hash non-null values. str(v) ensures compatibility regardless of original dtype.
+                # We apply the transformation only to the relevant slice.
+                df.loc[~is_null, col] = df.loc[~is_null, col].map(
+                    lambda v: hashlib.blake2b(
+                        v.encode("utf-8"), digest_size=32
+                    ).hexdigest()
+                )
+
+            # Ensure all nulls are consistently represented as pd.NA in the hashed column
+            if is_null.any():
+                df.loc[is_null, col] = pd.NA
+
     def _validate_dataframe(
         self, index: str, cast_column_names_lower: bool = True
     ) -> None:
@@ -308,6 +331,27 @@ class PandasCompare(BaseCompare):
         else:
             LOG.info("df1 does not match df2")
 
+        # hash any sensitive columns in outer_join before moving on
+        if self.sensitive_columns:
+            sensitive = set(self.sensitive_columns)
+            common_cols = self.intersect_columns() - set(self.join_columns)
+
+            # hash columns in unq_rows
+            for df in (self.df1_unq_rows, self.df2_unq_rows):
+                LOG.debug(f"Hashing sensitive columns in {df}")
+
+                cols_to_hash = [col for col in df.columns if col in sensitive]
+                self._hash_df_sensitive_columns(df, cols_to_hash)
+
+            # hash columns in intersect_rows
+            LOG.debug("Hashing sensitive columns in self.intersect_rows")
+            cols_to_hash = [
+                *[col for col in self.join_columns if col in sensitive],
+                *[f"{col}_{self.df1_name}" for col in common_cols if col in sensitive],
+                *[f"{col}_{self.df2_name}" for col in common_cols if col in sensitive],
+            ]
+            self._hash_df_sensitive_columns(self.intersect_rows, cols_to_hash)
+
     def df1_unq_columns(self) -> OrderedSet[str]:
         """Get columns that are unique to df1."""
         return cast(
@@ -378,40 +422,6 @@ class PandasCompare(BaseCompare):
             indicator=True,
             **params,
         )
-
-        # hash any sensitive columns in outer_join before moving on
-        if self.sensitive_columns:
-            LOG.debug("Hashing sensitive columns in outer_join")
-            sensitive = set(self.sensitive_columns)
-            common_cols = self.intersect_columns() - set(self.join_columns)
-            cols_to_hash = [
-                *[col for col in self.join_columns if col in sensitive],
-                *[col for col in self.df1_unq_columns() if col in sensitive],
-                *[col for col in self.df2_unq_columns() if col in sensitive],
-                *[f"{col}_{self.df1_name}" for col in common_cols if col in sensitive],
-                *[f"{col}_{self.df2_name}" for col in common_cols if col in sensitive],
-            ]
-
-            for col in cols_to_hash:
-                is_null = outer_join[col].isnull()
-
-                # Convert the column to object type before hashing to allow
-                # assignment of strings and pd.NA regardless of the original dtype.
-                outer_join[col] = outer_join[col].astype(str)
-
-                # Only process if there are non-null values to hash
-                if not is_null.all():
-                    # Hash non-null values. str(v) ensures compatibility regardless of original dtype.
-                    # We apply the transformation only to the relevant slice.
-                    outer_join.loc[~is_null, col] = outer_join.loc[~is_null, col].map(
-                        lambda v: hashlib.blake2b(
-                            v.encode("utf-8"), digest_size=32
-                        ).hexdigest()
-                    )
-
-                # Ensure all nulls are consistently represented as pd.NA in the hashed column
-                if is_null.any():
-                    outer_join.loc[is_null, col] = pd.NA
 
         # Clean up temp columns for duplicate row matching
         if self._any_dupes:

--- a/datacompy/pandas.py
+++ b/datacompy/pandas.py
@@ -168,6 +168,7 @@ class PandasCompare(BaseCompare):
         self.intersect_rows: pd.DataFrame
         self.column_stats: List[Dict[str, Any]] = []
         self._compare(ignore_spaces=ignore_spaces, ignore_case=ignore_case)
+        self._hash_sensitive_columns()
 
     def _get_comparators(self) -> List[BaseComparator]:
         """Build and return the list of comparators to be used.
@@ -255,6 +256,30 @@ class PandasCompare(BaseCompare):
             if is_null.any():
                 df.loc[is_null, col] = pd.NA
 
+    def _hash_sensitive_columns(self) -> None:
+        """Hash sensitive columns if applicable."""
+        if self.sensitive_columns is None:
+            return None
+
+        sensitive = set(self.sensitive_columns)
+        common_cols = self.intersect_columns() - set(self.join_columns)
+
+        # hash columns in unq_rows
+        for df in (self.df1_unq_rows, self.df2_unq_rows):
+            LOG.debug(f"Hashing sensitive columns in {df}")
+
+            cols_to_hash = [col for col in df.columns if col in sensitive]
+            self._hash_df_sensitive_columns(df, cols_to_hash)
+
+        # hash columns in intersect_rows
+        LOG.debug("Hashing sensitive columns in self.intersect_rows")
+        cols_to_hash = [
+            *[col for col in self.join_columns if col in sensitive],
+            *[f"{col}_{self.df1_name}" for col in common_cols if col in sensitive],
+            *[f"{col}_{self.df2_name}" for col in common_cols if col in sensitive],
+        ]
+        self._hash_df_sensitive_columns(self.intersect_rows, cols_to_hash)
+
     def _validate_dataframe(
         self, index: str, cast_column_names_lower: bool = True
     ) -> None:
@@ -330,27 +355,6 @@ class PandasCompare(BaseCompare):
             LOG.info("df1 matches df2")
         else:
             LOG.info("df1 does not match df2")
-
-        # hash any sensitive columns in outer_join before moving on
-        if self.sensitive_columns:
-            sensitive = set(self.sensitive_columns)
-            common_cols = self.intersect_columns() - set(self.join_columns)
-
-            # hash columns in unq_rows
-            for df in (self.df1_unq_rows, self.df2_unq_rows):
-                LOG.debug(f"Hashing sensitive columns in {df}")
-
-                cols_to_hash = [col for col in df.columns if col in sensitive]
-                self._hash_df_sensitive_columns(df, cols_to_hash)
-
-            # hash columns in intersect_rows
-            LOG.debug("Hashing sensitive columns in self.intersect_rows")
-            cols_to_hash = [
-                *[col for col in self.join_columns if col in sensitive],
-                *[f"{col}_{self.df1_name}" for col in common_cols if col in sensitive],
-                *[f"{col}_{self.df2_name}" for col in common_cols if col in sensitive],
-            ]
-            self._hash_df_sensitive_columns(self.intersect_rows, cols_to_hash)
 
     def df1_unq_columns(self) -> OrderedSet[str]:
         """Get columns that are unique to df1."""

--- a/datacompy/pandas.py
+++ b/datacompy/pandas.py
@@ -169,7 +169,6 @@ class PandasCompare(BaseCompare):
         self.df2_unq_rows: pd.DataFrame
         self.intersect_rows: pd.DataFrame
         self.column_stats: List[Dict[str, Any]] = []
-        self._hash_sensitive_columns()
         self._compare(ignore_spaces=ignore_spaces, ignore_case=ignore_case)
 
     def _get_comparators(self) -> List[BaseComparator]:
@@ -232,41 +231,6 @@ class PandasCompare(BaseCompare):
         duplicates = {c for c, n in Counter(self.sensitive_columns).items() if n > 1}
         if duplicates:
             raise ValueError(f"duplicate columns: {duplicates}")
-
-    def _hash_sensitive_columns(self) -> None:
-        """Hash sensitive columns in both dataframes."""
-        if not self.sensitive_columns:
-            return None
-
-        # Logs warning only if sensitive columns is set and validation passes
-        LOG.warning(
-            "dataframes with columns in sensitive_columns will be modified inplace."
-        )
-
-        for df in (self.df1, self.df2):
-            # Process only the columns that actually exist in the current dataframe
-            cols_to_hash = [c for c in self.sensitive_columns if c in df.columns]
-
-            for col in cols_to_hash:
-                is_null = df[col].isnull()
-
-                # Convert the column to object type before hashing to allow
-                # assignment of strings and pd.NA regardless of the original dtype.
-                df[col] = df[col].astype(str)
-
-                # Only process if there are non-null values to hash
-                if not is_null.all():
-                    # Hash non-null values. str(v) ensures compatibility regardless of original dtype.
-                    # We apply the transformation only to the relevant slice.
-                    df.loc[~is_null, col] = df.loc[~is_null, col].map(
-                        lambda v: hashlib.blake2b(
-                            v.encode("utf-8"), digest_size=32
-                        ).hexdigest()
-                    )
-
-                # Ensure all nulls are consistently represented as pd.NA in the hashed column
-                if is_null.any():
-                    df.loc[is_null, col] = pd.NA
 
     def _validate_dataframe(
         self, index: str, cast_column_names_lower: bool = True
@@ -414,6 +378,41 @@ class PandasCompare(BaseCompare):
             indicator=True,
             **params,
         )
+
+        # hash any sensitive columns in outer_join before moving on
+        if self.sensitive_columns:
+            LOG.debug("Hashing sensitive columns in outer_join")
+            sensitive = set(self.sensitive_columns)
+            common_cols = self.intersect_columns() - set(self.join_columns)
+            cols_to_hash = [
+                *[col for col in self.join_columns if col in sensitive],
+                *[col for col in self.df1_unq_columns() if col in sensitive],
+                *[col for col in self.df2_unq_columns() if col in sensitive],
+                *[f"{col}_{self.df1_name}" for col in common_cols if col in sensitive],
+                *[f"{col}_{self.df2_name}" for col in common_cols if col in sensitive],
+            ]
+
+            for col in cols_to_hash:
+                is_null = outer_join[col].isnull()
+
+                # Convert the column to object type before hashing to allow
+                # assignment of strings and pd.NA regardless of the original dtype.
+                outer_join[col] = outer_join[col].astype(str)
+
+                # Only process if there are non-null values to hash
+                if not is_null.all():
+                    # Hash non-null values. str(v) ensures compatibility regardless of original dtype.
+                    # We apply the transformation only to the relevant slice.
+                    outer_join.loc[~is_null, col] = outer_join.loc[~is_null, col].map(
+                        lambda v: hashlib.blake2b(
+                            v.encode("utf-8"), digest_size=32
+                        ).hexdigest()
+                    )
+
+                # Ensure all nulls are consistently represented as pd.NA in the hashed column
+                if is_null.any():
+                    outer_join.loc[is_null, col] = pd.NA
+
         # Clean up temp columns for duplicate row matching
         if self._any_dupes:
             if self.on_index:

--- a/datacompy/pandas.py
+++ b/datacompy/pandas.py
@@ -1037,15 +1037,6 @@ def columns_equal(
     - Non-numeric values (i.e. where np.isclose can't be used) will just trigger
       ``True`` on two nulls or exact matches.
 
-    Notes
-    -----
-    - As of version ``0.14.0`` If a column is of a mixed data type the compare
-      will default to returning ``False``.
-    - ``list`` and ``np.array`` types will be compared row wise using ``np.array_equal``.
-      Depending on the size of your data this might lead to performance issues.
-    - All the rows must be of the same type otherwise it is considered "mixed"
-      and will default to being ``False`` for everything.
-
     Parameters
     ----------
     col_1 : Pandas.Series
@@ -1070,6 +1061,15 @@ def columns_equal(
     pandas.Series
         A series of Boolean values.  True == the values match, False == the
         values don't match.
+
+    Notes
+    -----
+    - As of version ``0.14.0`` If a column is of a mixed data type the compare
+      will default to returning ``False``.
+    - ``list`` and ``np.array`` types will be compared row wise using ``np.array_equal``.
+      Depending on the size of your data this might lead to performance issues.
+    - All the rows must be of the same type otherwise it is considered "mixed"
+      and will default to being ``False`` for everything.
     """
     compare: pd.Series[bool] | None
 

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -2179,9 +2179,18 @@ def test_sensitive_columns():
     compare = datacompy.PandasCompare(
         df1, df2, join_columns=["a"], sensitive_columns=["b"]
     )
-    assert compare.df1.loc[0, "b"] != 2
-    assert compare.df1.loc[1, "b"] != 0
+    assert compare.df1.loc[0, "b"] == 2
+    assert compare.df1.loc[1, "b"] == 0
     assert len(compare.df1_unq_rows) == 1
+    assert compare.df1_unq_rows.reset_index(drop=True).loc[0, "a"] == 1
+    assert compare.df1_unq_rows.reset_index(drop=True).loc[0, "b"] != 0
+    assert len(compare.df2_unq_rows) == 1
+    assert compare.df2_unq_rows.reset_index(drop=True).loc[0, "a"] == 2
+    assert compare.df2_unq_rows.reset_index(drop=True).loc[0, "b"] != 0
+    assert len(compare.intersect_rows) == 1
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "a"] == 1
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_df1"] != 2
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_df2"] != 2
     # Just render the report to make sure it renders.
     compare.report()
 
@@ -2192,9 +2201,18 @@ def test_sensitive_columns_null():
     compare = datacompy.PandasCompare(
         df1, df2, join_columns=["a"], sensitive_columns=["b"]
     )
-    assert compare.df1.loc[0, "b"] != "hello"
+    assert compare.df1.loc[0, "b"] == "hello"
     assert pd.isna(compare.df1.loc[1, "b"])
     assert len(compare.df1_unq_rows) == 1
+    assert compare.df1_unq_rows.reset_index(drop=True).loc[0, "a"] == 1
+    assert pd.isna(compare.df1_unq_rows.reset_index(drop=True).loc[0, "b"])
+    assert len(compare.df2_unq_rows) == 1
+    assert compare.df2_unq_rows.reset_index(drop=True).loc[0, "a"] == 2
+    assert compare.df2_unq_rows.reset_index(drop=True).loc[0, "b"] != "yo"
+    assert len(compare.intersect_rows) == 1
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "a"] == 1
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_df1"] != "hello"
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_df2"] != "hello"
     # Just render the report to make sure it renders.
     compare.report()
 
@@ -2205,15 +2223,24 @@ def test_sensitive_columns_cast_lower():
     compare = datacompy.PandasCompare(
         df1, df2, join_columns=["a"], sensitive_columns=["B"]
     )
-    assert compare.df1.loc[0, "b"] != 2
-    assert compare.df1.loc[1, "b"] != 0
+    assert compare.df1.loc[0, "b"] == 2
+    assert compare.df1.loc[1, "b"] == 0
     assert len(compare.df1_unq_rows) == 1
+    assert compare.df1_unq_rows.reset_index(drop=True).loc[0, "a"] == 1
+    assert compare.df1_unq_rows.reset_index(drop=True).loc[0, "b"] != 0
+    assert len(compare.df2_unq_rows) == 1
+    assert compare.df2_unq_rows.reset_index(drop=True).loc[0, "a"] == 2
+    assert compare.df2_unq_rows.reset_index(drop=True).loc[0, "b"] != 0
+    assert len(compare.intersect_rows) == 1
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "a"] == 1
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_df1"] != 2
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_df2"] != 2
     # Just render the report to make sure it renders.
     compare.report()
 
 
 def test_sensitive_columns_no_cast_lower():
-    df1 = pd.DataFrame([{"a": 1, "b": 2, "B": 2}, {"a": 1, "b": 0, "B": 0}])
+    df1 = pd.DataFrame([{"a": 1, "b": 2, "B": 2}, {"a": 3, "b": 1, "B": 0}])
     df2 = pd.DataFrame([{"a": 1, "b": 2, "B": 2}, {"a": 2, "b": 0, "B": 0}])
     compare = datacompy.PandasCompare(
         df1,
@@ -2223,10 +2250,19 @@ def test_sensitive_columns_no_cast_lower():
         cast_column_names_lower=False,
     )
     assert compare.df1.loc[0, "b"] == 2
-    assert compare.df1.loc[1, "b"] == 0
-    assert compare.df1.loc[0, "B"] != 2
-    assert compare.df1.loc[1, "B"] != 0
+    assert compare.df1.loc[1, "b"] == 1
+    assert compare.df1.loc[0, "B"] == 2
+    assert compare.df1.loc[1, "B"] == 0
     assert len(compare.df1_unq_rows) == 1
+    assert compare.df1_unq_rows.reset_index(drop=True).loc[0, "a"] == 3
+    assert compare.df1_unq_rows.reset_index(drop=True).loc[0, "B"] != 0
+    assert len(compare.df2_unq_rows) == 1
+    assert compare.df2_unq_rows.reset_index(drop=True).loc[0, "a"] == 2
+    assert compare.df2_unq_rows.reset_index(drop=True).loc[0, "B"] != 0
+    assert len(compare.intersect_rows) == 1
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "a"] == 1
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "B_df1"] != 2
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "B_df2"] != 2
     # Just render the report to make sure it renders.
     compare.report()
 
@@ -2237,26 +2273,44 @@ def test_sensitive_columns_as_join_columns():
     compare = datacompy.PandasCompare(
         df1, df2, join_columns=["a"], sensitive_columns=["a"]
     )
-    assert compare.df1.loc[0, "a"] != 1
-    assert compare.df1.loc[1, "a"] != 1
+    assert compare.df1.loc[0, "a"] == 1
+    assert compare.df1.loc[1, "a"] == 1
     assert len(compare.df1_unq_rows) == 1
+    assert compare.df1_unq_rows.reset_index(drop=True).loc[0, "a"] != 1
+    assert len(compare.sample_mismatch("a")) == 2
+    assert isinstance(
+        compare.sample_mismatch("a").reset_index(drop=True).loc[0, "a"], str
+    )
+    assert len(compare.sample_mismatch("a").reset_index(drop=True).loc[0, "a"]) == 64
+    assert isinstance(
+        compare.sample_mismatch("a").reset_index(drop=True).loc[1, "a"], str
+    )
+    assert len(compare.sample_mismatch("a").reset_index(drop=True).loc[1, "a"]) == 64
     # Just render the report to make sure it renders.
     compare.report()
 
 
 def test_sensitive_columns_missing():
-    df1 = pd.DataFrame([{"a": 1, "b": "hello", "c": 3}, {"a": 1, "b": "67", "c": 6}])
+    df1 = pd.DataFrame([{"a": 1, "b": "hello", "c": 3}, {"a": 3, "b": "67", "c": 6}])
     df2 = pd.DataFrame([{"a": 1, "b": "hello", "d": 4}, {"a": 2, "b": "yo", "d": 7}])
     compare = datacompy.PandasCompare(
         df1, df2, join_columns=["a"], sensitive_columns=["b", "c"]
     )
-    assert compare.df1.loc[0, "b"] != "hello"
-    assert compare.df1.loc[1, "b"] != "67"
-    assert compare.df1.loc[0, "c"] != 3
-    assert compare.df1.loc[1, "c"] != 6
+    assert compare.df1.loc[0, "b"] == "hello"
+    assert compare.df1.loc[1, "b"] == "67"
+    assert compare.df1.loc[0, "c"] == 3
+    assert compare.df1.loc[1, "c"] == 6
     assert compare.df2.loc[0, "d"] == 4
     assert compare.df2.loc[1, "d"] == 7
     assert len(compare.df1_unq_rows) == 1
+    assert compare.df1_unq_rows.reset_index(drop=True).loc[0, "a"] == 3
+    assert compare.df1_unq_rows.reset_index(drop=True).loc[0, "b"] != "67"
+    assert isinstance(compare.df1_unq_rows.reset_index(drop=True).loc[0, "c"], str)
+    assert len(compare.df1_unq_rows.reset_index(drop=True).loc[0, "c"]) == 64
+    assert len(compare.df2_unq_rows) == 1
+    assert compare.df2_unq_rows.reset_index(drop=True).loc[0, "a"] == 2
+    assert compare.df2_unq_rows.reset_index(drop=True).loc[0, "b"] != "yo"
+    assert not isinstance(compare.df2_unq_rows.reset_index(drop=True).loc[0, "d"], str)
     # Just render the report to make sure it renders.
     compare.report()
 
@@ -2294,11 +2348,18 @@ def test_sensitive_columns_numeric_types():
         df1, df2, join_columns=["a"], sensitive_columns=["b", "c"]
     )
 
-    assert isinstance(compare.df1["b"].loc[0], str)
-    assert isinstance(compare.df1["c"].loc[0], str)
+    assert not isinstance(compare.df1["b"].loc[0], str)
+    assert not isinstance(compare.df1["c"].loc[0], str)
+    assert len(compare.df1_unq_rows) == 0
+    assert isinstance(
+        compare.intersect_rows.reset_index(drop=True).loc[0, "b_df1"], str
+    )
+    assert isinstance(
+        compare.intersect_rows.reset_index(drop=True).loc[0, "c_df1"], str
+    )
     # blake2b with digest_size=32 returns 64 hex characters
-    assert len(compare.df1["b"].loc[0]) == 64
-    assert len(compare.df1["c"].loc[0]) == 64
+    assert len(compare.intersect_rows.reset_index(drop=True).loc[0, "b_df1"]) == 64
+    assert len(compare.intersect_rows.reset_index(drop=True).loc[0, "c_df1"]) == 64
 
 
 def test_columns_with_mismatches_single_column():

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -2362,6 +2362,51 @@ def test_sensitive_columns_numeric_types():
     assert len(compare.intersect_rows.reset_index(drop=True).loc[0, "c_df1"]) == 64
 
 
+def test_sensitive_columns_numeric_types_with_tolerance():
+    """Verify that hashing works for different numeric types with tolerance."""
+    df1 = pd.DataFrame({"a": [1, 2], "b": [10, 20], "c": [1.1, 2.1]})
+    df2 = pd.DataFrame({"a": [1, 3], "b": [10, 21], "c": [1.2, 2.1]})
+
+    compare = datacompy.PandasCompare(
+        df1,
+        df2,
+        join_columns=["a"],
+        sensitive_columns=["b", "c"],
+        abs_tol=0.1,
+    )
+    assert not isinstance(compare.df1["b"].loc[0], str)
+    assert not isinstance(compare.df1["c"].loc[0], str)
+    assert len(compare.df1_unq_rows) == 1
+    assert isinstance(compare.df1_unq_rows.reset_index(drop=True).loc[0, "b"], str)
+    assert len(compare.df1_unq_rows.reset_index(drop=True).loc[0, "b"]) == 64
+    assert isinstance(compare.df1_unq_rows.reset_index(drop=True).loc[0, "c"], str)
+    assert len(compare.df1_unq_rows.reset_index(drop=True).loc[0, "c"]) == 64
+    assert len(compare.df2_unq_rows) == 1
+    assert isinstance(compare.df2_unq_rows.reset_index(drop=True).loc[0, "b"], str)
+    assert len(compare.df2_unq_rows.reset_index(drop=True).loc[0, "b"]) == 64
+    assert isinstance(compare.df2_unq_rows.reset_index(drop=True).loc[0, "c"], str)
+    assert len(compare.df2_unq_rows.reset_index(drop=True).loc[0, "c"]) == 64
+    assert len(compare.intersect_rows) == 1
+    assert isinstance(
+        compare.intersect_rows.reset_index(drop=True).loc[0, "b_df1"], str
+    )
+    assert len(compare.intersect_rows.reset_index(drop=True).loc[0, "b_df1"]) == 64
+    assert isinstance(
+        compare.intersect_rows.reset_index(drop=True).loc[0, "b_df2"], str
+    )
+    assert len(compare.intersect_rows.reset_index(drop=True).loc[0, "b_df2"]) == 64
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_match"]
+    assert isinstance(
+        compare.intersect_rows.reset_index(drop=True).loc[0, "c_df1"], str
+    )
+    assert len(compare.intersect_rows.reset_index(drop=True).loc[0, "c_df1"]) == 64
+    assert isinstance(
+        compare.intersect_rows.reset_index(drop=True).loc[0, "c_df2"], str
+    )
+    assert len(compare.intersect_rows.reset_index(drop=True).loc[0, "c_df2"]) == 64
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "c_match"]
+
+
 def test_columns_with_mismatches_single_column():
     """Test columns_with_mismatches with a single mismatched column."""
     df1 = pd.DataFrame(


### PR DESCRIPTION
Improves on PR [490](https://github.com/capitalone/datacompy/pull/490), hashing can now be done without affecting original dataframes and should not blow up memory footprint. 

- Realized data is already being copied internally when merging dataframes in `_dataframe_merge()`, so we can hash the relevant columns in `df1_unq_rows`, `df2_unq_rows`, and `intersect_rows` after calling `_compare()` to achieve sensitive column hashing without modifying original dataframes.
- Something not caught previously but should be fixed now is that tolerances wouldn't have worked for floats because the hashing was done prior to comparing.
- Also shouldn't introduce any significant memory pressure since we are modifying the internal dataframes inplace.
- Updated unit tests.