### PR TITLE
feat: hide sensitive columns in PandasCompare without modifying original dfs

### DIFF
--- a/datacompy/pandas.py
+++ b/datacompy/pandas.py
@@ -223,7 +223,7 @@ class PandasCompare(BaseCompare):
         if duplicates:
             raise ValueError(f"duplicate columns: {duplicates}")
 
-        # Warn if column not in both df1 and df2
+        # Warn if column not found in either dataframe
         unused = [
             col
             for col in self.sensitive_columns
@@ -231,7 +231,7 @@ class PandasCompare(BaseCompare):
         ]
         if unused:
             LOG.warning(
-                f"sensitive columns not found in both df1 and df2 will be ignored: {unused}"
+                f"sensitive columns not found in either df1 or df2 will be ignored: {unused}"
             )
 
     def hide_sensitive_columns(self, sensitive_columns: List[str]) -> None:

--- a/datacompy/pandas.py
+++ b/datacompy/pandas.py
@@ -117,7 +117,7 @@ class PandasCompare(BaseCompare):
     ) -> None:
         self.cast_column_names_lower = cast_column_names_lower
         self.custom_comparators = custom_comparators or []
-        self.sensitive_columns: List[str] | None = None
+        self._set_sensitive_columns(None)
 
         # Validate tolerance parameters first
         self._abs_tol_dict = validate_tolerance_parameter(
@@ -203,8 +203,7 @@ class PandasCompare(BaseCompare):
         """Get the list of sensitive columns."""
         return self._sensitive_columns
 
-    @sensitive_columns.setter
-    def sensitive_columns(self, sensitive_columns: List[str] | None) -> None:
+    def _set_sensitive_columns(self, sensitive_columns: List[str] | None) -> None:
         """Set sensitive_columns and then validate if needed."""
         self._sensitive_columns = sensitive_columns
         if self._sensitive_columns:
@@ -217,8 +216,6 @@ class PandasCompare(BaseCompare):
 
         # Cast to lowercase if applicable
         if self.cast_column_names_lower:
-            # Need to directly modify _sensitive_columns here otherwise it will
-            # infinitely recurse in @sensitive_columns.setter
             self._sensitive_columns = [col.lower() for col in self.sensitive_columns]
 
         # Check duplicates
@@ -244,7 +241,7 @@ class PandasCompare(BaseCompare):
                 "sensitive columns are already hidden, call reveal_sensitive_columns() first"
             )
 
-        self.sensitive_columns = sensitive_columns  # validates through setter
+        self._set_sensitive_columns(sensitive_columns)  # validates through private setter
         sensitive = set(self.sensitive_columns)
         common_cols = self.intersect_columns() - set(self.join_columns)
 
@@ -281,7 +278,7 @@ class PandasCompare(BaseCompare):
             return None
 
         LOG.debug("Revealing sensitive columns and re-comparing dfs")
-        self.sensitive_columns = None
+        self._set_sensitive_columns(None)
         self.column_stats.clear()
         self._compare(ignore_spaces=self.ignore_spaces, ignore_case=self.ignore_case)
 

--- a/datacompy/pandas.py
+++ b/datacompy/pandas.py
@@ -249,21 +249,23 @@ class PandasCompare(BaseCompare):
 
         # Hide columns in unq_rows
         for df in (self.df1_unq_rows, self.df2_unq_rows):
-            LOG.debug("Hiding sensitive columns in unq_rows")
-            cols_to_hash = [col for col in df.columns if col in sensitive]
-            for col in cols_to_hash:
+            LOG.debug(f"Hiding sensitive columns in unq_rows: {df.columns}")
+            cols_to_hide = [col for col in df.columns if col in sensitive]
+            for col in cols_to_hide:
                 df[col] = "*******"
 
         # Hide columns in intersect_rows
-        LOG.debug("Hiding sensitive columns in intersect_rows")
-        cols_to_hash = [
+        LOG.debug(
+            f"Hiding sensitive columns in intersect_rows: {self.intersect_rows.columns}"
+        )
+        cols_to_hide = [
             *[col for col in self.join_columns if col in sensitive],
             *[col for col in self.df1_unq_columns() if col in sensitive],
             *[col for col in self.df2_unq_columns() if col in sensitive],
             *[f"{col}_{self.df1_name}" for col in common_cols if col in sensitive],
             *[f"{col}_{self.df2_name}" for col in common_cols if col in sensitive],
         ]
-        for col in cols_to_hash:
+        for col in cols_to_hide:
             self.intersect_rows[col] = "*******"
 
     def reveal_sensitive_columns(self) -> None:

--- a/datacompy/pandas.py
+++ b/datacompy/pandas.py
@@ -258,16 +258,15 @@ class PandasCompare(BaseCompare):
         )
 
         # Hide columns in unq_rows
-        for df in (self.df1_unq_rows, self.df2_unq_rows):
-            LOG.debug(f"Hiding sensitive columns in unq_rows: {df.columns}")
+        for df_name in ("df1_unq_rows", "df2_unq_rows"):
+            df = getattr(self, df_name)
+            LOG.debug(f"Hiding sensitive columns in {df_name}")
             cols_to_hide = [col for col in df.columns if col in sensitive]
             for col in cols_to_hide:
                 df[col] = "*******"
 
         # Hide columns in intersect_rows
-        LOG.debug(
-            f"Hiding sensitive columns in intersect_rows: {self.intersect_rows.columns}"
-        )
+        LOG.debug("Hiding sensitive columns in intersect_rows")
         cols_to_hide = [
             col for col in self.intersect_rows.columns if col in sensitive_with_suffixes
         ]

--- a/datacompy/pandas.py
+++ b/datacompy/pandas.py
@@ -251,7 +251,11 @@ class PandasCompare(BaseCompare):
         if not self.sensitive_columns:
             return
         sensitive = set(self.sensitive_columns)  # Otherwise this fails due to None
-        common_cols = self.intersect_columns() - set(self.join_columns)
+        sensitive_with_suffixes = (
+            sensitive
+            | {f"{c}_{self.df1_name}" for c in sensitive}
+            | {f"{c}_{self.df2_name}" for c in sensitive}
+        )
 
         # Hide columns in unq_rows
         for df in (self.df1_unq_rows, self.df2_unq_rows):
@@ -265,11 +269,7 @@ class PandasCompare(BaseCompare):
             f"Hiding sensitive columns in intersect_rows: {self.intersect_rows.columns}"
         )
         cols_to_hide = [
-            *[col for col in self.join_columns if col in sensitive],
-            *[col for col in self.df1_unq_columns() if col in sensitive],
-            *[col for col in self.df2_unq_columns() if col in sensitive],
-            *[f"{col}_{self.df1_name}" for col in common_cols if col in sensitive],
-            *[f"{col}_{self.df2_name}" for col in common_cols if col in sensitive],
+            col for col in self.intersect_rows.columns if col in sensitive_with_suffixes
         ]
         for col in cols_to_hide:
             self.intersect_rows[col] = "*******"

--- a/datacompy/pandas.py
+++ b/datacompy/pandas.py
@@ -228,7 +228,7 @@ class PandasCompare(BaseCompare):
 
     def hide_sensitive_columns(self, sensitive_columns: List[str]) -> None:
         """Hide sensitive columns of df1 or df2 if applicable in the compare."""
-        # don't allow hiding columns again before first revealing
+        # Don't allow hiding columns again before first revealing
         if self.sensitive_columns:
             raise ValueError(
                 "sensitive columns are already hidden, call reveal_sensitive_columns() first"
@@ -238,14 +238,14 @@ class PandasCompare(BaseCompare):
         sensitive = set(self.sensitive_columns)
         common_cols = self.intersect_columns() - set(self.join_columns)
 
-        # hash columns in unq_rows
+        # Hide columns in unq_rows
         for df in (self.df1_unq_rows, self.df2_unq_rows):
             LOG.debug(f"Hiding sensitive columns in {df}")
             cols_to_hash = [col for col in df.columns if col in sensitive]
             for col in cols_to_hash:
                 df[col] = "*******"
 
-        # hash columns in intersect_rows
+        # Hide columns in intersect_rows
         LOG.debug("Hiding sensitive columns in self.intersect_rows")
         cols_to_hash = [
             *[col for col in self.join_columns if col in sensitive],

--- a/datacompy/pandas.py
+++ b/datacompy/pandas.py
@@ -117,7 +117,7 @@ class PandasCompare(BaseCompare):
     ) -> None:
         self.cast_column_names_lower = cast_column_names_lower
         self.custom_comparators = custom_comparators or []
-        self._set_sensitive_columns(None)
+        self._set_and_validate_sensitive_columns(None)
 
         # Validate tolerance parameters first
         self._abs_tol_dict = validate_tolerance_parameter(
@@ -203,14 +203,18 @@ class PandasCompare(BaseCompare):
         """Get the list of sensitive columns."""
         return self._sensitive_columns
 
-    def _set_sensitive_columns(self, sensitive_columns: List[str] | None) -> None:
-        """Set sensitive_columns and then validate if needed."""
-        self._sensitive_columns = sensitive_columns
-        if self._sensitive_columns:
-            self._validate_sensitive_columns()
+    def _set_and_validate_sensitive_columns(
+        self, sensitive_columns: List[str] | None
+    ) -> None:
+        """Set and validate sensitive columns.
 
-    def _validate_sensitive_columns(self) -> None:
-        """Validate sensitive columns, assumes self.sensitive_columns is a list."""
+        Normalizes empty lists to None so there is only one representation
+        for "no sensitive columns".
+        """
+        self._sensitive_columns = sensitive_columns or None
+        if not self._sensitive_columns:
+            return
+
         if not all(isinstance(c, str) for c in self.sensitive_columns):
             raise TypeError("sensitive_columns must be a list of strings")
 
@@ -242,9 +246,11 @@ class PandasCompare(BaseCompare):
                 "sensitive columns are already hidden, call reveal_sensitive_columns() first"
             )
 
-        # validates through private setter
-        self._set_sensitive_columns(sensitive_columns)
-        sensitive = set(self.sensitive_columns)
+        self._set_and_validate_sensitive_columns(sensitive_columns)
+        # Don't do anything if [] is passed (normalized to None)
+        if not self.sensitive_columns:
+            return
+        sensitive = set(self.sensitive_columns)  # Otherwise this fails due to None
         common_cols = self.intersect_columns() - set(self.join_columns)
 
         # Hide columns in unq_rows
@@ -282,7 +288,7 @@ class PandasCompare(BaseCompare):
             return None
 
         LOG.debug("Revealing sensitive columns and re-comparing dfs")
-        self._set_sensitive_columns(None)
+        self._set_and_validate_sensitive_columns(None)
         self.column_stats.clear()
         self._compare(ignore_spaces=self.ignore_spaces, ignore_case=self.ignore_case)
 

--- a/datacompy/pandas.py
+++ b/datacompy/pandas.py
@@ -225,6 +225,16 @@ class PandasCompare(BaseCompare):
         duplicates = {c for c, n in Counter(self.sensitive_columns).items() if n > 1}
         if duplicates:
             raise ValueError(f"duplicate columns: {duplicates}")
+        
+        # Warn if column not in both df1 and df2
+        unused = [
+            c for c in self.sensitive_columns 
+            if (c not in self.df1.columns) and (c not in self.df2.columns)
+        ]
+        if unused:
+            LOG.warning(
+                 f"sensitive columns not found in both df1 and df2 will be ignored: {unused}"
+            )
 
     def hide_sensitive_columns(self, sensitive_columns: List[str]) -> None:
         """Hide sensitive columns of df1 or df2 if applicable in the compare."""

--- a/datacompy/pandas.py
+++ b/datacompy/pandas.py
@@ -237,7 +237,7 @@ class PandasCompare(BaseCompare):
             )
 
     def hide_sensitive_columns(self, sensitive_columns: List[str]) -> None:
-        """Hide sensitive columns of df1 or df2 if applicable in the compare."""
+        """Hides sensitive columns of df1 or df2 if applicable in the compare."""
         # Don't allow hiding columns again before first revealing
         if self.sensitive_columns:
             raise ValueError(
@@ -268,8 +268,16 @@ class PandasCompare(BaseCompare):
             self.intersect_rows[col] = "*******"
 
     def reveal_sensitive_columns(self) -> None:
-        """Reveal all sensitive columns and re-compare."""
-        if self.sensitive_columns is None:
+        """Reveals all sensitive columns.
+        
+        Notes
+        -----
+        - This re-runs the full comparison to restore original values.
+        - Revealing sensitive columns when there aren't any is treated as a NOP
+          to avoid redundant computations.
+        """
+        # Don't do anything if there aren't any sensitive columns
+        if not self.sensitive_columns:
             return None
 
         LOG.debug("Revealing sensitive columns and re-comparing dfs")

--- a/datacompy/pandas.py
+++ b/datacompy/pandas.py
@@ -285,7 +285,7 @@ class PandasCompare(BaseCompare):
         """
         # Don't do anything if there aren't any sensitive columns
         if not self.sensitive_columns:
-            return None
+            return
 
         LOG.debug("Revealing sensitive columns and re-comparing dfs")
         self._set_and_validate_sensitive_columns(None)

--- a/datacompy/pandas.py
+++ b/datacompy/pandas.py
@@ -21,7 +21,6 @@ PROC COMPARE in SAS - i.e. human-readable reporting on the difference between
 two dataframes.
 """
 
-import hashlib
 import logging
 from collections import Counter
 from typing import Any, Dict, List, cast
@@ -99,10 +98,6 @@ class PandasCompare(BaseCompare):
         Boolean indicator that controls of column names will be cast into lower case
     custom_comparators : list of ``BaseComparator``, optional
         A list of custom comparator classes to use to compare columns.
-    sensitive_columns: list[str], optional
-        A list of the columns in df1 or df2 that should have their values hashed to mask sensitive data.
-        [WARNING]: dataframes with columns in sensitive_columns will be modified inplace, it is advised
-        to manually copy any columns that may need to be later restored prior to using this parameter.
     """
 
     def __init__(
@@ -119,11 +114,10 @@ class PandasCompare(BaseCompare):
         ignore_case: bool = False,
         cast_column_names_lower: bool = True,
         custom_comparators: List[BaseComparator] | None = None,
-        sensitive_columns: List[str] | None = None,
     ) -> None:
         self.cast_column_names_lower = cast_column_names_lower
         self.custom_comparators = custom_comparators or []
-        self.sensitive_columns = sensitive_columns
+        self.sensitive_columns: List[str] | None = None
 
         # Validate tolerance parameters first
         self._abs_tol_dict = validate_tolerance_parameter(
@@ -169,7 +163,6 @@ class PandasCompare(BaseCompare):
         self.df2_unq_rows: pd.DataFrame
         self.intersect_rows: pd.DataFrame
         self.column_stats: List[Dict[str, Any]] = []
-        self._hash_sensitive_columns()
         self._compare(ignore_spaces=ignore_spaces, ignore_case=ignore_case)
 
     def _get_comparators(self) -> List[BaseComparator]:
@@ -233,40 +226,46 @@ class PandasCompare(BaseCompare):
         if duplicates:
             raise ValueError(f"duplicate columns: {duplicates}")
 
-    def _hash_sensitive_columns(self) -> None:
-        """Hash sensitive columns in both dataframes."""
-        if not self.sensitive_columns:
+    def hide_sensitive_columns(self, sensitive_columns: List[str]) -> None:
+        """Hide sensitive columns of df1 or df2 if applicable in the compare."""
+        # don't allow hiding columns again before first revealing
+        if self.sensitive_columns:
+            raise ValueError(
+                "sensitive columns are already hidden, call reveal_sensitive_columns() first"
+            )
+
+        self.sensitive_columns = sensitive_columns  # validates through setter
+        sensitive = set(self.sensitive_columns)
+        common_cols = self.intersect_columns() - set(self.join_columns)
+
+        # hash columns in unq_rows
+        for df in (self.df1_unq_rows, self.df2_unq_rows):
+            LOG.debug(f"Hiding sensitive columns in {df}")
+            cols_to_hash = [col for col in df.columns if col in sensitive]
+            for col in cols_to_hash:
+                df[col] = "*******"
+
+        # hash columns in intersect_rows
+        LOG.debug("Hiding sensitive columns in self.intersect_rows")
+        cols_to_hash = [
+            *[col for col in self.join_columns if col in sensitive],
+            *[col for col in self.df1_unq_columns() if col in sensitive],
+            *[col for col in self.df2_unq_columns() if col in sensitive],
+            *[f"{col}_{self.df1_name}" for col in common_cols if col in sensitive],
+            *[f"{col}_{self.df2_name}" for col in common_cols if col in sensitive],
+        ]
+        for col in cols_to_hash:
+            self.intersect_rows[col] = "*******"
+
+    def reveal_sensitive_columns(self) -> None:
+        """Reveal all sensitive columns and re-compare."""
+        if self.sensitive_columns is None:
             return None
 
-        # Logs warning only if sensitive columns is set and validation passes
-        LOG.warning(
-            "dataframes with columns in sensitive_columns will be modified inplace."
-        )
-
-        for df in (self.df1, self.df2):
-            # Process only the columns that actually exist in the current dataframe
-            cols_to_hash = [c for c in self.sensitive_columns if c in df.columns]
-
-            for col in cols_to_hash:
-                is_null = df[col].isnull()
-
-                # Convert the column to object type before hashing to allow
-                # assignment of strings and pd.NA regardless of the original dtype.
-                df[col] = df[col].astype(str)
-
-                # Only process if there are non-null values to hash
-                if not is_null.all():
-                    # Hash non-null values. str(v) ensures compatibility regardless of original dtype.
-                    # We apply the transformation only to the relevant slice.
-                    df.loc[~is_null, col] = df.loc[~is_null, col].map(
-                        lambda v: hashlib.blake2b(
-                            v.encode("utf-8"), digest_size=32
-                        ).hexdigest()
-                    )
-
-                # Ensure all nulls are consistently represented as pd.NA in the hashed column
-                if is_null.any():
-                    df.loc[is_null, col] = pd.NA
+        LOG.debug("Revealing sensitive columns and re-comparing dfs")
+        self.sensitive_columns = None
+        self.column_stats.clear()
+        self._compare(ignore_spaces=self.ignore_spaces, ignore_case=self.ignore_case)
 
     def _validate_dataframe(
         self, index: str, cast_column_names_lower: bool = True
@@ -414,6 +413,7 @@ class PandasCompare(BaseCompare):
             indicator=True,
             **params,
         )
+
         # Clean up temp columns for duplicate row matching
         if self._any_dupes:
             if self.on_index:

--- a/datacompy/pandas.py
+++ b/datacompy/pandas.py
@@ -1037,15 +1037,6 @@ def columns_equal(
     - Non-numeric values (i.e. where np.isclose can't be used) will just trigger
       ``True`` on two nulls or exact matches.
 
-    Notes
-    -----
-    - As of version ``0.14.0`` If a column is of a mixed data type the compare
-      will default to returning ``False``.
-    - ``list`` and ``np.array`` types will be compared row wise using ``np.array_equal``.
-      Depending on the size of your data this might lead to performance issues.
-    - All the rows must be of the same type otherwise it is considered "mixed"
-      and will default to being ``False`` for everything.
-
     Parameters
     ----------
     col_1 : Pandas.Series
@@ -1070,6 +1061,15 @@ def columns_equal(
     pandas.Series
         A series of Boolean values.  True == the values match, False == the
         values don't match.
+
+    Notes
+    -----
+    - As of version ``0.14.0`` If a column is of a mixed data type the compare
+      will default to returning ``False``.
+    - ``list`` and ``np.array`` types will be compared row wise using ``np.array_equal``.
+      Depending on the size of your data this might lead to performance issues.
+    - All the rows must be of the same type otherwise it is considered "mixed"
+      and will default to being ``False`` for everything.
     """
     compare: pd.Series[bool] | None
 

--- a/datacompy/pandas.py
+++ b/datacompy/pandas.py
@@ -240,13 +240,13 @@ class PandasCompare(BaseCompare):
 
         # Hide columns in unq_rows
         for df in (self.df1_unq_rows, self.df2_unq_rows):
-            LOG.debug(f"Hiding sensitive columns in {df}")
+            LOG.debug("Hiding sensitive columns in unq_rows")
             cols_to_hash = [col for col in df.columns if col in sensitive]
             for col in cols_to_hash:
                 df[col] = "*******"
 
         # Hide columns in intersect_rows
-        LOG.debug("Hiding sensitive columns in self.intersect_rows")
+        LOG.debug("Hiding sensitive columns in intersect_rows")
         cols_to_hash = [
             *[col for col in self.join_columns if col in sensitive],
             *[col for col in self.df1_unq_columns() if col in sensitive],

--- a/datacompy/pandas.py
+++ b/datacompy/pandas.py
@@ -222,15 +222,16 @@ class PandasCompare(BaseCompare):
         duplicates = {c for c, n in Counter(self.sensitive_columns).items() if n > 1}
         if duplicates:
             raise ValueError(f"duplicate columns: {duplicates}")
-        
+
         # Warn if column not in both df1 and df2
         unused = [
-            c for c in self.sensitive_columns 
-            if (c not in self.df1.columns) and (c not in self.df2.columns)
+            col
+            for col in self.sensitive_columns
+            if (col not in self.df1.columns) and (col not in self.df2.columns)
         ]
         if unused:
             LOG.warning(
-                 f"sensitive columns not found in both df1 and df2 will be ignored: {unused}"
+                f"sensitive columns not found in both df1 and df2 will be ignored: {unused}"
             )
 
     def hide_sensitive_columns(self, sensitive_columns: List[str]) -> None:
@@ -241,7 +242,8 @@ class PandasCompare(BaseCompare):
                 "sensitive columns are already hidden, call reveal_sensitive_columns() first"
             )
 
-        self._set_sensitive_columns(sensitive_columns)  # validates through private setter
+        # validates through private setter
+        self._set_sensitive_columns(sensitive_columns)
         sensitive = set(self.sensitive_columns)
         common_cols = self.intersect_columns() - set(self.join_columns)
 
@@ -266,7 +268,7 @@ class PandasCompare(BaseCompare):
 
     def reveal_sensitive_columns(self) -> None:
         """Reveals all sensitive columns.
-        
+
         Notes
         -----
         - This re-runs the full comparison to restore original values.

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -2392,7 +2392,10 @@ def test_sensitive_columns_unused(caplog):
     compare = datacompy.PandasCompare(df1, df2, join_columns=["a"])
     with caplog.at_level(logging.WARNING):
         compare.hide_sensitive_columns(["c"])
-        assert "sensitive columns not found in both df1 and df2 will be ignored: ['c']" in caplog.text
+        assert (
+            "sensitive columns not found in both df1 and df2 will be ignored: ['c']"
+            in caplog.text
+        )
 
     assert compare.df1.loc[0, "b"] == 2
     assert compare.df1.loc[1, "b"] == 0

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -2386,6 +2386,31 @@ def test_sensitive_columns_missing():
     compare.report()
 
 
+def test_sensitive_columns_unused(caplog):
+    df1 = pd.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = pd.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = datacompy.PandasCompare(df1, df2, join_columns=["a"])
+    with caplog.at_level(logging.WARNING):
+        compare.hide_sensitive_columns(["c"])
+        assert "sensitive columns not found in both df1 and df2 will be ignored: ['c']" in caplog.text
+
+    assert compare.df1.loc[0, "b"] == 2
+    assert compare.df1.loc[1, "b"] == 0
+    assert len(compare.df1_unq_rows) == 1
+    assert compare.df1_unq_rows.reset_index(drop=True).loc[0, "a"] == 1
+    assert compare.df1_unq_rows.reset_index(drop=True).loc[0, "b"] == 0
+    assert len(compare.df2_unq_rows) == 1
+    assert compare.df2_unq_rows.reset_index(drop=True).loc[0, "a"] == 2
+    assert compare.df2_unq_rows.reset_index(drop=True).loc[0, "b"] == 0
+    assert len(compare.intersect_rows) == 1
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "a"] == 1
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_df1"] == 2
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_df2"] == 2
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_match"]
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
 def test_sensitive_columns_setter():
     df1 = pd.DataFrame([{"a": 1, "b": 2}])
     df2 = pd.DataFrame([{"a": 1, "b": 2}])

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -2464,7 +2464,7 @@ def test_sensitive_columns_hide_reveal_empty():
 def test_sensitive_columns_setter():
     df1 = pd.DataFrame([{"a": 1, "b": 2}])
     df2 = pd.DataFrame([{"a": 1, "b": 2}])
-    compare = PandasCompare(df1, df2, join_columns=["a"])
+    compare = datacompy.PandasCompare(df1, df2, join_columns=["a"])
 
     # Valid setter call
     compare._set_sensitive_columns(["b"])

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -2467,12 +2467,12 @@ def test_sensitive_columns_setter():
     compare = datacompy.PandasCompare(df1, df2, join_columns=["a"])
 
     # Valid setter call
-    compare._set_sensitive_columns(["b"])
+    compare._set_and_validate_sensitive_columns(["b"])
     assert compare.sensitive_columns == ["b"]
 
     # Invalid setter call - not a list of strings
     with pytest.raises(TypeError, match="sensitive_columns must be a list of strings"):
-        compare._set_sensitive_columns([1, 2, 3])
+        compare._set_and_validate_sensitive_columns([1, 2, 3])
 
 
 def test_sensitive_columns_duplicates():

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -20,6 +20,7 @@ Testing out the datacompy functionality
 import io
 import logging
 import os
+import re
 import sys
 import tempfile
 from datetime import date, datetime
@@ -2173,28 +2174,89 @@ def test_array_comparator_pandas():
     assert list(mismatches["id"]) == [2, 5, 6]
 
 
-def test_sensitive_columns():
+def test_sensitive_columns_hide():
     df1 = pd.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
     df2 = pd.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
-    compare = datacompy.PandasCompare(
-        df1, df2, join_columns=["a"], sensitive_columns=["b"]
-    )
-    assert compare.df1.loc[0, "b"] != 2
-    assert compare.df1.loc[1, "b"] != 0
+    compare = datacompy.PandasCompare(df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["b"])
+
+    assert compare.df1.loc[0, "b"] == 2
+    assert compare.df1.loc[1, "b"] == 0
     assert len(compare.df1_unq_rows) == 1
+    assert compare.df1_unq_rows.reset_index(drop=True).loc[0, "a"] == 1
+    assert compare.df1_unq_rows.reset_index(drop=True).loc[0, "b"] == "*******"
+    assert len(compare.df2_unq_rows) == 1
+    assert compare.df2_unq_rows.reset_index(drop=True).loc[0, "a"] == 2
+    assert compare.df2_unq_rows.reset_index(drop=True).loc[0, "b"] == "*******"
+    assert len(compare.intersect_rows) == 1
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "a"] == 1
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_df1"] == "*******"
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_df2"] == "*******"
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_match"]
     # Just render the report to make sure it renders.
     compare.report()
 
 
-def test_sensitive_columns_null():
-    df1 = pd.DataFrame([{"a": 1, "b": "hello"}, {"a": 1, "b": None}])
-    df2 = pd.DataFrame([{"a": 1, "b": "hello"}, {"a": 2, "b": "yo"}])
-    compare = datacompy.PandasCompare(
-        df1, df2, join_columns=["a"], sensitive_columns=["b"]
-    )
-    assert compare.df1.loc[0, "b"] != "hello"
-    assert pd.isna(compare.df1.loc[1, "b"])
+def test_sensitive_columns_hide_hide():
+    df1 = pd.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = pd.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = datacompy.PandasCompare(df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["b"])
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "sensitive columns are already hidden, call reveal_sensitive_columns() first"
+        ),
+    ):
+        compare.hide_sensitive_columns(["c"])
+
+
+def test_sensitive_columns_hide_reveal():
+    df1 = pd.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = pd.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = datacompy.PandasCompare(df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["b"])
+    compare.reveal_sensitive_columns()
+
+    assert compare.df1.loc[0, "b"] == 2
+    assert compare.df1.loc[1, "b"] == 0
     assert len(compare.df1_unq_rows) == 1
+    assert compare.df1_unq_rows.reset_index(drop=True).loc[0, "a"] == 1
+    assert compare.df1_unq_rows.reset_index(drop=True).loc[0, "b"] == 0
+    assert len(compare.df2_unq_rows) == 1
+    assert compare.df2_unq_rows.reset_index(drop=True).loc[0, "a"] == 2
+    assert compare.df2_unq_rows.reset_index(drop=True).loc[0, "b"] == 0
+    assert len(compare.intersect_rows) == 1
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "a"] == 1
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_df1"] == 2
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_df2"] == 2
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_match"]
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_hide_reveal_hide():
+    df1 = pd.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = pd.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = datacompy.PandasCompare(df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["b"])
+    compare.reveal_sensitive_columns()
+    compare.hide_sensitive_columns(["b"])
+
+    assert compare.df1.loc[0, "b"] == 2
+    assert compare.df1.loc[1, "b"] == 0
+    assert len(compare.df1_unq_rows) == 1
+    assert compare.df1_unq_rows.reset_index(drop=True).loc[0, "a"] == 1
+    assert compare.df1_unq_rows.reset_index(drop=True).loc[0, "b"] == "*******"
+    assert len(compare.df2_unq_rows) == 1
+    assert compare.df2_unq_rows.reset_index(drop=True).loc[0, "a"] == 2
+    assert compare.df2_unq_rows.reset_index(drop=True).loc[0, "b"] == "*******"
+    assert len(compare.intersect_rows) == 1
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "a"] == 1
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_df1"] == "*******"
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_df2"] == "*******"
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_match"]
     # Just render the report to make sure it renders.
     compare.report()
 
@@ -2202,61 +2264,124 @@ def test_sensitive_columns_null():
 def test_sensitive_columns_cast_lower():
     df1 = pd.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
     df2 = pd.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
-    compare = datacompy.PandasCompare(
-        df1, df2, join_columns=["a"], sensitive_columns=["B"]
-    )
-    assert compare.df1.loc[0, "b"] != 2
-    assert compare.df1.loc[1, "b"] != 0
+    compare = datacompy.PandasCompare(df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["B"])
+
+    assert compare.df1.loc[0, "b"] == 2
+    assert compare.df1.loc[1, "b"] == 0
     assert len(compare.df1_unq_rows) == 1
+    assert compare.df1_unq_rows.reset_index(drop=True).loc[0, "a"] == 1
+    assert compare.df1_unq_rows.reset_index(drop=True).loc[0, "b"] == "*******"
+    assert len(compare.df2_unq_rows) == 1
+    assert compare.df2_unq_rows.reset_index(drop=True).loc[0, "a"] == 2
+    assert compare.df2_unq_rows.reset_index(drop=True).loc[0, "b"] == "*******"
+    assert len(compare.intersect_rows) == 1
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "a"] == 1
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_df1"] == "*******"
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_df2"] == "*******"
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_match"]
     # Just render the report to make sure it renders.
     compare.report()
 
 
 def test_sensitive_columns_no_cast_lower():
-    df1 = pd.DataFrame([{"a": 1, "b": 2, "B": 2}, {"a": 1, "b": 0, "B": 0}])
+    df1 = pd.DataFrame([{"a": 1, "b": 2, "B": 1}, {"a": 3, "b": 1, "B": 0}])
     df2 = pd.DataFrame([{"a": 1, "b": 2, "B": 2}, {"a": 2, "b": 0, "B": 0}])
     compare = datacompy.PandasCompare(
         df1,
         df2,
         join_columns=["a"],
-        sensitive_columns=["B"],
         cast_column_names_lower=False,
     )
+    compare.hide_sensitive_columns(["B"])
+
     assert compare.df1.loc[0, "b"] == 2
-    assert compare.df1.loc[1, "b"] == 0
-    assert compare.df1.loc[0, "B"] != 2
-    assert compare.df1.loc[1, "B"] != 0
+    assert compare.df1.loc[1, "b"] == 1
+    assert compare.df1.loc[0, "B"] == 1
+    assert compare.df1.loc[1, "B"] == 0
     assert len(compare.df1_unq_rows) == 1
+    assert compare.df1_unq_rows.reset_index(drop=True).loc[0, "a"] == 3
+    assert compare.df1_unq_rows.reset_index(drop=True).loc[0, "B"] == "*******"
+    assert len(compare.df2_unq_rows) == 1
+    assert compare.df2_unq_rows.reset_index(drop=True).loc[0, "a"] == 2
+    assert compare.df2_unq_rows.reset_index(drop=True).loc[0, "B"] == "*******"
+    assert len(compare.intersect_rows) == 1
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "a"] == 1
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_df1"] == 2
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_df2"] == 2
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "B_df1"] == "*******"
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "B_df2"] == "*******"
+    assert not compare.intersect_rows.reset_index(drop=True).loc[0, "B_match"]
     # Just render the report to make sure it renders.
     compare.report()
 
 
-def test_sensitive_columns_as_join_columns():
+def test_sensitive_columns_hide_join_columns():
     df1 = pd.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
     df2 = pd.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
-    compare = datacompy.PandasCompare(
-        df1, df2, join_columns=["a"], sensitive_columns=["a"]
-    )
-    assert compare.df1.loc[0, "a"] != 1
-    assert compare.df1.loc[1, "a"] != 1
+    compare = datacompy.PandasCompare(df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["a"])
+
+    assert compare.df1.loc[0, "a"] == 1
+    assert compare.df1.loc[1, "a"] == 1
     assert len(compare.df1_unq_rows) == 1
+    assert compare.df1_unq_rows.reset_index(drop=True).loc[0, "a"] == "*******"
+    assert len(compare.sample_mismatch("a")) == 2
+    assert compare.sample_mismatch("a").reset_index(drop=True).loc[0, "a"] == "*******"
+    assert compare.sample_mismatch("a").reset_index(drop=True).loc[1, "a"] == "*******"
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_hide_reveal_join_columns():
+    df1 = pd.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = pd.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = datacompy.PandasCompare(df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["a"])
+    compare.reveal_sensitive_columns()
+
+    assert compare.df1.loc[0, "a"] == 1
+    assert compare.df1.loc[1, "a"] == 1
+    assert len(compare.df1_unq_rows) == 1
+    assert compare.df1_unq_rows.reset_index(drop=True).loc[0, "a"] == 1
+    assert len(compare.sample_mismatch("a")) == 2
+    assert (
+        compare.sample_mismatch("a").sort_values("a").reset_index(drop=True).loc[0, "a"]
+        == 1
+    )
+    assert (
+        compare.sample_mismatch("a").sort_values("a").reset_index(drop=True).loc[1, "a"]
+        == 2
+    )
     # Just render the report to make sure it renders.
     compare.report()
 
 
 def test_sensitive_columns_missing():
-    df1 = pd.DataFrame([{"a": 1, "b": "hello", "c": 3}, {"a": 1, "b": "67", "c": 6}])
+    df1 = pd.DataFrame([{"a": 1, "b": "bruh", "c": 3}, {"a": 3, "b": "67", "c": 6}])
     df2 = pd.DataFrame([{"a": 1, "b": "hello", "d": 4}, {"a": 2, "b": "yo", "d": 7}])
-    compare = datacompy.PandasCompare(
-        df1, df2, join_columns=["a"], sensitive_columns=["b", "c"]
-    )
-    assert compare.df1.loc[0, "b"] != "hello"
-    assert compare.df1.loc[1, "b"] != "67"
-    assert compare.df1.loc[0, "c"] != 3
-    assert compare.df1.loc[1, "c"] != 6
+    compare = datacompy.PandasCompare(df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["b", "c"])
+
+    assert compare.df1.loc[0, "b"] == "bruh"
+    assert compare.df1.loc[1, "b"] == "67"
+    assert compare.df1.loc[0, "c"] == 3
+    assert compare.df1.loc[1, "c"] == 6
     assert compare.df2.loc[0, "d"] == 4
     assert compare.df2.loc[1, "d"] == 7
     assert len(compare.df1_unq_rows) == 1
+    assert compare.df1_unq_rows.reset_index(drop=True).loc[0, "a"] == 3
+    assert compare.df1_unq_rows.reset_index(drop=True).loc[0, "b"] == "*******"
+    assert compare.df1_unq_rows.reset_index(drop=True).loc[0, "c"] == "*******"
+    assert len(compare.df2_unq_rows) == 1
+    assert compare.df2_unq_rows.reset_index(drop=True).loc[0, "a"] == 2
+    assert compare.df2_unq_rows.reset_index(drop=True).loc[0, "b"] == "*******"
+    assert compare.df2_unq_rows.reset_index(drop=True).loc[0, "d"] == 7
+    assert len(compare.intersect_rows) == 1
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_df1"] == "*******"
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_df2"] == "*******"
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "c"] == "*******"
+    assert not compare.intersect_rows.reset_index(drop=True).loc[0, "b_match"]
     # Just render the report to make sure it renders.
     compare.report()
 
@@ -2264,7 +2389,7 @@ def test_sensitive_columns_missing():
 def test_sensitive_columns_setter():
     df1 = pd.DataFrame([{"a": 1, "b": 2}])
     df2 = pd.DataFrame([{"a": 1, "b": 2}])
-    compare = datacompy.PandasCompare(df1, df2, join_columns=["a"])
+    compare = PandasCompare(df1, df2, join_columns=["a"])
 
     # Valid setter call
     compare.sensitive_columns = ["b"]
@@ -2278,11 +2403,11 @@ def test_sensitive_columns_setter():
 def test_sensitive_columns_duplicates():
     df1 = pd.DataFrame([{"a": 1, "b": 2}])
     df2 = pd.DataFrame([{"a": 1, "b": 2}])
-    # Duplicate columns should raise ValueError during init/hashing
+
+    compare = datacompy.PandasCompare(df1, df2, join_columns=["a"])
+    # Duplicate columns should raise ValueError during hide_sensitive_columns()
     with pytest.raises(ValueError, match=r"duplicate columns: {'b'}"):
-        datacompy.PandasCompare(
-            df1, df2, join_columns=["a"], sensitive_columns=["b", "b"]
-        )
+        compare.hide_sensitive_columns(["b", "b"])
 
 
 def test_sensitive_columns_numeric_types():
@@ -2290,15 +2415,41 @@ def test_sensitive_columns_numeric_types():
     df1 = pd.DataFrame({"a": [1, 2], "b": [10, 20], "c": [1.1, 2.2]})
     df2 = pd.DataFrame({"a": [1, 2], "b": [10, 20], "c": [1.1, 2.2]})
 
-    compare = datacompy.PandasCompare(
-        df1, df2, join_columns=["a"], sensitive_columns=["b", "c"]
-    )
+    compare = datacompy.PandasCompare(df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["b", "c"])
 
-    assert isinstance(compare.df1["b"].loc[0], str)
-    assert isinstance(compare.df1["c"].loc[0], str)
-    # blake2b with digest_size=32 returns 64 hex characters
-    assert len(compare.df1["b"].loc[0]) == 64
-    assert len(compare.df1["c"].loc[0]) == 64
+    assert not isinstance(compare.df1["b"].loc[0], str)
+    assert not isinstance(compare.df1["c"].loc[0], str)
+    assert len(compare.df1_unq_rows) == 0
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_df1"] == "*******"
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_df2"] == "*******"
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "c_df1"] == "*******"
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "c_df2"] == "*******"
+
+
+def test_sensitive_columns_numeric_types_with_tolerance():
+    """Verify that hashing works for different numeric types with tolerance."""
+    df1 = pd.DataFrame({"a": [1, 2], "b": [10, 20], "c": [1.1, 2.1]})
+    df2 = pd.DataFrame({"a": [1, 3], "b": [10, 21], "c": [1.2, 2.1]})
+
+    compare = datacompy.PandasCompare(df1, df2, join_columns=["a"], abs_tol=0.1)
+    compare.hide_sensitive_columns(["b", "c"])
+
+    assert not isinstance(compare.df1["b"].loc[0], str)
+    assert not isinstance(compare.df1["c"].loc[0], str)
+    assert len(compare.df1_unq_rows) == 1
+    assert compare.df1_unq_rows.reset_index(drop=True).loc[0, "b"] == "*******"
+    assert compare.df1_unq_rows.reset_index(drop=True).loc[0, "c"] == "*******"
+    assert len(compare.df2_unq_rows) == 1
+    assert compare.df2_unq_rows.reset_index(drop=True).loc[0, "b"] == "*******"
+    assert compare.df2_unq_rows.reset_index(drop=True).loc[0, "c"] == "*******"
+    assert len(compare.intersect_rows) == 1
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_df1"] == "*******"
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_df2"] == "*******"
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_match"]
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "c_df1"] == "*******"
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "c_df2"] == "*******"
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "c_match"]
 
 
 def test_columns_with_mismatches_single_column():

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -2411,6 +2411,53 @@ def test_sensitive_columns_unused(caplog):
     compare.report()
 
 
+def test_sensitive_columns_hide_empty():
+    df1 = pd.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = pd.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = datacompy.PandasCompare(df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns([])
+
+    assert compare.df1.loc[0, "b"] == 2
+    assert compare.df1.loc[1, "b"] == 0
+    assert len(compare.df1_unq_rows) == 1
+    assert compare.df1_unq_rows.reset_index(drop=True).loc[0, "a"] == 1
+    assert compare.df1_unq_rows.reset_index(drop=True).loc[0, "b"] == 0
+    assert len(compare.df2_unq_rows) == 1
+    assert compare.df2_unq_rows.reset_index(drop=True).loc[0, "a"] == 2
+    assert compare.df2_unq_rows.reset_index(drop=True).loc[0, "b"] == 0
+    assert len(compare.intersect_rows) == 1
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "a"] == 1
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_df1"] == 2
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_df2"] == 2
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_match"]
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_hide_reveal_empty():
+    df1 = pd.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = pd.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = datacompy.PandasCompare(df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns([])
+    compare.reveal_sensitive_columns()
+
+    assert compare.df1.loc[0, "b"] == 2
+    assert compare.df1.loc[1, "b"] == 0
+    assert len(compare.df1_unq_rows) == 1
+    assert compare.df1_unq_rows.reset_index(drop=True).loc[0, "a"] == 1
+    assert compare.df1_unq_rows.reset_index(drop=True).loc[0, "b"] == 0
+    assert len(compare.df2_unq_rows) == 1
+    assert compare.df2_unq_rows.reset_index(drop=True).loc[0, "a"] == 2
+    assert compare.df2_unq_rows.reset_index(drop=True).loc[0, "b"] == 0
+    assert len(compare.intersect_rows) == 1
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "a"] == 1
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_df1"] == 2
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_df2"] == 2
+    assert compare.intersect_rows.reset_index(drop=True).loc[0, "b_match"]
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
 def test_sensitive_columns_setter():
     df1 = pd.DataFrame([{"a": 1, "b": 2}])
     df2 = pd.DataFrame([{"a": 1, "b": 2}])

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -2464,12 +2464,12 @@ def test_sensitive_columns_setter():
     compare = PandasCompare(df1, df2, join_columns=["a"])
 
     # Valid setter call
-    compare.sensitive_columns = ["b"]
+    compare._set_sensitive_columns(["b"])
     assert compare.sensitive_columns == ["b"]
 
     # Invalid setter call - not a list of strings
     with pytest.raises(TypeError, match="sensitive_columns must be a list of strings"):
-        compare.sensitive_columns = [1, 2, 3]
+        compare._set_sensitive_columns([1, 2, 3])
 
 
 def test_sensitive_columns_duplicates():

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -2393,7 +2393,7 @@ def test_sensitive_columns_unused(caplog):
     with caplog.at_level(logging.WARNING):
         compare.hide_sensitive_columns(["c"])
         assert (
-            "sensitive columns not found in both df1 and df2 will be ignored: ['c']"
+            "sensitive columns not found in either df1 or df2 will be ignored: ['c']"
             in caplog.text
         )
 


### PR DESCRIPTION
Improves on https://github.com/capitalone/datacompy/pull/490. Column hashing changed to data hiding/censoring. Can now be done without affecting the original dataframes and should not blow up memory footprint. 

- Realized data is already being copied internally when merging dataframes in `_dataframe_merge()`, with `df1_unq_rows`, `df2_unq_rows`, and `intersect_rows` being used downstream.
- We can modify these dataframes after `_compare()` is called to hide the relevant sensitive columns without modifying the original dataframes, also shouldn't introduce any significant memory pressure.
- Something not caught previously but should be fixed now is that tolerances wouldn't have worked for floats because the hashing was done prior to comparing.
- Since things are being done after the compare now instead of before, we can change the hashing to a simple column replacement of all `*******` to achieve full data hiding.
    - Much faster and simpler this way (don't need to worry about nulls).
- Sensitive column hiding is now done through the `hide_sensitive_columns(sensitive_columns)` method, we can also reveal the hidden columns through  `reveal_sensitive_columns()`.
    - combined the setter and validation into a single private method to prevent direct attribute modification, `self.sensitive_columns` should only be controlled through the hide/reveal methods.
- Updated unit tests.