### PR TITLE
feat: hide sensitive columns in PolarsCompare

### DIFF
--- a/datacompy/base.py
+++ b/datacompy/base.py
@@ -23,8 +23,9 @@ two dataframes.
 
 import logging
 from abc import ABC, abstractmethod
+from collections import Counter
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from ordered_set import OrderedSet
@@ -56,6 +57,46 @@ class BaseCompare(ABC):
     def df2(self, df2: Any) -> None:
         """Check that it is a dataframe and has the join columns."""
         pass
+
+    @property
+    def sensitive_columns(self) -> List[str] | None:
+        """Get the list of sensitive columns."""
+        return self._sensitive_columns
+
+    def _set_and_validate_sensitive_columns(
+        self, sensitive_columns: List[str] | None
+    ) -> None:
+        """Set and validate sensitive columns.
+
+        Normalizes empty lists to None so there is only one representation
+        for "no sensitive columns".
+        """
+        self._sensitive_columns = sensitive_columns or None
+        if not self._sensitive_columns:
+            return
+
+        if not all(isinstance(c, str) for c in self.sensitive_columns):
+            raise TypeError("sensitive_columns must be a list of strings")
+
+        # Cast to lowercase if applicable
+        if self.cast_column_names_lower:
+            self._sensitive_columns = [col.lower() for col in self.sensitive_columns]
+
+        # Check duplicates
+        duplicates = {c for c, n in Counter(self.sensitive_columns).items() if n > 1}
+        if duplicates:
+            raise ValueError(f"duplicate columns: {duplicates}")
+
+        # Warn if column not found in either dataframe
+        unused = [
+            col
+            for col in self.sensitive_columns
+            if (col not in self.df1.columns) and (col not in self.df2.columns)
+        ]
+        if unused:
+            LOG.warning(
+                f"sensitive columns not found in either df1 or df2 will be ignored: {unused}"
+            )
 
     @abstractmethod
     def _validate_dataframe(
@@ -181,6 +222,24 @@ class BaseCompare(ABC):
             The report, formatted according to the template.
         """
         pass
+
+    def reveal_sensitive_columns(self) -> None:
+        """Reveals all sensitive columns.
+
+        Notes
+        -----
+        - This re-runs the full comparison to restore original values.
+        - Revealing sensitive columns when there aren't any is treated as a NOP
+          to avoid redundant computations.
+        """
+        # Don't do anything if there aren't any sensitive columns
+        if not self.sensitive_columns:
+            return
+
+        LOG.debug("Revealing sensitive columns and re-comparing dfs")
+        self._set_and_validate_sensitive_columns(None)
+        self.column_stats.clear()
+        self._compare(ignore_spaces=self.ignore_spaces, ignore_case=self.ignore_case)
 
     def only_join_columns(self) -> bool:
         """Boolean on if the only columns are the join columns."""

--- a/datacompy/base.py
+++ b/datacompy/base.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 """
-Compare two Pandas DataFrames.
+Base module for comparing two DataFrames.
 
 Originally this package was meant to provide similar functionality to
 PROC COMPARE in SAS - i.e. human-readable reporting on the difference between

--- a/datacompy/pandas.py
+++ b/datacompy/pandas.py
@@ -116,7 +116,7 @@ class PandasCompare(BaseCompare):
     ) -> None:
         self.cast_column_names_lower = cast_column_names_lower
         self.custom_comparators = custom_comparators or []
-        self._set_and_validate_sensitive_columns(None)
+        self._sensitive_columns: List[str] | None = None
 
         # Validate tolerance parameters first
         self._abs_tol_dict = validate_tolerance_parameter(

--- a/datacompy/pandas.py
+++ b/datacompy/pandas.py
@@ -22,7 +22,6 @@ two dataframes.
 """
 
 import logging
-from collections import Counter
 from typing import Any, Dict, List, cast
 
 import pandas as pd
@@ -198,46 +197,6 @@ class PandasCompare(BaseCompare):
             "df2", cast_column_names_lower=self.cast_column_names_lower
         )
 
-    @property
-    def sensitive_columns(self) -> List[str] | None:
-        """Get the list of sensitive columns."""
-        return self._sensitive_columns
-
-    def _set_and_validate_sensitive_columns(
-        self, sensitive_columns: List[str] | None
-    ) -> None:
-        """Set and validate sensitive columns.
-
-        Normalizes empty lists to None so there is only one representation
-        for "no sensitive columns".
-        """
-        self._sensitive_columns = sensitive_columns or None
-        if not self._sensitive_columns:
-            return
-
-        if not all(isinstance(c, str) for c in self.sensitive_columns):
-            raise TypeError("sensitive_columns must be a list of strings")
-
-        # Cast to lowercase if applicable
-        if self.cast_column_names_lower:
-            self._sensitive_columns = [col.lower() for col in self.sensitive_columns]
-
-        # Check duplicates
-        duplicates = {c for c, n in Counter(self.sensitive_columns).items() if n > 1}
-        if duplicates:
-            raise ValueError(f"duplicate columns: {duplicates}")
-
-        # Warn if column not found in either dataframe
-        unused = [
-            col
-            for col in self.sensitive_columns
-            if (col not in self.df1.columns) and (col not in self.df2.columns)
-        ]
-        if unused:
-            LOG.warning(
-                f"sensitive columns not found in either df1 or df2 will be ignored: {unused}"
-            )
-
     def hide_sensitive_columns(self, sensitive_columns: List[str]) -> None:
         """Hides sensitive columns of df1 or df2 if applicable in the compare."""
         # Don't allow hiding columns again before first revealing
@@ -272,24 +231,6 @@ class PandasCompare(BaseCompare):
         ]
         for col in cols_to_hide:
             self.intersect_rows[col] = "*******"
-
-    def reveal_sensitive_columns(self) -> None:
-        """Reveals all sensitive columns.
-
-        Notes
-        -----
-        - This re-runs the full comparison to restore original values.
-        - Revealing sensitive columns when there aren't any is treated as a NOP
-          to avoid redundant computations.
-        """
-        # Don't do anything if there aren't any sensitive columns
-        if not self.sensitive_columns:
-            return
-
-        LOG.debug("Revealing sensitive columns and re-comparing dfs")
-        self._set_and_validate_sensitive_columns(None)
-        self.column_stats.clear()
-        self._compare(ignore_spaces=self.ignore_spaces, ignore_case=self.ignore_case)
 
     def _validate_dataframe(
         self, index: str, cast_column_names_lower: bool = True

--- a/datacompy/polars.py
+++ b/datacompy/polars.py
@@ -266,7 +266,7 @@ class PolarsCompare(BaseCompare):
             *[f"{col}_{self.df2_name}" for col in common_cols if col in sensitive],
         ]
         if not cols_to_hide:  # skip if empty
-            return None
+            return
         self.intersect_rows = self.intersect_rows.with_columns(
             [pl.lit("*******").alias(col) for col in cols_to_hide]
         )
@@ -282,7 +282,7 @@ class PolarsCompare(BaseCompare):
         """
         # Don't do anything if there aren't any sensitive columns
         if not self.sensitive_columns:
-            return None
+            return
 
         LOG.debug("Revealing sensitive columns and re-comparing dfs")
         self._set_and_validate_sensitive_columns(None)

--- a/datacompy/polars.py
+++ b/datacompy/polars.py
@@ -211,7 +211,7 @@ class PolarsCompare(BaseCompare):
         if duplicates:
             raise ValueError(f"duplicate columns: {duplicates}")
 
-        # Warn if column not in both df1 and df2
+        # Warn if column not found in either dataframe
         unused = [
             col
             for col in self.sensitive_columns
@@ -219,7 +219,7 @@ class PolarsCompare(BaseCompare):
         ]
         if unused:
             LOG.warning(
-                f"sensitive columns not found in both df1 and df2 will be ignored: {unused}"
+                f"sensitive columns not found in either df1 or df2 will be ignored: {unused}"
             )
 
     def hide_sensitive_columns(self, sensitive_columns: List[str]) -> None:

--- a/datacompy/polars.py
+++ b/datacompy/polars.py
@@ -22,7 +22,6 @@ two dataframes.
 """
 
 import logging
-from collections import Counter
 from copy import deepcopy
 from typing import Any, Dict, List, cast
 
@@ -186,46 +185,6 @@ class PolarsCompare(BaseCompare):
             "df2", cast_column_names_lower=self.cast_column_names_lower
         )
 
-    @property
-    def sensitive_columns(self) -> List[str] | None:
-        """Get the list of sensitive columns."""
-        return self._sensitive_columns
-
-    def _set_and_validate_sensitive_columns(
-        self, sensitive_columns: List[str] | None
-    ) -> None:
-        """Set and validate sensitive columns.
-
-        Normalizes empty lists to None so there is only one representation
-        for "no sensitive columns".
-        """
-        self._sensitive_columns = sensitive_columns or None
-        if not self._sensitive_columns:
-            return
-
-        if not all(isinstance(c, str) for c in self.sensitive_columns):
-            raise TypeError("sensitive_columns must be a list of strings")
-
-        # Cast to lowercase if applicable
-        if self.cast_column_names_lower:
-            self._sensitive_columns = [col.lower() for col in self.sensitive_columns]
-
-        # Check duplicates
-        duplicates = {c for c, n in Counter(self.sensitive_columns).items() if n > 1}
-        if duplicates:
-            raise ValueError(f"duplicate columns: {duplicates}")
-
-        # Warn if column not found in either dataframe
-        unused = [
-            col
-            for col in self.sensitive_columns
-            if (col not in self.df1.columns) and (col not in self.df2.columns)
-        ]
-        if unused:
-            LOG.warning(
-                f"sensitive columns not found in either df1 or df2 will be ignored: {unused}"
-            )
-
     def hide_sensitive_columns(self, sensitive_columns: List[str]) -> None:
         """Hides sensitive columns of df1 or df2 if applicable in the compare."""
         # Don't allow hiding columns again before first revealing
@@ -268,24 +227,6 @@ class PolarsCompare(BaseCompare):
         self.intersect_rows = self.intersect_rows.with_columns(
             [pl.lit("*******").alias(col) for col in cols_to_hide]
         )
-
-    def reveal_sensitive_columns(self) -> None:
-        """Reveals all sensitive columns.
-
-        Notes
-        -----
-        - This re-runs the full comparison to restore original values.
-        - Revealing sensitive columns when there aren't any is treated as a NOP
-          to avoid redundant computations.
-        """
-        # Don't do anything if there aren't any sensitive columns
-        if not self.sensitive_columns:
-            return
-
-        LOG.debug("Revealing sensitive columns and re-comparing dfs")
-        self._set_and_validate_sensitive_columns(None)
-        self.column_stats.clear()
-        self._compare(ignore_spaces=self.ignore_spaces, ignore_case=self.ignore_case)
 
     def _validate_dataframe(
         self, index: str, cast_column_names_lower: bool = True

--- a/datacompy/polars.py
+++ b/datacompy/polars.py
@@ -22,6 +22,7 @@ two dataframes.
 """
 
 import logging
+from collections import Counter
 from copy import deepcopy
 from typing import Any, Dict, List, cast
 
@@ -113,6 +114,7 @@ class PolarsCompare(BaseCompare):
     ) -> None:
         self.cast_column_names_lower = cast_column_names_lower
         self.custom_comparators = custom_comparators or []
+        self._set_sensitive_columns(None)
 
         # Validate tolerance parameters first
         self._abs_tol_dict = validate_tolerance_parameter(
@@ -183,6 +185,42 @@ class PolarsCompare(BaseCompare):
         self._validate_dataframe(
             "df2", cast_column_names_lower=self.cast_column_names_lower
         )
+
+    @property
+    def sensitive_columns(self) -> List[str] | None:
+        """Get the list of sensitive columns."""
+        return self._sensitive_columns
+
+    def _set_sensitive_columns(self, sensitive_columns: List[str] | None) -> None:
+        """Set sensitive_columns and then validate if needed."""
+        self._sensitive_columns = sensitive_columns
+        if self._sensitive_columns:
+            self._validate_sensitive_columns()
+
+    def _validate_sensitive_columns(self) -> None:
+        """Validate sensitive columns, assumes self.sensitive_columns is a list."""
+        if not all(isinstance(c, str) for c in self.sensitive_columns):
+            raise TypeError("sensitive_columns must be a list of strings")
+
+        # Cast to lowercase if applicable
+        if self.cast_column_names_lower:
+            self._sensitive_columns = [col.lower() for col in self.sensitive_columns]
+
+        # Check duplicates
+        duplicates = {c for c, n in Counter(self.sensitive_columns).items() if n > 1}
+        if duplicates:
+            raise ValueError(f"duplicate columns: {duplicates}")
+
+        # Warn if column not in both df1 and df2
+        unused = [
+            col
+            for col in self.sensitive_columns
+            if (col not in self.df1.columns) and (col not in self.df2.columns)
+        ]
+        if unused:
+            LOG.warning(
+                f"sensitive columns not found in both df1 and df2 will be ignored: {unused}"
+            )
 
     def _validate_dataframe(
         self, index: str, cast_column_names_lower: bool = True

--- a/datacompy/polars.py
+++ b/datacompy/polars.py
@@ -222,6 +222,47 @@ class PolarsCompare(BaseCompare):
                 f"sensitive columns not found in both df1 and df2 will be ignored: {unused}"
             )
 
+    def hide_sensitive_columns(self, sensitive_columns: List[str]) -> None:
+        """Hides sensitive columns of df1 or df2 if applicable in the compare."""
+        # Don't allow hiding columns again before first revealing
+        if self.sensitive_columns:
+            raise ValueError(
+                "sensitive columns are already hidden, call reveal_sensitive_columns() first"
+            )
+
+        # validates through private setter
+        self._set_sensitive_columns(sensitive_columns)
+        sensitive = set(self.sensitive_columns)
+        common_cols = self.intersect_columns() - set(self.join_columns)
+
+        # Hide columns in unq_rows
+        for df_name in ("df1_unq_rows", "df2_unq_rows"):
+            df = getattr(self, df_name)
+            LOG.debug("Hiding sensitive columns in unq_rows")
+            cols_to_hide = [col for col in df.columns if col in sensitive]
+            if not cols_to_hide:  # skip if empty
+                continue
+            setattr(
+                self,
+                df_name,
+                df.with_columns([pl.lit("*******").alias(col) for col in cols_to_hide]),
+            )
+
+        # Hide columns in intersect_rows
+        LOG.debug("Hiding sensitive columns in intersect_rows")
+        cols_to_hide = [
+            *[col for col in self.join_columns if col in sensitive],
+            *[col for col in self.df1_unq_columns() if col in sensitive],
+            *[col for col in self.df2_unq_columns() if col in sensitive],
+            *[f"{col}_{self.df1_name}" for col in common_cols if col in sensitive],
+            *[f"{col}_{self.df2_name}" for col in common_cols if col in sensitive],
+        ]
+        if not cols_to_hide:  # skip if empty
+            return None
+        self.intersect_rows = self.intersect_rows.with_columns(
+            [pl.lit("*******").alias(col) for col in cols_to_hide]
+        )
+
     def _validate_dataframe(
         self, index: str, cast_column_names_lower: bool = True
     ) -> None:

--- a/datacompy/polars.py
+++ b/datacompy/polars.py
@@ -113,7 +113,7 @@ class PolarsCompare(BaseCompare):
     ) -> None:
         self.cast_column_names_lower = cast_column_names_lower
         self.custom_comparators = custom_comparators or []
-        self._set_and_validate_sensitive_columns(None)
+        self._sensitive_columns: List[str] | None = None
 
         # Validate tolerance parameters first
         self._abs_tol_dict = validate_tolerance_parameter(

--- a/datacompy/polars.py
+++ b/datacompy/polars.py
@@ -238,7 +238,7 @@ class PolarsCompare(BaseCompare):
         # Hide columns in unq_rows
         for df_name in ("df1_unq_rows", "df2_unq_rows"):
             df = getattr(self, df_name)
-            LOG.debug("Hiding sensitive columns in unq_rows")
+            LOG.debug(f"Hiding sensitive columns in unq_rows: {df.columns}")
             cols_to_hide = [col for col in df.columns if col in sensitive]
             if not cols_to_hide:  # skip if empty
                 continue
@@ -249,7 +249,9 @@ class PolarsCompare(BaseCompare):
             )
 
         # Hide columns in intersect_rows
-        LOG.debug("Hiding sensitive columns in intersect_rows")
+        LOG.debug(
+            f"Hiding sensitive columns in intersect_rows {self.intersect_rows.columns}"
+        )
         cols_to_hide = [
             *[col for col in self.join_columns if col in sensitive],
             *[col for col in self.df1_unq_columns() if col in sensitive],
@@ -262,6 +264,24 @@ class PolarsCompare(BaseCompare):
         self.intersect_rows = self.intersect_rows.with_columns(
             [pl.lit("*******").alias(col) for col in cols_to_hide]
         )
+
+    def reveal_sensitive_columns(self) -> None:
+        """Reveals all sensitive columns.
+
+        Notes
+        -----
+        - This re-runs the full comparison to restore original values.
+        - Revealing sensitive columns when there aren't any is treated as a NOP
+          to avoid redundant computations.
+        """
+        # Don't do anything if there aren't any sensitive columns
+        if not self.sensitive_columns:
+            return None
+
+        LOG.debug("Revealing sensitive columns and re-comparing dfs")
+        self._set_sensitive_columns(None)
+        self.column_stats.clear()
+        self._compare(ignore_spaces=self.ignore_spaces, ignore_case=self.ignore_case)
 
     def _validate_dataframe(
         self, index: str, cast_column_names_lower: bool = True

--- a/datacompy/polars.py
+++ b/datacompy/polars.py
@@ -248,7 +248,7 @@ class PolarsCompare(BaseCompare):
         # Hide columns in unq_rows
         for df_name in ("df1_unq_rows", "df2_unq_rows"):
             df = getattr(self, df_name)
-            LOG.debug(f"Hiding sensitive columns in unq_rows: {df.columns}")
+            LOG.debug(f"Hiding sensitive columns in {df_name}")
             cols_to_hide = [col for col in df.columns if col in sensitive]
             if not cols_to_hide:  # skip if empty
                 continue
@@ -259,9 +259,7 @@ class PolarsCompare(BaseCompare):
             )
 
         # Hide columns in intersect_rows
-        LOG.debug(
-            f"Hiding sensitive columns in intersect_rows {self.intersect_rows.columns}"
-        )
+        LOG.debug("Hiding sensitive columns in intersect_rows")
         cols_to_hide = [
             col for col in self.intersect_rows.columns if col in sensitive_with_suffixes
         ]

--- a/datacompy/polars.py
+++ b/datacompy/polars.py
@@ -239,7 +239,11 @@ class PolarsCompare(BaseCompare):
         if not self.sensitive_columns:
             return
         sensitive = set(self.sensitive_columns)  # Otherwise this fails due to None
-        common_cols = self.intersect_columns() - set(self.join_columns)
+        sensitive_with_suffixes = (
+            sensitive
+            | {f"{c}_{self.df1_name}" for c in sensitive}
+            | {f"{c}_{self.df2_name}" for c in sensitive}
+        )
 
         # Hide columns in unq_rows
         for df_name in ("df1_unq_rows", "df2_unq_rows"):
@@ -259,11 +263,7 @@ class PolarsCompare(BaseCompare):
             f"Hiding sensitive columns in intersect_rows {self.intersect_rows.columns}"
         )
         cols_to_hide = [
-            *[col for col in self.join_columns if col in sensitive],
-            *[f"{c}_{self.df1_name}" for c in self.df1_unq_columns() if c in sensitive],
-            *[f"{c}_{self.df2_name}" for c in self.df2_unq_columns() if c in sensitive],
-            *[f"{col}_{self.df1_name}" for col in common_cols if col in sensitive],
-            *[f"{col}_{self.df2_name}" for col in common_cols if col in sensitive],
+            col for col in self.intersect_rows.columns if col in sensitive_with_suffixes
         ]
         if not cols_to_hide:  # skip if empty
             return

--- a/datacompy/polars.py
+++ b/datacompy/polars.py
@@ -254,8 +254,8 @@ class PolarsCompare(BaseCompare):
         )
         cols_to_hide = [
             *[col for col in self.join_columns if col in sensitive],
-            *[col for col in self.df1_unq_columns() if col in sensitive],
-            *[col for col in self.df2_unq_columns() if col in sensitive],
+            *[f"{c}_{self.df1_name}" for c in self.df1_unq_columns() if c in sensitive],
+            *[f"{c}_{self.df2_name}" for c in self.df2_unq_columns() if c in sensitive],
             *[f"{col}_{self.df1_name}" for col in common_cols if col in sensitive],
             *[f"{col}_{self.df2_name}" for col in common_cols if col in sensitive],
         ]

--- a/datacompy/polars.py
+++ b/datacompy/polars.py
@@ -114,7 +114,7 @@ class PolarsCompare(BaseCompare):
     ) -> None:
         self.cast_column_names_lower = cast_column_names_lower
         self.custom_comparators = custom_comparators or []
-        self._set_sensitive_columns(None)
+        self._set_and_validate_sensitive_columns(None)
 
         # Validate tolerance parameters first
         self._abs_tol_dict = validate_tolerance_parameter(
@@ -191,14 +191,18 @@ class PolarsCompare(BaseCompare):
         """Get the list of sensitive columns."""
         return self._sensitive_columns
 
-    def _set_sensitive_columns(self, sensitive_columns: List[str] | None) -> None:
-        """Set sensitive_columns and then validate if needed."""
-        self._sensitive_columns = sensitive_columns
-        if self._sensitive_columns:
-            self._validate_sensitive_columns()
+    def _set_and_validate_sensitive_columns(
+        self, sensitive_columns: List[str] | None
+    ) -> None:
+        """Set and validate sensitive columns.
 
-    def _validate_sensitive_columns(self) -> None:
-        """Validate sensitive columns, assumes self.sensitive_columns is a list."""
+        Normalizes empty lists to None so there is only one representation
+        for "no sensitive columns".
+        """
+        self._sensitive_columns = sensitive_columns or None
+        if not self._sensitive_columns:
+            return
+
         if not all(isinstance(c, str) for c in self.sensitive_columns):
             raise TypeError("sensitive_columns must be a list of strings")
 
@@ -230,9 +234,11 @@ class PolarsCompare(BaseCompare):
                 "sensitive columns are already hidden, call reveal_sensitive_columns() first"
             )
 
-        # validates through private setter
-        self._set_sensitive_columns(sensitive_columns)
-        sensitive = set(self.sensitive_columns)
+        self._set_and_validate_sensitive_columns(sensitive_columns)
+        # Don't do anything if [] is passed (normalized to None)
+        if not self.sensitive_columns:
+            return
+        sensitive = set(self.sensitive_columns)  # Otherwise this fails due to None
         common_cols = self.intersect_columns() - set(self.join_columns)
 
         # Hide columns in unq_rows
@@ -279,7 +285,7 @@ class PolarsCompare(BaseCompare):
             return None
 
         LOG.debug("Revealing sensitive columns and re-comparing dfs")
-        self._set_sensitive_columns(None)
+        self._set_and_validate_sensitive_columns(None)
         self.column_stats.clear()
         self._compare(ignore_spaces=self.ignore_spaces, ignore_case=self.ignore_case)
 

--- a/datacompy/snowflake.py
+++ b/datacompy/snowflake.py
@@ -153,6 +153,7 @@ class SnowflakeCompare(BaseCompare):
         self._rel_tol_dict = validate_tolerance_parameter(
             rel_tol, "rel_tol", case_mode="upper"
         )
+        self._sensitive_columns: List[str] | None = None
 
         if join_columns is None:
             errmsg = "join_columns cannot be None"

--- a/datacompy/spark.py
+++ b/datacompy/spark.py
@@ -148,6 +148,7 @@ class SparkSQLCompare(BaseCompare):
         self.cast_column_names_lower = cast_column_names_lower
         self.custom_comparators = custom_comparators or []
         self.cache_intermediates = cache_intermediates
+        self._sensitive_columns: List[str] | None = None
 
         # Validate tolerance parameters first
         self._abs_tol_dict = validate_tolerance_parameter(

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -2486,7 +2486,7 @@ def test_sensitive_columns_duplicates():
 
 
 def test_sensitive_columns_numeric_types():
-    """Verify that hashing works for different numeric types without LossySetitemError."""
+    """Verify that hiding works for different numeric types without LossySetitemError."""
     df1 = pd.DataFrame({"a": [1, 2], "b": [10, 20], "c": [1.1, 2.2]})
     df2 = pd.DataFrame({"a": [1, 2], "b": [10, 20], "c": [1.1, 2.2]})
 
@@ -2503,7 +2503,7 @@ def test_sensitive_columns_numeric_types():
 
 
 def test_sensitive_columns_numeric_types_with_tolerance():
-    """Verify that hashing works for different numeric types with tolerance."""
+    """Verify that hiding works for different numeric types with tolerance."""
     df1 = pd.DataFrame({"a": [1, 2], "b": [10, 20], "c": [1.1, 2.1]})
     df2 = pd.DataFrame({"a": [1, 3], "b": [10, 21], "c": [1.2, 2.1]})
 

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -2599,7 +2599,7 @@ def test_sensitive_columns_duplicates():
 
 
 def test_sensitive_columns_numeric_types():
-    """Verify that hashing works for different numeric types without LossySetitemError."""
+    """Verify that hiding works for different numeric types without LossySetitemError."""
     df1 = pl.DataFrame({"a": [1, 2], "b": [10, 20], "c": [1.1, 2.2]})
     df2 = pl.DataFrame({"a": [1, 2], "b": [10, 20], "c": [1.1, 2.2]})
 

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -20,6 +20,7 @@ Testing out the datacompy functionality
 import io
 import logging
 import os
+import re
 import sys
 import tempfile
 from datetime import datetime
@@ -2287,3 +2288,353 @@ def test_columns_with_mismatches_multiple_join_columns():
     assert "id1" not in result
     assert "id2" not in result
     assert sorted(result) == ["value1", "value2"]
+
+
+def test_sensitive_columns_hide():
+    df1 = pl.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = pl.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = PolarsCompare(df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["b"])
+
+    assert compare.df1[0, "b"] == 2
+    assert compare.df1[1, "b"] == 0
+    assert len(compare.df1_unq_rows) == 1
+    assert compare.df1_unq_rows[0, "a"] == 1
+    assert compare.df1_unq_rows[0, "b"] == "*******"
+    assert len(compare.df2_unq_rows) == 1
+    assert compare.df2_unq_rows[0, "a"] == 2
+    assert compare.df2_unq_rows[0, "b"] == "*******"
+    assert len(compare.intersect_rows) == 1
+    assert compare.intersect_rows[0, "a"] == 1
+    assert compare.intersect_rows[0, "b_df1"] == "*******"
+    assert compare.intersect_rows[0, "b_df2"] == "*******"
+    assert compare.intersect_rows[0, "b_match"]
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_hide_hide():
+    df1 = pl.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = pl.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = PolarsCompare(df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["b"])
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "sensitive columns are already hidden, call reveal_sensitive_columns() first"
+        ),
+    ):
+        compare.hide_sensitive_columns(["c"])
+
+
+def test_sensitive_columns_hide_reveal():
+    df1 = pl.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = pl.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = PolarsCompare(df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["b"])
+    compare.reveal_sensitive_columns()
+
+    assert compare.df1[0, "b"] == 2
+    assert compare.df1[1, "b"] == 0
+    assert len(compare.df1_unq_rows) == 1
+    assert compare.df1_unq_rows[0, "a"] == 1
+    assert compare.df1_unq_rows[0, "b"] == 0
+    assert len(compare.df2_unq_rows) == 1
+    assert compare.df2_unq_rows[0, "a"] == 2
+    assert compare.df2_unq_rows[0, "b"] == 0
+    assert len(compare.intersect_rows) == 1
+    assert compare.intersect_rows[0, "a"] == 1
+    assert compare.intersect_rows[0, "b_df1"] == 2
+    assert compare.intersect_rows[0, "b_df2"] == 2
+    assert compare.intersect_rows[0, "b_match"]
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_hide_reveal_hide():
+    df1 = pl.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = pl.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = PolarsCompare(df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["b"])
+    compare.reveal_sensitive_columns()
+    compare.hide_sensitive_columns(["b"])
+
+    assert compare.df1[0, "b"] == 2
+    assert compare.df2[1, "b"] == 0
+    assert len(compare.df1_unq_rows) == 1
+    assert compare.df1_unq_rows[0, "a"] == 1
+    assert compare.df1_unq_rows[0, "b"] == "*******"
+    assert len(compare.df2_unq_rows) == 1
+    assert compare.df2_unq_rows[0, "a"] == 2
+    assert compare.df2_unq_rows[0, "b"] == "*******"
+    assert len(compare.intersect_rows) == 1
+    assert compare.intersect_rows[0, "a"] == 1
+    assert compare.intersect_rows[0, "b_df1"] == "*******"
+    assert compare.intersect_rows[0, "b_df2"] == "*******"
+    assert compare.intersect_rows[0, "b_match"]
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_cast_lower():
+    df1 = pl.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = pl.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = PolarsCompare(df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["B"])
+
+    assert compare.df1[0, "b"] == 2
+    assert compare.df1[1, "b"] == 0
+    assert len(compare.df1_unq_rows) == 1
+    assert compare.df1_unq_rows[0, "a"] == 1
+    assert compare.df1_unq_rows[0, "b"] == "*******"
+    assert len(compare.df2_unq_rows) == 1
+    assert compare.df2_unq_rows[0, "a"] == 2
+    assert compare.df2_unq_rows[0, "b"] == "*******"
+    assert len(compare.intersect_rows) == 1
+    assert compare.intersect_rows[0, "a"] == 1
+    assert compare.intersect_rows[0, "b_df1"] == "*******"
+    assert compare.intersect_rows[0, "b_df2"] == "*******"
+    assert compare.intersect_rows[0, "b_match"]
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_no_cast_lower():
+    df1 = pl.DataFrame([{"a": 1, "b": 2, "B": 1}, {"a": 3, "b": 1, "B": 0}])
+    df2 = pl.DataFrame([{"a": 1, "b": 2, "B": 2}, {"a": 2, "b": 0, "B": 0}])
+    compare = PolarsCompare(
+        df1,
+        df2,
+        join_columns=["a"],
+        cast_column_names_lower=False,
+    )
+    compare.hide_sensitive_columns(["B"])
+
+    assert compare.df1[0, "b"] == 2
+    assert compare.df1[1, "b"] == 1
+    assert compare.df1[0, "B"] == 1
+    assert compare.df1[1, "B"] == 0
+    assert len(compare.df1_unq_rows) == 1
+    assert compare.df1_unq_rows[0, "a"] == 3
+    assert compare.df1_unq_rows[0, "B"] == "*******"
+    assert len(compare.df2_unq_rows) == 1
+    assert compare.df2_unq_rows[0, "a"] == 2
+    assert compare.df2_unq_rows[0, "B"] == "*******"
+    assert len(compare.intersect_rows) == 1
+    assert compare.intersect_rows[0, "a"] == 1
+    assert compare.intersect_rows[0, "b_df1"] == 2
+    assert compare.intersect_rows[0, "b_df2"] == 2
+    assert compare.intersect_rows[0, "B_df1"] == "*******"
+    assert compare.intersect_rows[0, "B_df2"] == "*******"
+    assert not compare.intersect_rows[0, "B_match"]
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_hide_join_columns():
+    df1 = pl.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = pl.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = PolarsCompare(df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["a"])
+
+    assert compare.df1[0, "a"] == 1
+    assert compare.df1[1, "a"] == 1
+    assert len(compare.df1_unq_rows) == 1
+    assert compare.df1_unq_rows[0, "a"] == "*******"
+    assert len(compare.sample_mismatch("a")) == 2
+    assert compare.sample_mismatch("a")[0, "a"] == "*******"
+    assert compare.sample_mismatch("a")[1, "a"] == "*******"
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_hide_reveal_join_columns():
+    df1 = pl.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = pl.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = PolarsCompare(df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["a"])
+    compare.reveal_sensitive_columns()
+
+    assert compare.df1[0, "a"] == 1
+    assert compare.df1[1, "a"] == 1
+    assert len(compare.df1_unq_rows) == 1
+    assert compare.df1_unq_rows[0, "a"] == 1
+    assert len(compare.sample_mismatch("a")) == 2
+    assert compare.sample_mismatch("a").sort("a")[0, "a"] == 1
+    assert compare.sample_mismatch("a").sort("a")[1, "a"] == 2
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_missing():
+    df1 = pl.DataFrame([{"a": 1, "b": "bruh", "c": 3}, {"a": 3, "b": "67", "c": 6}])
+    df2 = pl.DataFrame([{"a": 1, "b": "hello", "d": 4}, {"a": 2, "b": "yo", "d": 7}])
+    compare = PolarsCompare(df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["b", "c"])
+
+    assert compare.df1[0, "b"] == "bruh"
+    assert compare.df1[1, "b"] == "67"
+    assert compare.df1[0, "c"] == 3
+    assert compare.df1[1, "c"] == 6
+    assert compare.df2[0, "d"] == 4
+    assert compare.df2[1, "d"] == 7
+    assert len(compare.df1_unq_rows) == 1
+    assert compare.df1_unq_rows[0, "a"] == 3
+    assert compare.df1_unq_rows[0, "b"] == "*******"
+    assert compare.df1_unq_rows[0, "c"] == "*******"
+    assert len(compare.df2_unq_rows) == 1
+    assert compare.df2_unq_rows[0, "a"] == 2
+    assert compare.df2_unq_rows[0, "b"] == "*******"
+    assert compare.df2_unq_rows[0, "d"] == 7
+    assert len(compare.intersect_rows) == 1
+    assert compare.intersect_rows[0, "b_df1"] == "*******"
+    assert compare.intersect_rows[0, "b_df2"] == "*******"
+    assert compare.intersect_rows[0, "c_df1"] == "*******"
+    assert compare.intersect_rows[0, "d_df2"] == 4
+    assert "c" not in compare.intersect_rows.columns
+    assert "d" not in compare.intersect_rows.columns
+    assert not compare.intersect_rows[0, "b_match"]
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_unused(caplog):
+    df1 = pl.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = pl.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = PolarsCompare(df1, df2, join_columns=["a"])
+    with caplog.at_level(logging.WARNING):
+        compare.hide_sensitive_columns(["c"])
+        assert (
+            "sensitive columns not found in both df1 and df2 will be ignored: ['c']"
+            in caplog.text
+        )
+
+    assert compare.df1[0, "b"] == 2
+    assert compare.df1[1, "b"] == 0
+    assert len(compare.df1_unq_rows) == 1
+    assert compare.df1_unq_rows[0, "a"] == 1
+    assert compare.df1_unq_rows[0, "b"] == 0
+    assert len(compare.df2_unq_rows) == 1
+    assert compare.df2_unq_rows[0, "a"] == 2
+    assert compare.df2_unq_rows[0, "b"] == 0
+    assert len(compare.intersect_rows) == 1
+    assert compare.intersect_rows[0, "a"] == 1
+    assert compare.intersect_rows[0, "b_df1"] == 2
+    assert compare.intersect_rows[0, "b_df2"] == 2
+    assert compare.intersect_rows[0, "b_match"]
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_hide_empty():
+    df1 = pl.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = pl.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = PolarsCompare(df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns([])
+
+    assert compare.df1[0, "b"] == 2
+    assert compare.df1[1, "b"] == 0
+    assert len(compare.df1_unq_rows) == 1
+    assert compare.df1_unq_rows[0, "a"] == 1
+    assert compare.df1_unq_rows[0, "b"] == 0
+    assert len(compare.df2_unq_rows) == 1
+    assert compare.df2_unq_rows[0, "a"] == 2
+    assert compare.df2_unq_rows[0, "b"] == 0
+    assert len(compare.intersect_rows) == 1
+    assert compare.intersect_rows[0, "a"] == 1
+    assert compare.intersect_rows[0, "b_df1"] == 2
+    assert compare.intersect_rows[0, "b_df2"] == 2
+    assert compare.intersect_rows[0, "b_match"]
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_hide_reveal_empty():
+    df1 = pl.DataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = pl.DataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = PolarsCompare(df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns([])
+    compare.reveal_sensitive_columns()
+
+    assert compare.df1[0, "b"] == 2
+    assert compare.df1[1, "b"] == 0
+    assert len(compare.df1_unq_rows) == 1
+    assert compare.df1_unq_rows[0, "a"] == 1
+    assert compare.df1_unq_rows[0, "b"] == 0
+    assert len(compare.df2_unq_rows) == 1
+    assert compare.df2_unq_rows[0, "a"] == 2
+    assert compare.df2_unq_rows[0, "b"] == 0
+    assert len(compare.intersect_rows) == 1
+    assert compare.intersect_rows[0, "a"] == 1
+    assert compare.intersect_rows[0, "b_df1"] == 2
+    assert compare.intersect_rows[0, "b_df2"] == 2
+    assert compare.intersect_rows[0, "b_match"]
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_setter():
+    df1 = pl.DataFrame([{"a": 1, "b": 2}])
+    df2 = pl.DataFrame([{"a": 1, "b": 2}])
+    compare = PolarsCompare(df1, df2, join_columns=["a"])
+
+    # Valid setter call
+    compare._set_sensitive_columns(["b"])
+    assert compare.sensitive_columns == ["b"]
+
+    # Invalid setter call - not a list of strings
+    with pytest.raises(TypeError, match="sensitive_columns must be a list of strings"):
+        compare._set_sensitive_columns([1, 2, 3])
+
+
+def test_sensitive_columns_duplicates():
+    df1 = pl.DataFrame([{"a": 1, "b": 2}])
+    df2 = pl.DataFrame([{"a": 1, "b": 2}])
+
+    compare = PolarsCompare(df1, df2, join_columns=["a"])
+    # Duplicate columns should raise ValueError during hide_sensitive_columns()
+    with pytest.raises(ValueError, match=r"duplicate columns: {'b'}"):
+        compare.hide_sensitive_columns(["b", "b"])
+
+
+def test_sensitive_columns_numeric_types():
+    """Verify that hashing works for different numeric types without LossySetitemError."""
+    df1 = pl.DataFrame({"a": [1, 2], "b": [10, 20], "c": [1.1, 2.2]})
+    df2 = pl.DataFrame({"a": [1, 2], "b": [10, 20], "c": [1.1, 2.2]})
+
+    compare = PolarsCompare(df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["b", "c"])
+
+    assert not isinstance(compare.df1[0, "b"], str)
+    assert not isinstance(compare.df1[0, "c"], str)
+    assert len(compare.df1_unq_rows) == 0
+    assert compare.intersect_rows[0, "b_df1"] == "*******"
+    assert compare.intersect_rows[0, "b_df2"] == "*******"
+    assert compare.intersect_rows[0, "c_df1"] == "*******"
+    assert compare.intersect_rows[0, "c_df2"] == "*******"
+
+
+def test_sensitive_columns_numeric_types_with_tolerance():
+    """Verify that hashing works for different numeric types with tolerance."""
+    df1 = pl.DataFrame({"a": [1, 2], "b": [10, 20], "c": [1.1, 2.1]})
+    df2 = pl.DataFrame({"a": [1, 3], "b": [10, 21], "c": [1.2, 2.1]})
+
+    compare = PolarsCompare(df1, df2, join_columns=["a"], abs_tol=0.1)
+    compare.hide_sensitive_columns(["b", "c"])
+
+    assert not isinstance(compare.df1[0, "b"], str)
+    assert not isinstance(compare.df1[0, "c"], str)
+    assert len(compare.df1_unq_rows) == 1
+    assert compare.df1_unq_rows[0, "b"] == "*******"
+    assert compare.df1_unq_rows[0, "c"] == "*******"
+    assert len(compare.df2_unq_rows) == 1
+    assert compare.df2_unq_rows[0, "b"] == "*******"
+    assert compare.df2_unq_rows[0, "c"] == "*******"
+    assert len(compare.intersect_rows) == 1
+    assert compare.intersect_rows[0, "b_df1"] == "*******"
+    assert compare.intersect_rows[0, "b_df2"] == "*******"
+    assert compare.intersect_rows[0, "b_match"]
+    assert compare.intersect_rows[0, "c_df1"] == "*******"
+    assert compare.intersect_rows[0, "c_df2"] == "*******"
+    assert compare.intersect_rows[0, "c_match"]

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -2506,7 +2506,7 @@ def test_sensitive_columns_unused(caplog):
     with caplog.at_level(logging.WARNING):
         compare.hide_sensitive_columns(["c"])
         assert (
-            "sensitive columns not found in both df1 and df2 will be ignored: ['c']"
+            "sensitive columns not found in either df1 or df2 will be ignored: ['c']"
             in caplog.text
         )
 

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -2616,7 +2616,7 @@ def test_sensitive_columns_numeric_types():
 
 
 def test_sensitive_columns_numeric_types_with_tolerance():
-    """Verify that hashing works for different numeric types with tolerance."""
+    """Verify that hiding works for different numeric types with tolerance."""
     df1 = pl.DataFrame({"a": [1, 2], "b": [10, 20], "c": [1.1, 2.1]})
     df2 = pl.DataFrame({"a": [1, 3], "b": [10, 21], "c": [1.2, 2.1]})
 

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -2580,12 +2580,12 @@ def test_sensitive_columns_setter():
     compare = PolarsCompare(df1, df2, join_columns=["a"])
 
     # Valid setter call
-    compare._set_sensitive_columns(["b"])
+    compare._set_and_validate_sensitive_columns(["b"])
     assert compare.sensitive_columns == ["b"]
 
     # Invalid setter call - not a list of strings
     with pytest.raises(TypeError, match="sensitive_columns must be a list of strings"):
-        compare._set_sensitive_columns([1, 2, 3])
+        compare._set_and_validate_sensitive_columns([1, 2, 3])
 
 
 def test_sensitive_columns_duplicates():

--- a/tests/test_snowflake.py
+++ b/tests/test_snowflake.py
@@ -2174,3 +2174,11 @@ def test_columns_with_mismatches_multiple_join_columns(snowflake_session):
     assert "ID1" not in result
     assert "ID2" not in result
     assert sorted(result) == ["VALUE1", "VALUE2"]
+
+
+def test_sensitive_columns_placeholder(snowflake_session):
+    """Check compare won't crash trying to access _sensitive_columns (to be removed later)."""
+    df1 = snowflake_session.createDataFrame([{"a": 1, "b": 2}])
+    df2 = snowflake_session.createDataFrame([{"a": 1, "b": 2}])
+    compare = SnowflakeCompare(snowflake_session, df1, df2, join_columns=["a"])
+    _ = compare._sensitive_columns  # this shouldn't crash

--- a/tests/test_snowflake.py
+++ b/tests/test_snowflake.py
@@ -2181,4 +2181,4 @@ def test_sensitive_columns_placeholder(snowflake_session):
     df1 = snowflake_session.createDataFrame([{"a": 1, "b": 2}])
     df2 = snowflake_session.createDataFrame([{"a": 1, "b": 2}])
     compare = SnowflakeCompare(snowflake_session, df1, df2, join_columns=["a"])
-    _ = compare._sensitive_columns  # this shouldn't crash
+    _ = compare.sensitive_columns  # this shouldn't crash

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -2435,7 +2435,7 @@ def test_columns_with_mismatches_multiple_join_columns(spark_session):
     assert sorted(result) == ["value1", "value2"]
 
 
-def test_forbid_case_sensitvive_columns(spark_session):
+def test_forbid_case_sensitive_columns(spark_session):
     """Test error case for case sensitive columns in dataframes."""
     df1 = spark_session.createDataFrame(
         [{"a": 1, "b": 2, "B": 1}, {"a": 3, "b": 1, "B": 0}]

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -2466,4 +2466,4 @@ def test_sensitive_columns_placeholder(spark_session):
     df1 = spark_session.createDataFrame([{"a": 1, "b": 2}])
     df2 = spark_session.createDataFrame([{"a": 1, "b": 2}])
     compare = SparkSQLCompare(spark_session, df1, df2, join_columns=["a"])
-    _ = compare._sensitive_columns  # this shouldn't crash
+    _ = compare.sensitive_columns  # this shouldn't crash

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -2459,3 +2459,11 @@ def test_forbid_case_sensitive_columns(spark_session):
             join_columns=["a"],
             cast_column_names_lower=False,
         )
+
+
+def test_sensitive_columns_placeholder(spark_session):
+    """Check compare won't crash trying to access _sensitive_columns (to be removed later)."""
+    df1 = spark_session.createDataFrame([{"a": 1, "b": 2}])
+    df2 = spark_session.createDataFrame([{"a": 1, "b": 2}])
+    compare = SparkSQLCompare(spark_session, df1, df2, join_columns=["a"])
+    _ = compare._sensitive_columns  # this shouldn't crash


### PR DESCRIPTION
Implements `sensitive_columns` in a similar fashion to https://github.com/capitalone/datacompy/pull/494 but done in polars instead.

- Slight difference in `intersect_rows`. In pandas, the merge does not suffix the dataframe name for columns that are only in one of the dataframes, while the way merging is implemented in PolarsCompare always adds the suffix. 
- Refactor: moved `_set_and_validate_sensitive_columns`, the `sensitive_columns` property, and `reveal_sensitive_columns` into `BaseCompare` since the implementations are identical and should remain so for the other compares.
