### PR TITLE
chore: v1 bump snowflake-snowpark-python minimum to 1.37

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ optional-dependencies.dev = [
 optional-dependencies.docs = [ "furo", "myst-parser", "sphinx" ]
 optional-dependencies.edgetest = [ "edgetest", "edgetest-conda" ]
 optional-dependencies.qa = [ "mypy", "pandas-stubs", "pre-commit", "ruff" ]
-optional-dependencies.snowflake = [ "snowflake-snowpark-python>=1.26,<=1.47" ]
+optional-dependencies.snowflake = [ "snowflake-snowpark-python>=1.37,<=1.47" ]
 optional-dependencies.spark = [
   "pyspark[connect]>=3.5,!=4,<=4.1.1; python_version<='3.11'",
   "pyspark[connect]>=4; python_version>='3.12'",


### PR DESCRIPTION
Should fix https://github.com/capitalone/datacompy/issues/503 for the develop branch.
- bumps optional `snowflake-snowpark-python`  to `1.37` minimum which is the version that deprecates `pkg_resources`.