### PR TITLE
feat: hide sensitive columns in SparkSQLCompare

### DIFF
--- a/datacompy/base.py
+++ b/datacompy/base.py
@@ -23,8 +23,9 @@ two dataframes.
 
 import logging
 from abc import ABC, abstractmethod
+from collections import Counter
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from ordered_set import OrderedSet
@@ -56,6 +57,46 @@ class BaseCompare(ABC):
     def df2(self, df2: Any) -> None:
         """Check that it is a dataframe and has the join columns."""
         pass
+
+    @property
+    def sensitive_columns(self) -> List[str] | None:
+        """Get the list of sensitive columns."""
+        return self._sensitive_columns
+
+    def _set_and_validate_sensitive_columns(
+        self, sensitive_columns: List[str] | None
+    ) -> None:
+        """Set and validate sensitive columns.
+
+        Normalizes empty lists to None so there is only one representation
+        for "no sensitive columns".
+        """
+        self._sensitive_columns = sensitive_columns or None
+        if not self._sensitive_columns:
+            return
+
+        if not all(isinstance(c, str) for c in self.sensitive_columns):
+            raise TypeError("sensitive_columns must be a list of strings")
+
+        # Cast to lowercase if applicable
+        if self.cast_column_names_lower:
+            self._sensitive_columns = [col.lower() for col in self.sensitive_columns]
+
+        # Check duplicates
+        duplicates = {c for c, n in Counter(self.sensitive_columns).items() if n > 1}
+        if duplicates:
+            raise ValueError(f"duplicate columns: {duplicates}")
+
+        # Warn if column not found in either dataframe
+        unused = [
+            col
+            for col in self.sensitive_columns
+            if (col not in self.df1.columns) and (col not in self.df2.columns)
+        ]
+        if unused:
+            LOG.warning(
+                f"sensitive columns not found in either df1 or df2 will be ignored: {unused}"
+            )
 
     @abstractmethod
     def _validate_dataframe(
@@ -181,6 +222,24 @@ class BaseCompare(ABC):
             The report, formatted according to the template.
         """
         pass
+
+    def reveal_sensitive_columns(self) -> None:
+        """Reveals all sensitive columns.
+
+        Notes
+        -----
+        - This re-runs the full comparison to restore original values.
+        - Revealing sensitive columns when there aren't any is treated as a NOP
+          to avoid redundant computations.
+        """
+        # Don't do anything if there aren't any sensitive columns
+        if not self.sensitive_columns:
+            return
+
+        LOG.debug("Revealing sensitive columns and re-comparing dfs")
+        self._set_and_validate_sensitive_columns(None)
+        self.column_stats.clear()
+        self._compare(ignore_spaces=self.ignore_spaces, ignore_case=self.ignore_case)
 
     def only_join_columns(self) -> bool:
         """Boolean on if the only columns are the join columns."""

--- a/datacompy/base.py
+++ b/datacompy/base.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 """
-Compare two Pandas DataFrames.
+Base module for comparing two DataFrames.
 
 Originally this package was meant to provide similar functionality to
 PROC COMPARE in SAS - i.e. human-readable reporting on the difference between

--- a/datacompy/spark.py
+++ b/datacompy/spark.py
@@ -447,14 +447,6 @@ class SparkSQLCompare(BaseCompare):
             {c: f"{c}_{self.df2_name}" for c in temp_join_columns}
         )
 
-        # cache only if enabled
-        if self.cache_intermediates:
-            LOG.debug("Caching intermediate dataframes")
-            df1.cache()
-            df2.cache()
-        else:
-            LOG.debug("Caching disabled - skipping cache() calls")
-
         # NULL SAFE Outer join using ON
         df1.createOrReplaceTempView("df1")
         df2.createOrReplaceTempView("df2")

--- a/datacompy/spark.py
+++ b/datacompy/spark.py
@@ -265,6 +265,9 @@ class SparkSQLCompare(BaseCompare):
             F.lit("*******").alias(col) if col in cols_to_hide else F.col(col)
             for col in self.intersect_rows.columns
         ]
+        # avoid orphaned cached data (incl. unmasked sensitive vals) in executor memory
+        if self.cache_intermediates:
+            self.intersect_rows.unpersist()
         self.intersect_rows = self.intersect_rows.select(select_cols)
 
     def _validate_dataframe(

--- a/datacompy/spark.py
+++ b/datacompy/spark.py
@@ -248,12 +248,10 @@ class SparkSQLCompare(BaseCompare):
             if not cols_to_hide:  # skip if empty
                 continue
             # Maintains column ordering for the hide
-            select_cols = []
-            for col in df.columns:
-                if col in cols_to_hide:
-                    select_cols.append(F.lit("*******").alias(col))
-                else:
-                    select_cols.append(F.col(col))
+            select_cols = [
+                F.lit("*******").alias(col) if col in cols_to_hide else F.col(col)
+                for col in df.columns
+            ]
             setattr(self, df_name, df.select(select_cols))
 
         # Hide columns in intersect_rows
@@ -263,12 +261,10 @@ class SparkSQLCompare(BaseCompare):
         ]
         if not cols_to_hide:  # skip if empty
             return
-        select_cols = []
-        for col in self.intersect_rows.columns:
-            if col in cols_to_hide:
-                select_cols.append(F.lit("*******").alias(col))
-            else:
-                select_cols.append(F.col(col))
+        select_cols = [
+            F.lit("*******").alias(col) if col in cols_to_hide else F.col(col)
+            for col in self.intersect_rows.columns
+        ]
         self.intersect_rows = self.intersect_rows.select(select_cols)
 
     def _validate_dataframe(

--- a/datacompy/spark.py
+++ b/datacompy/spark.py
@@ -148,6 +148,7 @@ class SparkSQLCompare(BaseCompare):
         self.cast_column_names_lower = cast_column_names_lower
         self.custom_comparators = custom_comparators or []
         self.cache_intermediates = cache_intermediates
+        self._set_and_validate_sensitive_columns(None)
 
         # Validate tolerance parameters first
         self._abs_tol_dict = validate_tolerance_parameter(
@@ -219,6 +220,56 @@ class SparkSQLCompare(BaseCompare):
         self._validate_dataframe(
             "df2", cast_column_names_lower=self.cast_column_names_lower
         )
+
+    def hide_sensitive_columns(self, sensitive_columns: List[str]) -> None:
+        """Hides sensitive columns of df1 or df2 if applicable in the compare."""
+        # Don't allow hiding columns again before first revealing
+        if self.sensitive_columns:
+            raise ValueError(
+                "sensitive columns are already hidden, call reveal_sensitive_columns() first"
+            )
+
+        self._set_and_validate_sensitive_columns(sensitive_columns)
+        # Don't do anything if [] is passed (normalized to None)
+        if not self.sensitive_columns:
+            return
+        sensitive = set(self.sensitive_columns)  # Otherwise this fails due to None
+        sensitive_with_suffixes = (
+            sensitive
+            | {f"{c}_{self.df1_name}" for c in sensitive}
+            | {f"{c}_{self.df2_name}" for c in sensitive}
+        )
+
+        # Hide columns in unq_rows
+        for df_name in ("df1_unq_rows", "df2_unq_rows"):
+            df = getattr(self, df_name)
+            LOG.debug(f"Hiding sensitive columns in {df_name}")
+            cols_to_hide = [col for col in df.columns if col in sensitive_with_suffixes]
+            if not cols_to_hide:  # skip if empty
+                continue
+            # Maintains column ordering for the hide
+            select_cols = []
+            for col in df.columns:
+                if col in cols_to_hide:
+                    select_cols.append(F.lit("*******").alias(col))
+                else:
+                    select_cols.append(F.col(col))
+            setattr(self, df_name, df.select(select_cols))
+
+        # Hide columns in intersect_rows
+        LOG.debug("Hiding sensitive columns in intersect_rows")
+        cols_to_hide = [
+            col for col in self.intersect_rows.columns if col in sensitive_with_suffixes
+        ]
+        if not cols_to_hide:  # skip if empty
+            return
+        select_cols = []
+        for col in self.intersect_rows.columns:
+            if col in cols_to_hide:
+                select_cols.append(F.lit("*******").alias(col))
+            else:
+                select_cols.append(F.col(col))
+        self.intersect_rows = self.intersect_rows.select(select_cols)
 
     def _validate_dataframe(
         self, index: str, cast_column_names_lower: bool = True

--- a/datacompy/spark.py
+++ b/datacompy/spark.py
@@ -148,7 +148,7 @@ class SparkSQLCompare(BaseCompare):
         self.cast_column_names_lower = cast_column_names_lower
         self.custom_comparators = custom_comparators or []
         self.cache_intermediates = cache_intermediates
-        self._set_and_validate_sensitive_columns(None)
+        self._sensitive_columns: List[str] | None = None
 
         # Validate tolerance parameters first
         self._abs_tol_dict = validate_tolerance_parameter(

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -2287,7 +2287,6 @@ def test_cache_intermediates_enabled(spark_session, caplog):
 
     # Verify the log message
     assert compare.cache_intermediates is True
-    assert "Caching intermediate dataframes" in caplog.text
     assert "Caching intersect_rows dataframe" in caplog.text
 
 
@@ -2306,7 +2305,6 @@ def test_cache_intermediates_disabled(spark_session, caplog):
 
     # Verify the log message
     assert compare.cache_intermediates is False
-    assert "Caching disabled - skipping cache() calls" in caplog.text
     assert "Caching disabled - skipping cache() on intersect_rows" in caplog.text
 
 
@@ -2323,7 +2321,6 @@ def test_cache_intermediates_default_is_true(spark_session, caplog):
 
     # Verify the log message
     assert compare.cache_intermediates is True
-    assert "Caching intermediate dataframes" in caplog.text
     assert "Caching intersect_rows dataframe" in caplog.text
 
 

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -19,6 +19,7 @@ Testing out the datacompy functionality
 
 import logging
 import os
+import re
 import tempfile
 from datetime import datetime
 from decimal import Decimal
@@ -2433,3 +2434,428 @@ def test_columns_with_mismatches_multiple_join_columns(spark_session):
     assert "id1" not in result
     assert "id2" not in result
     assert sorted(result) == ["value1", "value2"]
+
+
+def test_sensitive_columns_hide(spark_session):
+    df1 = spark_session.createDataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = spark_session.createDataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = SparkSQLCompare(spark_session, df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["b"])
+
+    df1_unq_rows = compare.df1_unq_rows.toPandas().reset_index(drop=True)
+    df2_unq_rows = compare.df2_unq_rows.toPandas().reset_index(drop=True)
+    intersect_rows = compare.intersect_rows.toPandas().reset_index(drop=True)
+
+    assert compare.df1.toPandas().loc[0, "b"] == 2
+    assert compare.df1.toPandas().loc[1, "b"] == 0
+    assert len(df1_unq_rows) == 1
+    assert df1_unq_rows.loc[0, "a_df1"] == 1
+    assert df1_unq_rows.loc[0, "b_df1"] == "*******"
+    assert len(df2_unq_rows) == 1
+    assert df2_unq_rows.loc[0, "a_df2"] == 2
+    assert df2_unq_rows.loc[0, "b_df2"] == "*******"
+    assert len(intersect_rows) == 1
+    assert intersect_rows.loc[0, "a_df1"] == 1
+    assert intersect_rows.loc[0, "b_df1"] == "*******"
+    assert intersect_rows.loc[0, "b_df2"] == "*******"
+    assert intersect_rows.loc[0, "b_match"]
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_hide_hide(spark_session):
+    df1 = spark_session.createDataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = spark_session.createDataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = SparkSQLCompare(spark_session, df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["b"])
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "sensitive columns are already hidden, call reveal_sensitive_columns() first"
+        ),
+    ):
+        compare.hide_sensitive_columns(["c"])
+
+
+def test_sensitive_columns_hide_reveal(spark_session):
+    df1 = spark_session.createDataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = spark_session.createDataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = SparkSQLCompare(spark_session, df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["b"])
+    compare.reveal_sensitive_columns()
+
+    df1_unq_rows = compare.df1_unq_rows.toPandas().reset_index(drop=True)
+    df2_unq_rows = compare.df2_unq_rows.toPandas().reset_index(drop=True)
+    intersect_rows = compare.intersect_rows.toPandas().reset_index(drop=True)
+
+    assert compare.df1.toPandas().loc[0, "b"] == 2
+    assert compare.df1.toPandas().loc[1, "b"] == 0
+    assert len(df1_unq_rows) == 1
+    assert df1_unq_rows.loc[0, "a_df1"] == 1
+    assert df1_unq_rows.loc[0, "b_df1"] == 0
+    assert len(df2_unq_rows) == 1
+    assert df2_unq_rows.loc[0, "a_df2"] == 2
+    assert df2_unq_rows.loc[0, "b_df2"] == 0
+    assert len(intersect_rows) == 1
+    assert intersect_rows.loc[0, "a_df1"] == 1
+    assert intersect_rows.loc[0, "b_df1"] == 2
+    assert intersect_rows.loc[0, "b_df2"] == 2
+    assert intersect_rows.loc[0, "b_match"]
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_hide_reveal_hide(spark_session):
+    df1 = spark_session.createDataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = spark_session.createDataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = SparkSQLCompare(spark_session, df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["b"])
+    compare.reveal_sensitive_columns()
+    compare.hide_sensitive_columns(["b"])
+
+    df1_unq_rows = compare.df1_unq_rows.toPandas().reset_index(drop=True)
+    df2_unq_rows = compare.df2_unq_rows.toPandas().reset_index(drop=True)
+    intersect_rows = compare.intersect_rows.toPandas().reset_index(drop=True)
+
+    assert compare.df1.toPandas().loc[0, "b"] == 2
+    assert compare.df1.toPandas().loc[1, "b"] == 0
+    assert len(df1_unq_rows) == 1
+    assert df1_unq_rows.loc[0, "a_df1"] == 1
+    assert df1_unq_rows.loc[0, "b_df1"] == "*******"
+    assert len(df2_unq_rows) == 1
+    assert df2_unq_rows.loc[0, "a_df2"] == 2
+    assert df2_unq_rows.loc[0, "b_df2"] == "*******"
+    assert len(intersect_rows) == 1
+    assert intersect_rows.loc[0, "a_df1"] == 1
+    assert intersect_rows.loc[0, "b_df1"] == "*******"
+    assert intersect_rows.loc[0, "b_df2"] == "*******"
+    assert intersect_rows.loc[0, "b_match"]
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_cast_lower(spark_session):
+    df1 = spark_session.createDataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = spark_session.createDataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = SparkSQLCompare(spark_session, df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["B"])
+
+    df1_unq_rows = compare.df1_unq_rows.toPandas().reset_index(drop=True)
+    df2_unq_rows = compare.df2_unq_rows.toPandas().reset_index(drop=True)
+    intersect_rows = compare.intersect_rows.toPandas().reset_index(drop=True)
+
+    assert compare.df1.toPandas().loc[0, "b"] == 2
+    assert compare.df1.toPandas().loc[1, "b"] == 0
+    assert len(df1_unq_rows) == 1
+    assert df1_unq_rows.loc[0, "a_df1"] == 1
+    assert df1_unq_rows.loc[0, "b_df1"] == "*******"
+    assert len(df2_unq_rows) == 1
+    assert df2_unq_rows.loc[0, "a_df2"] == 2
+    assert df2_unq_rows.loc[0, "b_df2"] == "*******"
+    assert len(intersect_rows) == 1
+    assert intersect_rows.loc[0, "a_df1"] == 1
+    assert intersect_rows.loc[0, "b_df1"] == "*******"
+    assert intersect_rows.loc[0, "b_df2"] == "*******"
+    assert intersect_rows.loc[0, "b_match"]
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_no_cast_lower(spark_session):
+    df1 = spark_session.createDataFrame(
+        [{"a": 1, "b": 2, "B": 1}, {"a": 3, "b": 1, "B": 0}]
+    )
+    df2 = spark_session.createDataFrame(
+        [{"a": 1, "b": 2, "B": 2}, {"a": 2, "b": 0, "B": 0}]
+    )
+    compare = SparkSQLCompare(
+        spark_session,
+        df1,
+        df2,
+        join_columns=["a"],
+        cast_column_names_lower=False,
+    )
+    compare.hide_sensitive_columns(["B"])
+
+    df1_unq_rows = compare.df1_unq_rows.toPandas().reset_index(drop=True)
+    df2_unq_rows = compare.df2_unq_rows.toPandas().reset_index(drop=True)
+    intersect_rows = compare.intersect_rows.toPandas().reset_index(drop=True)
+
+    assert compare.df1.toPandas().loc[0, "b"] == 2
+    assert compare.df1.toPandas().loc[1, "b"] == 1
+    assert compare.df1.toPandas().loc[0, "B"] == 1
+    assert compare.df1.toPandas().loc[1, "B"] == 0
+    assert len(df1_unq_rows) == 1
+    assert df1_unq_rows.loc[0, "a_df1"] == 3
+    assert df1_unq_rows.loc[0, "B_df1"] == "*******"
+    assert len(df2_unq_rows) == 1
+    assert df2_unq_rows.loc[0, "a_df2"] == 2
+    assert df2_unq_rows.loc[0, "B_df2"] == "*******"
+    assert len(intersect_rows) == 1
+    assert intersect_rows.loc[0, "a_df1"] == 1
+    assert intersect_rows.loc[0, "b_df1"] == 2
+    assert intersect_rows.loc[0, "b_df2"] == 2
+    assert intersect_rows.loc[0, "B_df1"] == "*******"
+    assert intersect_rows.loc[0, "B_df2"] == "*******"
+    assert not intersect_rows.loc[0, "B_match"]
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_hide_join_columns(spark_session):
+    df1 = spark_session.createDataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = spark_session.createDataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = SparkSQLCompare(spark_session, df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["a"])
+
+    df1_unq_rows = compare.df1_unq_rows.toPandas().reset_index(drop=True)
+    sample_mismatch = compare.sample_mismatch("a").toPandas().reset_index(drop=True)
+
+    assert compare.df1.toPandas().loc[0, "a"] == 1
+    assert compare.df1.toPandas().loc[1, "a"] == 1
+    assert len(df1_unq_rows) == 1
+    assert df1_unq_rows.loc[0, "a_df1"] == "*******"
+    assert len(sample_mismatch) == 2
+    assert sample_mismatch.loc[0, "a"] == "*******"
+    assert sample_mismatch.loc[1, "a"] == "*******"
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_hide_reveal_join_columns(spark_session):
+    df1 = spark_session.createDataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = spark_session.createDataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = SparkSQLCompare(spark_session, df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["a"])
+    compare.reveal_sensitive_columns()
+
+    df1_unq_rows = compare.df1_unq_rows.toPandas().reset_index(drop=True)
+    sample_mismatch = compare.sample_mismatch("a").toPandas().reset_index(drop=True)
+
+    assert compare.df1.toPandas().loc[0, "a"] == 1
+    assert compare.df1.toPandas().loc[1, "a"] == 1
+    assert len(df1_unq_rows) == 1
+    assert df1_unq_rows.loc[0, "a_df1"] == 1
+    assert len(sample_mismatch) == 2
+    assert sample_mismatch.sort_values("a").reset_index(drop=True).loc[0, "a"] == 1
+    assert sample_mismatch.sort_values("a").reset_index(drop=True).loc[1, "a"] == 2
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_missing(spark_session):
+    df1 = spark_session.createDataFrame(
+        [{"a": 1, "b": "bruh", "c": 3}, {"a": 3, "b": "67", "c": 6}]
+    )
+    df2 = spark_session.createDataFrame(
+        [{"a": 1, "b": "hello", "d": 4}, {"a": 2, "b": "yo", "d": 7}]
+    )
+    compare = SparkSQLCompare(spark_session, df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["b", "c"])
+
+    df1_unq_rows = compare.df1_unq_rows.toPandas().reset_index(drop=True)
+    df2_unq_rows = compare.df2_unq_rows.toPandas().reset_index(drop=True)
+    intersect_rows = compare.intersect_rows.toPandas().reset_index(drop=True)
+
+    assert compare.df1.toPandas().loc[0, "b"] == "bruh"
+    assert compare.df1.toPandas().loc[1, "b"] == "67"
+    assert compare.df1.toPandas().loc[0, "c"] == 3
+    assert compare.df1.toPandas().loc[1, "c"] == 6
+    assert compare.df2.toPandas().loc[0, "d"] == 4
+    assert compare.df2.toPandas().loc[1, "d"] == 7
+    assert len(df1_unq_rows) == 1
+    assert df1_unq_rows.loc[0, "a_df1"] == 3
+    assert df1_unq_rows.loc[0, "b_df1"] == "*******"
+    assert df1_unq_rows.loc[0, "c_df1"] == "*******"
+    assert len(df2_unq_rows) == 1
+    assert df2_unq_rows.loc[0, "a_df2"] == 2
+    assert df2_unq_rows.loc[0, "b_df2"] == "*******"
+    assert df2_unq_rows.loc[0, "d_df2"] == 7
+    assert len(intersect_rows) == 1
+    assert intersect_rows.loc[0, "b_df1"] == "*******"
+    assert intersect_rows.loc[0, "b_df2"] == "*******"
+    assert intersect_rows.loc[0, "c_df1"] == "*******"
+    assert not intersect_rows.loc[0, "b_match"]
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_unused(spark_session, caplog):
+    df1 = spark_session.createDataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = spark_session.createDataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = SparkSQLCompare(spark_session, df1, df2, join_columns=["a"])
+    with caplog.at_level(logging.WARNING):
+        compare.hide_sensitive_columns(["c"])
+        assert (
+            "sensitive columns not found in either df1 or df2 will be ignored: ['c']"
+            in caplog.text
+        )
+
+    df1_unq_rows = compare.df1_unq_rows.toPandas().reset_index(drop=True)
+    df2_unq_rows = compare.df2_unq_rows.toPandas().reset_index(drop=True)
+    intersect_rows = compare.intersect_rows.toPandas().reset_index(drop=True)
+
+    assert compare.df1.toPandas().loc[0, "b"] == 2
+    assert compare.df1.toPandas().loc[1, "b"] == 0
+    assert len(df1_unq_rows) == 1
+    assert df1_unq_rows.loc[0, "a_df1"] == 1
+    assert df1_unq_rows.loc[0, "b_df1"] == 0
+    assert len(df2_unq_rows) == 1
+    assert df2_unq_rows.loc[0, "a_df2"] == 2
+    assert df2_unq_rows.loc[0, "b_df2"] == 0
+    assert len(intersect_rows) == 1
+    assert intersect_rows.loc[0, "a_df1"] == 1
+    assert intersect_rows.loc[0, "b_df1"] == 2
+    assert intersect_rows.loc[0, "b_df2"] == 2
+    assert intersect_rows.loc[0, "b_match"]
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_hide_reveal_empty(spark_session):
+    df1 = spark_session.createDataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = spark_session.createDataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = SparkSQLCompare(spark_session, df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns([])
+    compare.reveal_sensitive_columns()
+
+    df1_unq_rows = compare.df1_unq_rows.toPandas().reset_index(drop=True)
+    df2_unq_rows = compare.df2_unq_rows.toPandas().reset_index(drop=True)
+    intersect_rows = compare.intersect_rows.toPandas().reset_index(drop=True)
+
+    assert compare.df1.toPandas().loc[0, "b"] == 2
+    assert compare.df1.toPandas().loc[1, "b"] == 0
+    assert len(df1_unq_rows) == 1
+    assert df1_unq_rows.loc[0, "a_df1"] == 1
+    assert df1_unq_rows.loc[0, "b_df1"] == 0
+    assert len(df2_unq_rows) == 1
+    assert df2_unq_rows.loc[0, "a_df2"] == 2
+    assert df2_unq_rows.loc[0, "b_df2"] == 0
+    assert len(intersect_rows) == 1
+    assert intersect_rows.loc[0, "a_df1"] == 1
+    assert intersect_rows.loc[0, "b_df1"] == 2
+    assert intersect_rows.loc[0, "b_df2"] == 2
+    assert intersect_rows.loc[0, "b_match"]
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_hide_empty(spark_session):
+    df1 = spark_session.createDataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = spark_session.createDataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = SparkSQLCompare(spark_session, df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns([])
+
+    df1_unq_rows = compare.df1_unq_rows.toPandas().reset_index(drop=True)
+    df2_unq_rows = compare.df2_unq_rows.toPandas().reset_index(drop=True)
+    intersect_rows = compare.intersect_rows.toPandas().reset_index(drop=True)
+
+    assert compare.df1.toPandas().loc[0, "b"] == 2
+    assert compare.df1.toPandas().loc[1, "b"] == 0
+    assert len(df1_unq_rows) == 1
+    assert df1_unq_rows.loc[0, "a_df1"] == 1
+    assert df1_unq_rows.loc[0, "b_df1"] == 0
+    assert len(df2_unq_rows) == 1
+    assert df2_unq_rows.loc[0, "a_df2"] == 2
+    assert df2_unq_rows.loc[0, "b_df2"] == 0
+    assert len(intersect_rows) == 1
+    assert intersect_rows.loc[0, "a_df1"] == 1
+    assert intersect_rows.loc[0, "b_df1"] == 2
+    assert intersect_rows.loc[0, "b_df2"] == 2
+    assert intersect_rows.loc[0, "b_match"]
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_setter(spark_session):
+    df1 = spark_session.createDataFrame([{"a": 1, "b": 2}])
+    df2 = spark_session.createDataFrame([{"a": 1, "b": 2}])
+    compare = SparkSQLCompare(spark_session, df1, df2, join_columns=["a"])
+
+    # Valid setter call
+    compare._set_and_validate_sensitive_columns(["b"])
+    assert compare.sensitive_columns == ["b"]
+
+    # Invalid setter call - not a list of strings
+    with pytest.raises(TypeError, match="sensitive_columns must be a list of strings"):
+        compare._set_and_validate_sensitive_columns([1, 2, 3])
+
+
+def test_sensitive_columns_duplicates(spark_session):
+    df1 = spark_session.createDataFrame([{"a": 1, "b": 2}])
+    df2 = spark_session.createDataFrame([{"a": 1, "b": 2}])
+
+    compare = SparkSQLCompare(spark_session, df1, df2, join_columns=["a"])
+    # Duplicate columns should raise ValueError during hide_sensitive_columns()
+    with pytest.raises(ValueError, match=r"duplicate columns: {'b'}"):
+        compare.hide_sensitive_columns(["b", "b"])
+
+
+def test_sensitive_columns_numeric_types(spark_session):
+    """Verify that hashing works for different numeric types without LossySetitemError."""
+    df1 = spark_session.createDataFrame(
+        [
+            {"a": 1, "b": 10, "c": 1.1},
+            {"a": 2, "b": 20, "c": 2.2},
+        ]
+    )
+    df2 = spark_session.createDataFrame(
+        [
+            {"a": 1, "b": 10, "c": 1.1},
+            {"a": 2, "b": 20, "c": 2.2},
+        ]
+    )
+
+    compare = SparkSQLCompare(spark_session, df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["b", "c"])
+
+    df1_unq_rows = compare.df1_unq_rows.toPandas().reset_index(drop=True)
+    intersect_rows = compare.intersect_rows.toPandas().reset_index(drop=True)
+
+    assert not isinstance(compare.df1.toPandas()["b"].loc[0], str)
+    assert not isinstance(compare.df1.toPandas()["c"].loc[0], str)
+    assert len(df1_unq_rows) == 0
+    assert intersect_rows.loc[0, "b_df1"] == "*******"
+    assert intersect_rows.loc[0, "b_df2"] == "*******"
+    assert intersect_rows.loc[0, "c_df1"] == "*******"
+    assert intersect_rows.loc[0, "c_df2"] == "*******"
+
+
+def test_sensitive_columns_numeric_types_with_tolerance(spark_session):
+    """Verify that hashing works for different numeric types with tolerance."""
+    df1 = spark_session.createDataFrame(
+        [
+            {"a": 1, "b": 10, "c": 1.1},
+            {"a": 2, "b": 20, "c": 2.1},
+        ]
+    )
+    df2 = spark_session.createDataFrame(
+        [
+            {"a": 1, "b": 10, "c": 1.2},
+            {"a": 3, "b": 21, "c": 2.1},
+        ]
+    )
+
+    compare = SparkSQLCompare(spark_session, df1, df2, join_columns=["a"], abs_tol=0.1)
+    compare.hide_sensitive_columns(["b", "c"])
+
+    df1_unq_rows = compare.df1_unq_rows.toPandas().reset_index(drop=True)
+    df2_unq_rows = compare.df2_unq_rows.toPandas().reset_index(drop=True)
+    intersect_rows = compare.intersect_rows.toPandas().reset_index(drop=True)
+
+    assert not isinstance(compare.df1.toPandas()["b"].loc[0], str)
+    assert not isinstance(compare.df1.toPandas()["c"].loc[0], str)
+    assert len(df1_unq_rows) == 1
+    assert df1_unq_rows.loc[0, "b_df1"] == "*******"
+    assert df1_unq_rows.loc[0, "c_df1"] == "*******"
+    assert len(df2_unq_rows) == 1
+    assert df2_unq_rows.loc[0, "b_df2"] == "*******"
+    assert df2_unq_rows.loc[0, "c_df2"] == "*******"
+    assert len(intersect_rows) == 1
+    assert intersect_rows.loc[0, "b_df1"] == "*******"
+    assert intersect_rows.loc[0, "b_df2"] == "*******"
+    assert intersect_rows.loc[0, "b_match"]
+    assert intersect_rows.loc[0, "c_df1"] == "*******"
+    assert intersect_rows.loc[0, "c_df2"] == "*******"
+    assert intersect_rows.loc[0, "c_match"]

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -2844,11 +2844,3 @@ def test_forbid_case_sensitive_columns(spark_session):
             join_columns=["a"],
             cast_column_names_lower=False,
         )
-
-
-def test_sensitive_columns_placeholder(spark_session):
-    """Check compare won't crash trying to access _sensitive_columns (to be removed later)."""
-    df1 = spark_session.createDataFrame([{"a": 1, "b": 2}])
-    df2 = spark_session.createDataFrame([{"a": 1, "b": 2}])
-    compare = SparkSQLCompare(spark_session, df1, df2, join_columns=["a"])
-    _ = compare.sensitive_columns  # this shouldn't crash

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -2752,7 +2752,7 @@ def test_sensitive_columns_duplicates(spark_session):
 
 
 def test_sensitive_columns_numeric_types(spark_session):
-    """Verify that hashing works for different numeric types without LossySetitemError."""
+    """Verify that hiding works for different numeric types without LossySetitemError."""
     df1 = spark_session.createDataFrame(
         [
             {"a": 1, "b": 10, "c": 1.1},
@@ -2782,7 +2782,7 @@ def test_sensitive_columns_numeric_types(spark_session):
 
 
 def test_sensitive_columns_numeric_types_with_tolerance(spark_session):
-    """Verify that hashing works for different numeric types with tolerance."""
+    """Verify that hiding works for different numeric types with tolerance."""
     df1 = spark_session.createDataFrame(
         [
             {"a": 1, "b": 10, "c": 1.1},

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -2562,47 +2562,6 @@ def test_sensitive_columns_cast_lower(spark_session):
     compare.report()
 
 
-def test_sensitive_columns_no_cast_lower(spark_session):
-    df1 = spark_session.createDataFrame(
-        [{"a": 1, "b": 2, "B": 1}, {"a": 3, "b": 1, "B": 0}]
-    )
-    df2 = spark_session.createDataFrame(
-        [{"a": 1, "b": 2, "B": 2}, {"a": 2, "b": 0, "B": 0}]
-    )
-    compare = SparkSQLCompare(
-        spark_session,
-        df1,
-        df2,
-        join_columns=["a"],
-        cast_column_names_lower=False,
-    )
-    compare.hide_sensitive_columns(["B"])
-
-    df1_unq_rows = compare.df1_unq_rows.toPandas().reset_index(drop=True)
-    df2_unq_rows = compare.df2_unq_rows.toPandas().reset_index(drop=True)
-    intersect_rows = compare.intersect_rows.toPandas().reset_index(drop=True)
-
-    assert compare.df1.toPandas().loc[0, "b"] == 2
-    assert compare.df1.toPandas().loc[1, "b"] == 1
-    assert compare.df1.toPandas().loc[0, "B"] == 1
-    assert compare.df1.toPandas().loc[1, "B"] == 0
-    assert len(df1_unq_rows) == 1
-    assert df1_unq_rows.loc[0, "a_df1"] == 3
-    assert df1_unq_rows.loc[0, "B_df1"] == "*******"
-    assert len(df2_unq_rows) == 1
-    assert df2_unq_rows.loc[0, "a_df2"] == 2
-    assert df2_unq_rows.loc[0, "B_df2"] == "*******"
-    assert len(intersect_rows) == 1
-    assert intersect_rows.loc[0, "a_df1"] == 1
-    assert intersect_rows.loc[0, "b_df1"] == 2
-    assert intersect_rows.loc[0, "b_df2"] == 2
-    assert intersect_rows.loc[0, "B_df1"] == "*******"
-    assert intersect_rows.loc[0, "B_df2"] == "*******"
-    assert not intersect_rows.loc[0, "B_match"]
-    # Just render the report to make sure it renders.
-    compare.report()
-
-
 def test_sensitive_columns_hide_join_columns(spark_session):
     df1 = spark_session.createDataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
     df2 = spark_session.createDataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])


### PR DESCRIPTION
Ported over sensitive column hiding to `SparkSQLCompare`.
- Moved some methods over into `BaseCompare` to be synced with `PolarsCompare` PR (possibly subject to change).
- Added unit tests. 
- aside: removed caching of `df1` and `df2`.