### PR TITLE
feat: hide sensitive columns in SnowflakeCompare

### DIFF
--- a/datacompy/base.py
+++ b/datacompy/base.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 """
-Compare two Pandas DataFrames.
+Base module for comparing two DataFrames.
 
 Originally this package was meant to provide similar functionality to
 PROC COMPARE in SAS - i.e. human-readable reporting on the difference between
@@ -23,8 +23,9 @@ two dataframes.
 
 import logging
 from abc import ABC, abstractmethod
+from collections import Counter
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from ordered_set import OrderedSet
@@ -56,6 +57,46 @@ class BaseCompare(ABC):
     def df2(self, df2: Any) -> None:
         """Check that it is a dataframe and has the join columns."""
         pass
+
+    @property
+    def sensitive_columns(self) -> List[str] | None:
+        """Get the list of sensitive columns."""
+        return self._sensitive_columns
+
+    def _set_and_validate_sensitive_columns(
+        self, sensitive_columns: List[str] | None
+    ) -> None:
+        """Set and validate sensitive columns.
+
+        Normalizes empty lists to None so there is only one representation
+        for "no sensitive columns".
+        """
+        self._sensitive_columns = sensitive_columns or None
+        if not self._sensitive_columns:
+            return
+
+        if not all(isinstance(c, str) for c in self.sensitive_columns):
+            raise TypeError("sensitive_columns must be a list of strings")
+
+        # Cast to lowercase if applicable
+        if self.cast_column_names_lower:
+            self._sensitive_columns = [col.lower() for col in self.sensitive_columns]
+
+        # Check duplicates
+        duplicates = {c for c, n in Counter(self.sensitive_columns).items() if n > 1}
+        if duplicates:
+            raise ValueError(f"duplicate columns: {duplicates}")
+
+        # Warn if column not found in either dataframe
+        unused = [
+            col
+            for col in self.sensitive_columns
+            if (col not in self.df1.columns) and (col not in self.df2.columns)
+        ]
+        if unused:
+            LOG.warning(
+                f"sensitive columns not found in either df1 or df2 will be ignored: {unused}"
+            )
 
     @abstractmethod
     def _validate_dataframe(
@@ -181,6 +222,24 @@ class BaseCompare(ABC):
             The report, formatted according to the template.
         """
         pass
+
+    def reveal_sensitive_columns(self) -> None:
+        """Reveals all sensitive columns.
+
+        Notes
+        -----
+        - This re-runs the full comparison to restore original values.
+        - Revealing sensitive columns when there aren't any is treated as a NOP
+          to avoid redundant computations.
+        """
+        # Don't do anything if there aren't any sensitive columns
+        if not self.sensitive_columns:
+            return
+
+        LOG.debug("Revealing sensitive columns and re-comparing dfs")
+        self._set_and_validate_sensitive_columns(None)
+        self.column_stats.clear()
+        self._compare(ignore_spaces=self.ignore_spaces, ignore_case=self.ignore_case)
 
     def only_join_columns(self) -> bool:
         """Boolean on if the only columns are the join columns."""

--- a/datacompy/snowflake.py
+++ b/datacompy/snowflake.py
@@ -275,7 +275,15 @@ class SnowflakeCompare(BaseCompare):
             )
 
     def hide_sensitive_columns(self, sensitive_columns: List[str]) -> None:
-        """Hides sensitive columns of df1 or df2 if applicable in the compare."""
+        """Hides sensitive columns of df1 or df2 if applicable in the compare.
+
+        Parameters
+        ----------
+        sensitive_columns : List[str]
+            List of column names to hide. Column names are case-insensitive and
+            will be normalized to uppercase. Quoted identifiers (e.g. '"col"')
+            will have quotes stripped before matching.
+        """
         # Don't allow hiding columns again before first revealing
         if self.sensitive_columns:
             raise ValueError(

--- a/datacompy/snowflake.py
+++ b/datacompy/snowflake.py
@@ -153,6 +153,7 @@ class SnowflakeCompare(BaseCompare):
         self._rel_tol_dict = validate_tolerance_parameter(
             rel_tol, "rel_tol", case_mode="upper"
         )
+        self._sensitive_columns: List[str] | None = None
 
         if join_columns is None:
             errmsg = "join_columns cannot be None"
@@ -229,6 +230,52 @@ class SnowflakeCompare(BaseCompare):
             self._df2 = df
             self.df2_name = df_name.upper() if df_name else "DF2"
         self._validate_dataframe(self.df2_name, "df2")
+
+    def hide_sensitive_columns(self, sensitive_columns: List[str]) -> None:
+        """Hides sensitive columns of df1 or df2 if applicable in the compare."""
+        # Don't allow hiding columns again before first revealing
+        if self.sensitive_columns:
+            raise ValueError(
+                "sensitive columns are already hidden, call reveal_sensitive_columns() first"
+            )
+
+        self._set_and_validate_sensitive_columns(sensitive_columns)
+        # Don't do anything if [] is passed (normalized to None)
+        if not self.sensitive_columns:
+            return
+        sensitive = set(self.sensitive_columns)  # Otherwise this fails due to None
+        sensitive_with_suffixes = (
+            sensitive
+            | {f"{c}_{self.df1_name}" for c in sensitive}
+            | {f"{c}_{self.df2_name}" for c in sensitive}
+        )
+
+        # Hide columns in unq_rows
+        for df_name in ("df1_unq_rows", "df2_unq_rows"):
+            df = getattr(self, df_name)
+            LOG.debug(f"Hiding sensitive columns in {df_name}")
+            cols_to_hide = [col for col in df.columns if col in sensitive_with_suffixes]
+            if not cols_to_hide:  # skip if empty
+                continue
+            # Maintains column ordering for the hide
+            select_cols = [
+                lit("*******").alias(c) if c in cols_to_hide else col(c)
+                for c in df.columns
+            ]
+            setattr(self, df_name, df.select(select_cols))
+
+        # Hide columns in intersect_rows
+        LOG.debug("Hiding sensitive columns in intersect_rows")
+        cols_to_hide = [
+            col for col in self.intersect_rows.columns if col in sensitive_with_suffixes
+        ]
+        if not cols_to_hide:  # skip if empty
+            return
+        select_cols = [
+            lit("*******").alias(c) if c in cols_to_hide else col(c)
+            for c in self.intersect_rows.columns
+        ]
+        self.intersect_rows = self.intersect_rows.select(select_cols)
 
     def _validate_dataframe(self, df_name: str, index: str) -> None:
         """Validate the provided Snowpark dataframe.

--- a/datacompy/snowflake.py
+++ b/datacompy/snowflake.py
@@ -22,6 +22,7 @@ two dataframes.
 """
 
 import logging
+from collections import Counter
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from copy import deepcopy
 from typing import Any, Dict, List, Union, cast
@@ -230,6 +231,48 @@ class SnowflakeCompare(BaseCompare):
             self._df2 = df
             self.df2_name = df_name.upper() if df_name else "DF2"
         self._validate_dataframe(self.df2_name, "df2")
+
+    def _set_and_validate_sensitive_columns(
+        self, sensitive_columns: List[str] | None
+    ) -> None:
+        """Set and validate sensitive columns.
+
+        Notes
+        -----
+        - Normalizes empty lists to None so there is only one representation
+          for "no sensitive columns".
+        - This method requires an override in SnowflakeCompare because the class
+          does not support the cast_column_names_lower attribute.
+        - All columns will be converted to non-case-sensitive uppercase to match
+          with intent in _validate_dataframe.
+        """
+        self._sensitive_columns = sensitive_columns or None
+        if not self._sensitive_columns:
+            return
+
+        if not all(isinstance(c, str) for c in self.sensitive_columns):
+            raise TypeError("sensitive_columns must be a list of strings")
+
+        # Force all columns to be non-case-sensitive
+        self._sensitive_columns = [
+            str(c).replace('"', "").upper() for c in self.sensitive_columns
+        ]
+
+        # Check duplicates
+        duplicates = {c for c, n in Counter(self.sensitive_columns).items() if n > 1}
+        if duplicates:
+            raise ValueError(f"duplicate columns: {duplicates}")
+
+        # Warn if column not found in either dataframe
+        unused = [
+            col
+            for col in self.sensitive_columns
+            if (col not in self.df1.columns) and (col not in self.df2.columns)
+        ]
+        if unused:
+            LOG.warning(
+                f"sensitive columns not found in either df1 or df2 will be ignored: {unused}"
+            )
 
     def hide_sensitive_columns(self, sensitive_columns: List[str]) -> None:
         """Hides sensitive columns of df1 or df2 if applicable in the compare."""

--- a/datacompy/snowflake.py
+++ b/datacompy/snowflake.py
@@ -265,9 +265,9 @@ class SnowflakeCompare(BaseCompare):
 
         # Warn if column not found in either dataframe
         unused = [
-            col
-            for col in self.sensitive_columns
-            if (col not in self.df1.columns) and (col not in self.df2.columns)
+            c
+            for c in self.sensitive_columns
+            if (c not in self.df1.columns) and (c not in self.df2.columns)
         ]
         if unused:
             LOG.warning(
@@ -305,7 +305,7 @@ class SnowflakeCompare(BaseCompare):
         for df_name in ("df1_unq_rows", "df2_unq_rows"):
             df = getattr(self, df_name)
             LOG.debug(f"Hiding sensitive columns in {df_name}")
-            cols_to_hide = [col for col in df.columns if col in sensitive_with_suffixes]
+            cols_to_hide = [c for c in df.columns if c in sensitive_with_suffixes]
             if not cols_to_hide:  # skip if empty
                 continue
             # Maintains column ordering for the hide
@@ -318,7 +318,7 @@ class SnowflakeCompare(BaseCompare):
         # Hide columns in intersect_rows
         LOG.debug("Hiding sensitive columns in intersect_rows")
         cols_to_hide = [
-            col for col in self.intersect_rows.columns if col in sensitive_with_suffixes
+            c for c in self.intersect_rows.columns if c in sensitive_with_suffixes
         ]
         if not cols_to_hide:  # skip if empty
             return
@@ -961,12 +961,12 @@ class SnowflakeCompare(BaseCompare):
         return {
             "column_comparison": {
                 "unequal_columns": len(
-                    [col for col in self.column_stats if col["unequal_cnt"] > 0]
+                    [c for c in self.column_stats if c["unequal_cnt"] > 0]
                 ),
                 "equal_columns": len(
-                    [col for col in self.column_stats if col["unequal_cnt"] == 0]
+                    [c for c in self.column_stats if c["unequal_cnt"] == 0]
                 ),
-                "unequal_values": sum(col["unequal_cnt"] for col in self.column_stats),
+                "unequal_values": sum(c["unequal_cnt"] for c in self.column_stats),
             }
         }
 

--- a/tests/test_snowflake.py
+++ b/tests/test_snowflake.py
@@ -20,6 +20,7 @@ Testing out the datacompy functionality
 import io
 import logging
 import os
+import re
 import tempfile
 from datetime import datetime
 from decimal import Decimal
@@ -2174,3 +2175,389 @@ def test_columns_with_mismatches_multiple_join_columns(snowflake_session):
     assert "ID1" not in result
     assert "ID2" not in result
     assert sorted(result) == ["VALUE1", "VALUE2"]
+
+
+def test_sensitive_columns_hide(snowflake_session):
+    df1 = snowflake_session.createDataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = snowflake_session.createDataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = SnowflakeCompare(snowflake_session, df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["b"])
+
+    df1_unq_rows = compare.df1_unq_rows.toPandas().reset_index(drop=True)
+    df2_unq_rows = compare.df2_unq_rows.toPandas().reset_index(drop=True)
+    intersect_rows = compare.intersect_rows.toPandas().reset_index(drop=True)
+
+    assert compare.df1.toPandas().loc[0, "b"] == 2
+    assert compare.df1.toPandas().loc[1, "b"] == 0
+    assert len(df1_unq_rows) == 1
+    assert df1_unq_rows.loc[0, "a_df1"] == 1
+    assert df1_unq_rows.loc[0, "b_df1"] == "*******"
+    assert len(df2_unq_rows) == 1
+    assert df2_unq_rows.loc[0, "a_df2"] == 2
+    assert df2_unq_rows.loc[0, "b_df2"] == "*******"
+    assert len(intersect_rows) == 1
+    assert intersect_rows.loc[0, "a_df1"] == 1
+    assert intersect_rows.loc[0, "b_df1"] == "*******"
+    assert intersect_rows.loc[0, "b_df2"] == "*******"
+    assert intersect_rows.loc[0, "b_match"]
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_hide_hide(snowflake_session):
+    df1 = snowflake_session.createDataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = snowflake_session.createDataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = SnowflakeCompare(snowflake_session, df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["b"])
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "sensitive columns are already hidden, call reveal_sensitive_columns() first"
+        ),
+    ):
+        compare.hide_sensitive_columns(["c"])
+
+
+def test_sensitive_columns_hide_reveal(snowflake_session):
+    df1 = snowflake_session.createDataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = snowflake_session.createDataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = SnowflakeCompare(snowflake_session, df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["b"])
+    compare.reveal_sensitive_columns()
+
+    df1_unq_rows = compare.df1_unq_rows.toPandas().reset_index(drop=True)
+    df2_unq_rows = compare.df2_unq_rows.toPandas().reset_index(drop=True)
+    intersect_rows = compare.intersect_rows.toPandas().reset_index(drop=True)
+
+    assert compare.df1.toPandas().loc[0, "b"] == 2
+    assert compare.df1.toPandas().loc[1, "b"] == 0
+    assert len(df1_unq_rows) == 1
+    assert df1_unq_rows.loc[0, "a_df1"] == 1
+    assert df1_unq_rows.loc[0, "b_df1"] == 0
+    assert len(df2_unq_rows) == 1
+    assert df2_unq_rows.loc[0, "a_df2"] == 2
+    assert df2_unq_rows.loc[0, "b_df2"] == 0
+    assert len(intersect_rows) == 1
+    assert intersect_rows.loc[0, "a_df1"] == 1
+    assert intersect_rows.loc[0, "b_df1"] == 2
+    assert intersect_rows.loc[0, "b_df2"] == 2
+    assert intersect_rows.loc[0, "b_match"]
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_hide_reveal_hide(snowflake_session):
+    df1 = snowflake_session.createDataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = snowflake_session.createDataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = SnowflakeCompare(snowflake_session, df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["b"])
+    compare.reveal_sensitive_columns()
+    compare.hide_sensitive_columns(["b"])
+
+    df1_unq_rows = compare.df1_unq_rows.toPandas().reset_index(drop=True)
+    df2_unq_rows = compare.df2_unq_rows.toPandas().reset_index(drop=True)
+    intersect_rows = compare.intersect_rows.toPandas().reset_index(drop=True)
+
+    assert compare.df1.toPandas().loc[0, "b"] == 2
+    assert compare.df1.toPandas().loc[1, "b"] == 0
+    assert len(df1_unq_rows) == 1
+    assert df1_unq_rows.loc[0, "a_df1"] == 1
+    assert df1_unq_rows.loc[0, "b_df1"] == "*******"
+    assert len(df2_unq_rows) == 1
+    assert df2_unq_rows.loc[0, "a_df2"] == 2
+    assert df2_unq_rows.loc[0, "b_df2"] == "*******"
+    assert len(intersect_rows) == 1
+    assert intersect_rows.loc[0, "a_df1"] == 1
+    assert intersect_rows.loc[0, "b_df1"] == "*******"
+    assert intersect_rows.loc[0, "b_df2"] == "*******"
+    assert intersect_rows.loc[0, "b_match"]
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_case_insensitive(snowflake_session):
+    df1 = snowflake_session.createDataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = snowflake_session.createDataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = SnowflakeCompare(snowflake_session, df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["B"])
+
+    df1_unq_rows = compare.df1_unq_rows.toPandas().reset_index(drop=True)
+    df2_unq_rows = compare.df2_unq_rows.toPandas().reset_index(drop=True)
+    intersect_rows = compare.intersect_rows.toPandas().reset_index(drop=True)
+
+    assert compare.df1.toPandas().loc[0, "b"] == 2
+    assert compare.df1.toPandas().loc[1, "b"] == 0
+    assert len(df1_unq_rows) == 1
+    assert df1_unq_rows.loc[0, "a_df1"] == 1
+    assert df1_unq_rows.loc[0, "b_df1"] == "*******"
+    assert len(df2_unq_rows) == 1
+    assert df2_unq_rows.loc[0, "a_df2"] == 2
+    assert df2_unq_rows.loc[0, "b_df2"] == "*******"
+    assert len(intersect_rows) == 1
+    assert intersect_rows.loc[0, "a_df1"] == 1
+    assert intersect_rows.loc[0, "b_df1"] == "*******"
+    assert intersect_rows.loc[0, "b_df2"] == "*******"
+    assert intersect_rows.loc[0, "b_match"]
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_hide_join_columns(snowflake_session):
+    df1 = snowflake_session.createDataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = snowflake_session.createDataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = SnowflakeCompare(snowflake_session, df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["a"])
+
+    df1_unq_rows = compare.df1_unq_rows.toPandas().reset_index(drop=True)
+    sample_mismatch = compare.sample_mismatch("a").toPandas().reset_index(drop=True)
+
+    assert compare.df1.toPandas().loc[0, "a"] == 1
+    assert compare.df1.toPandas().loc[1, "a"] == 1
+    assert len(df1_unq_rows) == 1
+    assert df1_unq_rows.loc[0, "a_df1"] == "*******"
+    assert len(sample_mismatch) == 2
+    assert sample_mismatch.loc[0, "a"] == "*******"
+    assert sample_mismatch.loc[1, "a"] == "*******"
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_hide_reveal_join_columns(snowflake_session):
+    df1 = snowflake_session.createDataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = snowflake_session.createDataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = SnowflakeCompare(snowflake_session, df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["a"])
+    compare.reveal_sensitive_columns()
+
+    df1_unq_rows = compare.df1_unq_rows.toPandas().reset_index(drop=True)
+    sample_mismatch = compare.sample_mismatch("a").toPandas().reset_index(drop=True)
+
+    assert compare.df1.toPandas().loc[0, "a"] == 1
+    assert compare.df1.toPandas().loc[1, "a"] == 1
+    assert len(df1_unq_rows) == 1
+    assert df1_unq_rows.loc[0, "a_df1"] == 1
+    assert len(sample_mismatch) == 2
+    assert sample_mismatch.sort_values("a").reset_index(drop=True).loc[0, "a"] == 1
+    assert sample_mismatch.sort_values("a").reset_index(drop=True).loc[1, "a"] == 2
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_missing(snowflake_session):
+    df1 = snowflake_session.createDataFrame(
+        [{"a": 1, "b": "bruh", "c": 3}, {"a": 3, "b": "67", "c": 6}]
+    )
+    df2 = snowflake_session.createDataFrame(
+        [{"a": 1, "b": "hello", "d": 4}, {"a": 2, "b": "yo", "d": 7}]
+    )
+    compare = SnowflakeCompare(snowflake_session, df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["b", "c"])
+
+    df1_unq_rows = compare.df1_unq_rows.toPandas().reset_index(drop=True)
+    df2_unq_rows = compare.df2_unq_rows.toPandas().reset_index(drop=True)
+    intersect_rows = compare.intersect_rows.toPandas().reset_index(drop=True)
+
+    assert compare.df1.toPandas().loc[0, "b"] == "bruh"
+    assert compare.df1.toPandas().loc[1, "b"] == "67"
+    assert compare.df1.toPandas().loc[0, "c"] == 3
+    assert compare.df1.toPandas().loc[1, "c"] == 6
+    assert compare.df2.toPandas().loc[0, "d"] == 4
+    assert compare.df2.toPandas().loc[1, "d"] == 7
+    assert len(df1_unq_rows) == 1
+    assert df1_unq_rows.loc[0, "a_df1"] == 3
+    assert df1_unq_rows.loc[0, "b_df1"] == "*******"
+    assert df1_unq_rows.loc[0, "c_df1"] == "*******"
+    assert len(df2_unq_rows) == 1
+    assert df2_unq_rows.loc[0, "a_df2"] == 2
+    assert df2_unq_rows.loc[0, "b_df2"] == "*******"
+    assert df2_unq_rows.loc[0, "d_df2"] == 7
+    assert len(intersect_rows) == 1
+    assert intersect_rows.loc[0, "b_df1"] == "*******"
+    assert intersect_rows.loc[0, "b_df2"] == "*******"
+    assert intersect_rows.loc[0, "c_df1"] == "*******"
+    assert not intersect_rows.loc[0, "b_match"]
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_unused(snowflake_session, caplog):
+    df1 = snowflake_session.createDataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = snowflake_session.createDataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = SnowflakeCompare(snowflake_session, df1, df2, join_columns=["a"])
+    with caplog.at_level(logging.WARNING):
+        compare.hide_sensitive_columns(["c"])
+        assert (
+            "sensitive columns not found in either df1 or df2 will be ignored: ['c']"
+            in caplog.text
+        )
+
+    df1_unq_rows = compare.df1_unq_rows.toPandas().reset_index(drop=True)
+    df2_unq_rows = compare.df2_unq_rows.toPandas().reset_index(drop=True)
+    intersect_rows = compare.intersect_rows.toPandas().reset_index(drop=True)
+
+    assert compare.df1.toPandas().loc[0, "b"] == 2
+    assert compare.df1.toPandas().loc[1, "b"] == 0
+    assert len(df1_unq_rows) == 1
+    assert df1_unq_rows.loc[0, "a_df1"] == 1
+    assert df1_unq_rows.loc[0, "b_df1"] == 0
+    assert len(df2_unq_rows) == 1
+    assert df2_unq_rows.loc[0, "a_df2"] == 2
+    assert df2_unq_rows.loc[0, "b_df2"] == 0
+    assert len(intersect_rows) == 1
+    assert intersect_rows.loc[0, "a_df1"] == 1
+    assert intersect_rows.loc[0, "b_df1"] == 2
+    assert intersect_rows.loc[0, "b_df2"] == 2
+    assert intersect_rows.loc[0, "b_match"]
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_hide_reveal_empty(snowflake_session):
+    df1 = snowflake_session.createDataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = snowflake_session.createDataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = SnowflakeCompare(snowflake_session, df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns([])
+    compare.reveal_sensitive_columns()
+
+    df1_unq_rows = compare.df1_unq_rows.toPandas().reset_index(drop=True)
+    df2_unq_rows = compare.df2_unq_rows.toPandas().reset_index(drop=True)
+    intersect_rows = compare.intersect_rows.toPandas().reset_index(drop=True)
+
+    assert compare.df1.toPandas().loc[0, "b"] == 2
+    assert compare.df1.toPandas().loc[1, "b"] == 0
+    assert len(df1_unq_rows) == 1
+    assert df1_unq_rows.loc[0, "a_df1"] == 1
+    assert df1_unq_rows.loc[0, "b_df1"] == 0
+    assert len(df2_unq_rows) == 1
+    assert df2_unq_rows.loc[0, "a_df2"] == 2
+    assert df2_unq_rows.loc[0, "b_df2"] == 0
+    assert len(intersect_rows) == 1
+    assert intersect_rows.loc[0, "a_df1"] == 1
+    assert intersect_rows.loc[0, "b_df1"] == 2
+    assert intersect_rows.loc[0, "b_df2"] == 2
+    assert intersect_rows.loc[0, "b_match"]
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_hide_empty(snowflake_session):
+    df1 = snowflake_session.createDataFrame([{"a": 1, "b": 2}, {"a": 1, "b": 0}])
+    df2 = snowflake_session.createDataFrame([{"a": 1, "b": 2}, {"a": 2, "b": 0}])
+    compare = SnowflakeCompare(snowflake_session, df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns([])
+
+    df1_unq_rows = compare.df1_unq_rows.toPandas().reset_index(drop=True)
+    df2_unq_rows = compare.df2_unq_rows.toPandas().reset_index(drop=True)
+    intersect_rows = compare.intersect_rows.toPandas().reset_index(drop=True)
+
+    assert compare.df1.toPandas().loc[0, "b"] == 2
+    assert compare.df1.toPandas().loc[1, "b"] == 0
+    assert len(df1_unq_rows) == 1
+    assert df1_unq_rows.loc[0, "a_df1"] == 1
+    assert df1_unq_rows.loc[0, "b_df1"] == 0
+    assert len(df2_unq_rows) == 1
+    assert df2_unq_rows.loc[0, "a_df2"] == 2
+    assert df2_unq_rows.loc[0, "b_df2"] == 0
+    assert len(intersect_rows) == 1
+    assert intersect_rows.loc[0, "a_df1"] == 1
+    assert intersect_rows.loc[0, "b_df1"] == 2
+    assert intersect_rows.loc[0, "b_df2"] == 2
+    assert intersect_rows.loc[0, "b_match"]
+    # Just render the report to make sure it renders.
+    compare.report()
+
+
+def test_sensitive_columns_setter(snowflake_session):
+    df1 = snowflake_session.createDataFrame([{"a": 1, "b": 2}])
+    df2 = snowflake_session.createDataFrame([{"a": 1, "b": 2}])
+    compare = SnowflakeCompare(snowflake_session, df1, df2, join_columns=["a"])
+
+    # Valid setter call
+    compare._set_and_validate_sensitive_columns(["b"])
+    assert compare.sensitive_columns == ["b"]
+
+    # Invalid setter call - not a list of strings
+    with pytest.raises(TypeError, match="sensitive_columns must be a list of strings"):
+        compare._set_and_validate_sensitive_columns([1, 2, 3])
+
+
+def test_sensitive_columns_duplicates(snowflake_session):
+    df1 = snowflake_session.createDataFrame([{"a": 1, "b": 2}])
+    df2 = snowflake_session.createDataFrame([{"a": 1, "b": 2}])
+
+    compare = SnowflakeCompare(snowflake_session, df1, df2, join_columns=["a"])
+    # Duplicate columns should raise ValueError during hide_sensitive_columns()
+    with pytest.raises(ValueError, match=r"duplicate columns: {'b'}"):
+        compare.hide_sensitive_columns(["b", "b"])
+
+
+def test_sensitive_columns_numeric_types(snowflake_session):
+    """Verify that hiding works for different numeric types without LossySetitemError."""
+    df1 = snowflake_session.createDataFrame(
+        [
+            {"a": 1, "b": 10, "c": 1.1},
+            {"a": 2, "b": 20, "c": 2.2},
+        ]
+    )
+    df2 = snowflake_session.createDataFrame(
+        [
+            {"a": 1, "b": 10, "c": 1.1},
+            {"a": 2, "b": 20, "c": 2.2},
+        ]
+    )
+
+    compare = SnowflakeCompare(snowflake_session, df1, df2, join_columns=["a"])
+    compare.hide_sensitive_columns(["b", "c"])
+
+    df1_unq_rows = compare.df1_unq_rows.toPandas().reset_index(drop=True)
+    intersect_rows = compare.intersect_rows.toPandas().reset_index(drop=True)
+
+    assert not isinstance(compare.df1.toPandas()["b"].loc[0], str)
+    assert not isinstance(compare.df1.toPandas()["c"].loc[0], str)
+    assert len(df1_unq_rows) == 0
+    assert intersect_rows.loc[0, "b_df1"] == "*******"
+    assert intersect_rows.loc[0, "b_df2"] == "*******"
+    assert intersect_rows.loc[0, "c_df1"] == "*******"
+    assert intersect_rows.loc[0, "c_df2"] == "*******"
+
+
+def test_sensitive_columns_numeric_types_with_tolerance(snowflake_session):
+    """Verify that hiding works for different numeric types with tolerance."""
+    df1 = snowflake_session.createDataFrame(
+        [
+            {"a": 1, "b": 10, "c": 1.1},
+            {"a": 2, "b": 20, "c": 2.1},
+        ]
+    )
+    df2 = snowflake_session.createDataFrame(
+        [
+            {"a": 1, "b": 10, "c": 1.2},
+            {"a": 3, "b": 21, "c": 2.1},
+        ]
+    )
+
+    compare = SnowflakeCompare(
+        snowflake_session, df1, df2, join_columns=["a"], abs_tol=0.1
+    )
+    compare.hide_sensitive_columns(["b", "c"])
+
+    df1_unq_rows = compare.df1_unq_rows.toPandas().reset_index(drop=True)
+    df2_unq_rows = compare.df2_unq_rows.toPandas().reset_index(drop=True)
+    intersect_rows = compare.intersect_rows.toPandas().reset_index(drop=True)
+
+    assert not isinstance(compare.df1.toPandas()["b"].loc[0], str)
+    assert not isinstance(compare.df1.toPandas()["c"].loc[0], str)
+    assert len(df1_unq_rows) == 1
+    assert df1_unq_rows.loc[0, "b_df1"] == "*******"
+    assert df1_unq_rows.loc[0, "c_df1"] == "*******"
+    assert len(df2_unq_rows) == 1
+    assert df2_unq_rows.loc[0, "b_df2"] == "*******"
+    assert df2_unq_rows.loc[0, "c_df2"] == "*******"
+    assert len(intersect_rows) == 1
+    assert intersect_rows.loc[0, "b_df1"] == "*******"
+    assert intersect_rows.loc[0, "b_df2"] == "*******"
+    assert intersect_rows.loc[0, "b_match"]
+    assert intersect_rows.loc[0, "c_df1"] == "*******"
+    assert intersect_rows.loc[0, "c_df2"] == "*******"
+    assert intersect_rows.loc[0, "c_match"]

--- a/tests/test_snowflake.py
+++ b/tests/test_snowflake.py
@@ -2561,11 +2561,3 @@ def test_sensitive_columns_numeric_types_with_tolerance(snowflake_session):
     assert intersect_rows.loc[0, "C_DF1"] == "*******"
     assert intersect_rows.loc[0, "C_DF2"] == "*******"
     assert intersect_rows.loc[0, "C_MATCH"]
-
-
-def test_sensitive_columns_placeholder(snowflake_session):
-    """Check compare won't crash trying to access _sensitive_columns (to be removed later)."""
-    df1 = snowflake_session.createDataFrame([{"a": 1, "b": 2}])
-    df2 = snowflake_session.createDataFrame([{"a": 1, "b": 2}])
-    compare = SnowflakeCompare(snowflake_session, df1, df2, join_columns=["a"])
-    _ = compare.sensitive_columns  # this shouldn't crash

--- a/tests/test_snowflake.py
+++ b/tests/test_snowflake.py
@@ -2187,19 +2187,19 @@ def test_sensitive_columns_hide(snowflake_session):
     df2_unq_rows = compare.df2_unq_rows.toPandas().reset_index(drop=True)
     intersect_rows = compare.intersect_rows.toPandas().reset_index(drop=True)
 
-    assert compare.df1.toPandas().loc[0, "b"] == 2
-    assert compare.df1.toPandas().loc[1, "b"] == 0
+    assert compare.df1.toPandas().loc[0, "B"] == 2
+    assert compare.df1.toPandas().loc[1, "B"] == 0
     assert len(df1_unq_rows) == 1
-    assert df1_unq_rows.loc[0, "a_df1"] == 1
-    assert df1_unq_rows.loc[0, "b_df1"] == "*******"
+    assert df1_unq_rows.loc[0, "A_DF1"] == 1
+    assert df1_unq_rows.loc[0, "B_DF1"] == "*******"
     assert len(df2_unq_rows) == 1
-    assert df2_unq_rows.loc[0, "a_df2"] == 2
-    assert df2_unq_rows.loc[0, "b_df2"] == "*******"
+    assert df2_unq_rows.loc[0, "A_DF2"] == 2
+    assert df2_unq_rows.loc[0, "B_DF2"] == "*******"
     assert len(intersect_rows) == 1
-    assert intersect_rows.loc[0, "a_df1"] == 1
-    assert intersect_rows.loc[0, "b_df1"] == "*******"
-    assert intersect_rows.loc[0, "b_df2"] == "*******"
-    assert intersect_rows.loc[0, "b_match"]
+    assert intersect_rows.loc[0, "A_DF1"] == 1
+    assert intersect_rows.loc[0, "B_DF1"] == "*******"
+    assert intersect_rows.loc[0, "B_DF2"] == "*******"
+    assert intersect_rows.loc[0, "B_MATCH"]
     # Just render the report to make sure it renders.
     compare.report()
 
@@ -2230,19 +2230,19 @@ def test_sensitive_columns_hide_reveal(snowflake_session):
     df2_unq_rows = compare.df2_unq_rows.toPandas().reset_index(drop=True)
     intersect_rows = compare.intersect_rows.toPandas().reset_index(drop=True)
 
-    assert compare.df1.toPandas().loc[0, "b"] == 2
-    assert compare.df1.toPandas().loc[1, "b"] == 0
+    assert compare.df1.toPandas().loc[0, "B"] == 2
+    assert compare.df1.toPandas().loc[1, "B"] == 0
     assert len(df1_unq_rows) == 1
-    assert df1_unq_rows.loc[0, "a_df1"] == 1
-    assert df1_unq_rows.loc[0, "b_df1"] == 0
+    assert df1_unq_rows.loc[0, "A_DF1"] == 1
+    assert df1_unq_rows.loc[0, "B_DF1"] == 0
     assert len(df2_unq_rows) == 1
-    assert df2_unq_rows.loc[0, "a_df2"] == 2
-    assert df2_unq_rows.loc[0, "b_df2"] == 0
+    assert df2_unq_rows.loc[0, "A_DF2"] == 2
+    assert df2_unq_rows.loc[0, "B_DF2"] == 0
     assert len(intersect_rows) == 1
-    assert intersect_rows.loc[0, "a_df1"] == 1
-    assert intersect_rows.loc[0, "b_df1"] == 2
-    assert intersect_rows.loc[0, "b_df2"] == 2
-    assert intersect_rows.loc[0, "b_match"]
+    assert intersect_rows.loc[0, "A_DF1"] == 1
+    assert intersect_rows.loc[0, "B_DF1"] == 2
+    assert intersect_rows.loc[0, "B_DF2"] == 2
+    assert intersect_rows.loc[0, "B_MATCH"]
     # Just render the report to make sure it renders.
     compare.report()
 
@@ -2259,19 +2259,19 @@ def test_sensitive_columns_hide_reveal_hide(snowflake_session):
     df2_unq_rows = compare.df2_unq_rows.toPandas().reset_index(drop=True)
     intersect_rows = compare.intersect_rows.toPandas().reset_index(drop=True)
 
-    assert compare.df1.toPandas().loc[0, "b"] == 2
-    assert compare.df1.toPandas().loc[1, "b"] == 0
+    assert compare.df1.toPandas().loc[0, "B"] == 2
+    assert compare.df1.toPandas().loc[1, "B"] == 0
     assert len(df1_unq_rows) == 1
-    assert df1_unq_rows.loc[0, "a_df1"] == 1
-    assert df1_unq_rows.loc[0, "b_df1"] == "*******"
+    assert df1_unq_rows.loc[0, "A_DF1"] == 1
+    assert df1_unq_rows.loc[0, "B_DF1"] == "*******"
     assert len(df2_unq_rows) == 1
-    assert df2_unq_rows.loc[0, "a_df2"] == 2
-    assert df2_unq_rows.loc[0, "b_df2"] == "*******"
+    assert df2_unq_rows.loc[0, "A_DF2"] == 2
+    assert df2_unq_rows.loc[0, "B_DF2"] == "*******"
     assert len(intersect_rows) == 1
-    assert intersect_rows.loc[0, "a_df1"] == 1
-    assert intersect_rows.loc[0, "b_df1"] == "*******"
-    assert intersect_rows.loc[0, "b_df2"] == "*******"
-    assert intersect_rows.loc[0, "b_match"]
+    assert intersect_rows.loc[0, "A_DF1"] == 1
+    assert intersect_rows.loc[0, "B_DF1"] == "*******"
+    assert intersect_rows.loc[0, "B_DF2"] == "*******"
+    assert intersect_rows.loc[0, "B_MATCH"]
     # Just render the report to make sure it renders.
     compare.report()
 
@@ -2286,19 +2286,19 @@ def test_sensitive_columns_case_insensitive(snowflake_session):
     df2_unq_rows = compare.df2_unq_rows.toPandas().reset_index(drop=True)
     intersect_rows = compare.intersect_rows.toPandas().reset_index(drop=True)
 
-    assert compare.df1.toPandas().loc[0, "b"] == 2
-    assert compare.df1.toPandas().loc[1, "b"] == 0
+    assert compare.df1.toPandas().loc[0, "B"] == 2
+    assert compare.df1.toPandas().loc[1, "B"] == 0
     assert len(df1_unq_rows) == 1
-    assert df1_unq_rows.loc[0, "a_df1"] == 1
-    assert df1_unq_rows.loc[0, "b_df1"] == "*******"
+    assert df1_unq_rows.loc[0, "A_DF1"] == 1
+    assert df1_unq_rows.loc[0, "B_DF1"] == "*******"
     assert len(df2_unq_rows) == 1
-    assert df2_unq_rows.loc[0, "a_df2"] == 2
-    assert df2_unq_rows.loc[0, "b_df2"] == "*******"
+    assert df2_unq_rows.loc[0, "A_DF2"] == 2
+    assert df2_unq_rows.loc[0, "B_DF2"] == "*******"
     assert len(intersect_rows) == 1
-    assert intersect_rows.loc[0, "a_df1"] == 1
-    assert intersect_rows.loc[0, "b_df1"] == "*******"
-    assert intersect_rows.loc[0, "b_df2"] == "*******"
-    assert intersect_rows.loc[0, "b_match"]
+    assert intersect_rows.loc[0, "A_DF1"] == 1
+    assert intersect_rows.loc[0, "B_DF1"] == "*******"
+    assert intersect_rows.loc[0, "B_DF2"] == "*******"
+    assert intersect_rows.loc[0, "B_MATCH"]
     # Just render the report to make sure it renders.
     compare.report()
 
@@ -2312,13 +2312,13 @@ def test_sensitive_columns_hide_join_columns(snowflake_session):
     df1_unq_rows = compare.df1_unq_rows.toPandas().reset_index(drop=True)
     sample_mismatch = compare.sample_mismatch("a").toPandas().reset_index(drop=True)
 
-    assert compare.df1.toPandas().loc[0, "a"] == 1
-    assert compare.df1.toPandas().loc[1, "a"] == 1
+    assert compare.df1.toPandas().loc[0, "A"] == 1
+    assert compare.df1.toPandas().loc[1, "A"] == 1
     assert len(df1_unq_rows) == 1
-    assert df1_unq_rows.loc[0, "a_df1"] == "*******"
+    assert df1_unq_rows.loc[0, "A_DF1"] == "*******"
     assert len(sample_mismatch) == 2
-    assert sample_mismatch.loc[0, "a"] == "*******"
-    assert sample_mismatch.loc[1, "a"] == "*******"
+    assert sample_mismatch.loc[0, "A"] == "*******"
+    assert sample_mismatch.loc[1, "A"] == "*******"
     # Just render the report to make sure it renders.
     compare.report()
 
@@ -2333,13 +2333,13 @@ def test_sensitive_columns_hide_reveal_join_columns(snowflake_session):
     df1_unq_rows = compare.df1_unq_rows.toPandas().reset_index(drop=True)
     sample_mismatch = compare.sample_mismatch("a").toPandas().reset_index(drop=True)
 
-    assert compare.df1.toPandas().loc[0, "a"] == 1
-    assert compare.df1.toPandas().loc[1, "a"] == 1
+    assert compare.df1.toPandas().loc[0, "A"] == 1
+    assert compare.df1.toPandas().loc[1, "A"] == 1
     assert len(df1_unq_rows) == 1
-    assert df1_unq_rows.loc[0, "a_df1"] == 1
+    assert df1_unq_rows.loc[0, "A_DF1"] == 1
     assert len(sample_mismatch) == 2
-    assert sample_mismatch.sort_values("a").reset_index(drop=True).loc[0, "a"] == 1
-    assert sample_mismatch.sort_values("a").reset_index(drop=True).loc[1, "a"] == 2
+    assert sample_mismatch.sort_values("A").reset_index(drop=True).loc[0, "A"] == 1
+    assert sample_mismatch.sort_values("A").reset_index(drop=True).loc[1, "A"] == 2
     # Just render the report to make sure it renders.
     compare.report()
 
@@ -2358,25 +2358,25 @@ def test_sensitive_columns_missing(snowflake_session):
     df2_unq_rows = compare.df2_unq_rows.toPandas().reset_index(drop=True)
     intersect_rows = compare.intersect_rows.toPandas().reset_index(drop=True)
 
-    assert compare.df1.toPandas().loc[0, "b"] == "bruh"
-    assert compare.df1.toPandas().loc[1, "b"] == "67"
-    assert compare.df1.toPandas().loc[0, "c"] == 3
-    assert compare.df1.toPandas().loc[1, "c"] == 6
-    assert compare.df2.toPandas().loc[0, "d"] == 4
-    assert compare.df2.toPandas().loc[1, "d"] == 7
+    assert compare.df1.toPandas().loc[0, "B"] == "bruh"
+    assert compare.df1.toPandas().loc[1, "B"] == "67"
+    assert compare.df1.toPandas().loc[0, "C"] == 3
+    assert compare.df1.toPandas().loc[1, "C"] == 6
+    assert compare.df2.toPandas().loc[0, "D"] == 4
+    assert compare.df2.toPandas().loc[1, "D"] == 7
     assert len(df1_unq_rows) == 1
-    assert df1_unq_rows.loc[0, "a_df1"] == 3
-    assert df1_unq_rows.loc[0, "b_df1"] == "*******"
-    assert df1_unq_rows.loc[0, "c_df1"] == "*******"
+    assert df1_unq_rows.loc[0, "A_DF1"] == 3
+    assert df1_unq_rows.loc[0, "B_DF1"] == "*******"
+    assert df1_unq_rows.loc[0, "C_DF1"] == "*******"
     assert len(df2_unq_rows) == 1
-    assert df2_unq_rows.loc[0, "a_df2"] == 2
-    assert df2_unq_rows.loc[0, "b_df2"] == "*******"
-    assert df2_unq_rows.loc[0, "d_df2"] == 7
+    assert df2_unq_rows.loc[0, "A_DF2"] == 2
+    assert df2_unq_rows.loc[0, "B_DF2"] == "*******"
+    assert df2_unq_rows.loc[0, "D_DF2"] == 7
     assert len(intersect_rows) == 1
-    assert intersect_rows.loc[0, "b_df1"] == "*******"
-    assert intersect_rows.loc[0, "b_df2"] == "*******"
-    assert intersect_rows.loc[0, "c_df1"] == "*******"
-    assert not intersect_rows.loc[0, "b_match"]
+    assert intersect_rows.loc[0, "B_DF1"] == "*******"
+    assert intersect_rows.loc[0, "B_DF2"] == "*******"
+    assert intersect_rows.loc[0, "C_DF1"] == "*******"
+    assert not intersect_rows.loc[0, "B_MATCH"]
     # Just render the report to make sure it renders.
     compare.report()
 
@@ -2396,19 +2396,19 @@ def test_sensitive_columns_unused(snowflake_session, caplog):
     df2_unq_rows = compare.df2_unq_rows.toPandas().reset_index(drop=True)
     intersect_rows = compare.intersect_rows.toPandas().reset_index(drop=True)
 
-    assert compare.df1.toPandas().loc[0, "b"] == 2
-    assert compare.df1.toPandas().loc[1, "b"] == 0
+    assert compare.df1.toPandas().loc[0, "B"] == 2
+    assert compare.df1.toPandas().loc[1, "B"] == 0
     assert len(df1_unq_rows) == 1
-    assert df1_unq_rows.loc[0, "a_df1"] == 1
-    assert df1_unq_rows.loc[0, "b_df1"] == 0
+    assert df1_unq_rows.loc[0, "A_DF1"] == 1
+    assert df1_unq_rows.loc[0, "B_DF1"] == 0
     assert len(df2_unq_rows) == 1
-    assert df2_unq_rows.loc[0, "a_df2"] == 2
-    assert df2_unq_rows.loc[0, "b_df2"] == 0
+    assert df2_unq_rows.loc[0, "A_DF2"] == 2
+    assert df2_unq_rows.loc[0, "B_DF2"] == 0
     assert len(intersect_rows) == 1
-    assert intersect_rows.loc[0, "a_df1"] == 1
-    assert intersect_rows.loc[0, "b_df1"] == 2
-    assert intersect_rows.loc[0, "b_df2"] == 2
-    assert intersect_rows.loc[0, "b_match"]
+    assert intersect_rows.loc[0, "A_DF1"] == 1
+    assert intersect_rows.loc[0, "B_DF1"] == 2
+    assert intersect_rows.loc[0, "B_DF2"] == 2
+    assert intersect_rows.loc[0, "B_MATCH"]
     # Just render the report to make sure it renders.
     compare.report()
 
@@ -2424,19 +2424,19 @@ def test_sensitive_columns_hide_reveal_empty(snowflake_session):
     df2_unq_rows = compare.df2_unq_rows.toPandas().reset_index(drop=True)
     intersect_rows = compare.intersect_rows.toPandas().reset_index(drop=True)
 
-    assert compare.df1.toPandas().loc[0, "b"] == 2
-    assert compare.df1.toPandas().loc[1, "b"] == 0
+    assert compare.df1.toPandas().loc[0, "B"] == 2
+    assert compare.df1.toPandas().loc[1, "B"] == 0
     assert len(df1_unq_rows) == 1
-    assert df1_unq_rows.loc[0, "a_df1"] == 1
-    assert df1_unq_rows.loc[0, "b_df1"] == 0
+    assert df1_unq_rows.loc[0, "A_DF1"] == 1
+    assert df1_unq_rows.loc[0, "B_DF1"] == 0
     assert len(df2_unq_rows) == 1
-    assert df2_unq_rows.loc[0, "a_df2"] == 2
-    assert df2_unq_rows.loc[0, "b_df2"] == 0
+    assert df2_unq_rows.loc[0, "A_DF2"] == 2
+    assert df2_unq_rows.loc[0, "B_DF2"] == 0
     assert len(intersect_rows) == 1
-    assert intersect_rows.loc[0, "a_df1"] == 1
-    assert intersect_rows.loc[0, "b_df1"] == 2
-    assert intersect_rows.loc[0, "b_df2"] == 2
-    assert intersect_rows.loc[0, "b_match"]
+    assert intersect_rows.loc[0, "A_DF1"] == 1
+    assert intersect_rows.loc[0, "B_DF1"] == 2
+    assert intersect_rows.loc[0, "B_DF2"] == 2
+    assert intersect_rows.loc[0, "B_MATCH"]
     # Just render the report to make sure it renders.
     compare.report()
 
@@ -2451,19 +2451,19 @@ def test_sensitive_columns_hide_empty(snowflake_session):
     df2_unq_rows = compare.df2_unq_rows.toPandas().reset_index(drop=True)
     intersect_rows = compare.intersect_rows.toPandas().reset_index(drop=True)
 
-    assert compare.df1.toPandas().loc[0, "b"] == 2
-    assert compare.df1.toPandas().loc[1, "b"] == 0
+    assert compare.df1.toPandas().loc[0, "B"] == 2
+    assert compare.df1.toPandas().loc[1, "B"] == 0
     assert len(df1_unq_rows) == 1
-    assert df1_unq_rows.loc[0, "a_df1"] == 1
-    assert df1_unq_rows.loc[0, "b_df1"] == 0
+    assert df1_unq_rows.loc[0, "A_DF1"] == 1
+    assert df1_unq_rows.loc[0, "B_DF1"] == 0
     assert len(df2_unq_rows) == 1
-    assert df2_unq_rows.loc[0, "a_df2"] == 2
-    assert df2_unq_rows.loc[0, "b_df2"] == 0
+    assert df2_unq_rows.loc[0, "A_DF2"] == 2
+    assert df2_unq_rows.loc[0, "B_DF2"] == 0
     assert len(intersect_rows) == 1
-    assert intersect_rows.loc[0, "a_df1"] == 1
-    assert intersect_rows.loc[0, "b_df1"] == 2
-    assert intersect_rows.loc[0, "b_df2"] == 2
-    assert intersect_rows.loc[0, "b_match"]
+    assert intersect_rows.loc[0, "A_DF1"] == 1
+    assert intersect_rows.loc[0, "B_DF1"] == 2
+    assert intersect_rows.loc[0, "B_DF2"] == 2
+    assert intersect_rows.loc[0, "B_MATCH"]
     # Just render the report to make sure it renders.
     compare.report()
 
@@ -2475,7 +2475,7 @@ def test_sensitive_columns_setter(snowflake_session):
 
     # Valid setter call
     compare._set_and_validate_sensitive_columns(["b"])
-    assert compare.sensitive_columns == ["b"]
+    assert compare.sensitive_columns == ["B"]
 
     # Invalid setter call - not a list of strings
     with pytest.raises(TypeError, match="sensitive_columns must be a list of strings"):
@@ -2488,8 +2488,8 @@ def test_sensitive_columns_duplicates(snowflake_session):
 
     compare = SnowflakeCompare(snowflake_session, df1, df2, join_columns=["a"])
     # Duplicate columns should raise ValueError during hide_sensitive_columns()
-    with pytest.raises(ValueError, match=r"duplicate columns: {'b'}"):
-        compare.hide_sensitive_columns(["b", "b"])
+    with pytest.raises(ValueError, match=r"duplicate columns: {'B'}"):
+        compare.hide_sensitive_columns(["B", "b"])
 
 
 def test_sensitive_columns_numeric_types(snowflake_session):
@@ -2513,13 +2513,13 @@ def test_sensitive_columns_numeric_types(snowflake_session):
     df1_unq_rows = compare.df1_unq_rows.toPandas().reset_index(drop=True)
     intersect_rows = compare.intersect_rows.toPandas().reset_index(drop=True)
 
-    assert not isinstance(compare.df1.toPandas()["b"].loc[0], str)
-    assert not isinstance(compare.df1.toPandas()["c"].loc[0], str)
+    assert not isinstance(compare.df1.toPandas()["B"].loc[0], str)
+    assert not isinstance(compare.df1.toPandas()["C"].loc[0], str)
     assert len(df1_unq_rows) == 0
-    assert intersect_rows.loc[0, "b_df1"] == "*******"
-    assert intersect_rows.loc[0, "b_df2"] == "*******"
-    assert intersect_rows.loc[0, "c_df1"] == "*******"
-    assert intersect_rows.loc[0, "c_df2"] == "*******"
+    assert intersect_rows.loc[0, "B_DF1"] == "*******"
+    assert intersect_rows.loc[0, "B_DF2"] == "*******"
+    assert intersect_rows.loc[0, "C_DF1"] == "*******"
+    assert intersect_rows.loc[0, "C_DF2"] == "*******"
 
 
 def test_sensitive_columns_numeric_types_with_tolerance(snowflake_session):
@@ -2546,18 +2546,18 @@ def test_sensitive_columns_numeric_types_with_tolerance(snowflake_session):
     df2_unq_rows = compare.df2_unq_rows.toPandas().reset_index(drop=True)
     intersect_rows = compare.intersect_rows.toPandas().reset_index(drop=True)
 
-    assert not isinstance(compare.df1.toPandas()["b"].loc[0], str)
-    assert not isinstance(compare.df1.toPandas()["c"].loc[0], str)
+    assert not isinstance(compare.df1.toPandas()["B"].loc[0], str)
+    assert not isinstance(compare.df1.toPandas()["C"].loc[0], str)
     assert len(df1_unq_rows) == 1
-    assert df1_unq_rows.loc[0, "b_df1"] == "*******"
-    assert df1_unq_rows.loc[0, "c_df1"] == "*******"
+    assert df1_unq_rows.loc[0, "B_DF1"] == "*******"
+    assert df1_unq_rows.loc[0, "C_DF1"] == "*******"
     assert len(df2_unq_rows) == 1
-    assert df2_unq_rows.loc[0, "b_df2"] == "*******"
-    assert df2_unq_rows.loc[0, "c_df2"] == "*******"
+    assert df2_unq_rows.loc[0, "B_DF2"] == "*******"
+    assert df2_unq_rows.loc[0, "C_DF2"] == "*******"
     assert len(intersect_rows) == 1
-    assert intersect_rows.loc[0, "b_df1"] == "*******"
-    assert intersect_rows.loc[0, "b_df2"] == "*******"
-    assert intersect_rows.loc[0, "b_match"]
-    assert intersect_rows.loc[0, "c_df1"] == "*******"
-    assert intersect_rows.loc[0, "c_df2"] == "*******"
-    assert intersect_rows.loc[0, "c_match"]
+    assert intersect_rows.loc[0, "B_DF1"] == "*******"
+    assert intersect_rows.loc[0, "B_DF2"] == "*******"
+    assert intersect_rows.loc[0, "B_MATCH"]
+    assert intersect_rows.loc[0, "C_DF1"] == "*******"
+    assert intersect_rows.loc[0, "C_DF2"] == "*******"
+    assert intersect_rows.loc[0, "C_MATCH"]

--- a/tests/test_snowflake.py
+++ b/tests/test_snowflake.py
@@ -2388,7 +2388,7 @@ def test_sensitive_columns_unused(snowflake_session, caplog):
     with caplog.at_level(logging.WARNING):
         compare.hide_sensitive_columns(["c"])
         assert (
-            "sensitive columns not found in either df1 or df2 will be ignored: ['c']"
+            "sensitive columns not found in either df1 or df2 will be ignored: ['C']"
             in caplog.text
         )
 


### PR DESCRIPTION
Ported over sensitive column hiding to `SnowflakeCompare`.

- Moved some methods over into `BaseCompare` to be synced with `PolarsCompare` PR (possibly subject to change).
- Added unit tests.
- Note: `cast_column_names_lower` is not a supported class attribute, and instead the dataframe column names are cast to uppercase to be case-insensitive in `_validate_dataframe`. 
  - sensitive columns setting and validation intent is modified to match this behaviour along with the unit tests. 