### PR TITLE
release: bump to v1.0.0, update dependency constraints, and update README for v1 GA

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ and lets you tweak how accurate matches have to be). Supported types include:
 - Snowflake
 
 > [!IMPORTANT]
-> datacompy is progressing towards a `v1` release. During this transition, a `support/0.19.x` branch will be maintained solely for `v0.19.x` users.
-> This branch will only receive dependency updates and critical bug fixes; no new features will be added.
-> All new feature development should target the `v1` branches (`develop` and eventually `main`).
+> datacompy has released `v1`. The `v0.19.x` line is no longer supported — users should upgrade to `v1` going forward.
+> The `support/0.19.x` branch is archived and will only receive critical security fixes on a best-effort basis; no new features or regular maintenance will be provided.
+> All active development targets the `v1` branches (`develop` and `main`).
 
 
 ## Quick Installation

--- a/datacompy/__init__.py
+++ b/datacompy/__init__.py
@@ -18,7 +18,7 @@ Originally started to be something of a replacement for SAS's PROC COMPARE for P
 Then extended to carry that functionality over to Spark Dataframes.
 """
 
-__version__ = "1.0.0b4"
+__version__ = "1.0.0"
 
 from datacompy.base import BaseCompare
 from datacompy.pandas import PandasCompare

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 dynamic = [ "version" ]
 dependencies = [
   "jinja2>=3",
-  "numpy<2.5>=1.26.4",
+  "numpy<2.5,>=1.26.4",
   "ordered-set<=4.1,>=4.0.2",
   "pandas<3.1,>=2.2",
   "polars[pandas]<1.41,>=0.20.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,10 @@ classifiers = [
 dynamic = [ "version" ]
 dependencies = [
   "jinja2>=3",
-  "numpy<=2.4.4,>=1.26.4",
+  "numpy<2.5>=1.26.4",
   "ordered-set<=4.1,>=4.0.2",
-  "pandas<3.1.0,>=2.2",
-  "polars[pandas]<=1.40.1,>=0.20.4",
+  "pandas<3.1,>=2.2",
+  "polars[pandas]<1.41,>=0.20.4",
 ]
 optional-dependencies.build = [ "build", "twine", "wheel" ]
 optional-dependencies.dev = [


### PR DESCRIPTION
- Bumps version from `1.0.0b4` to `1.0.0` marking the official GA release
- Updates `README` to reflect `v1` GA status and clarify that `v0.19.x` is no longer actively maintained
- Tightens dependency constraints for `numpy`, `pandas`, and `polars` to use exclusive upper bounds (<) for more predictable version resolution