### PR TITLE
docs: datacompy update release instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,3 @@ sign the [Contributor License Agreement (CLA)](https://cla-assistant.io/capitalo
 
 This project adheres to the [Open Source Code of Conduct](https://developer.capitalone.com/resources/code-of-conduct/).
 By participating, you are expected to honor this code.
-
-
-## Roadmap
-
-Roadmap details can be found [here](https://github.com/capitalone/datacompy/blob/develop/ROADMAP.rst)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ and lets you tweak how accurate matches have to be). Supported types include:
 > [!IMPORTANT]
 > datacompy has released `v1`. The `v0.19.x` line is no longer supported — users should upgrade to `v1` going forward.
 > The `support/0.19.x` branch is archived and will only receive critical security fixes on a best-effort basis; no new features or regular maintenance will be provided.
-> All active development targets the `v1` branches (`develop` and `main`).
+> All active development targets `main`.
 
 
 ## Quick Installation

--- a/docs/source/developer_instructions.rst
+++ b/docs/source/developer_instructions.rst
@@ -102,16 +102,16 @@ This should return output like the following and also updating ``pyproject.toml`
 Release Guide
 -------------
 
-For ``datacompy`` we want to use a simple workflow branching style and follow
+For ``datacompy`` we want to use a simple trunk-based workflow and follow
 `Semantic Versioning <https://semver.org/>`_ for each release.
 
-``develop`` is the default branch where most people will work with day to day. All features must be squash merged into
-this branch. The reason we squash merge is to prevent the develop branch from being polluted with endless commit messages
-when people are developing. Squashing collapses all the commits into one single new commit. It will also make it much easier to
-back out changes if something breaks.
+``main`` is the single active branch where all day-to-day development happens. All feature branches must be squash
+merged into ``main``. The reason we squash merge is to keep the branch history clean and prevent it from being
+polluted with interim commit messages. Squashing collapses all the commits into one single new commit, which also
+makes it easier to back out changes if something breaks.
 
-``main`` is where official releases will go. Each release on ``main`` should be tagged properly to denote a "version"
-that will have the corresponding artifact on pypi for users to ``pip install``.
+Releases are cut directly from ``main`` by tagging the desired commit with the appropriate version. Each tag should
+correspond to a published artifact on PyPI that users can ``pip install``.
 
 ``gh-pages`` is where official documentation will go. After each release you should build the docs and push the HTML to
 the pages branch. When first setting up the repo you want to make sure your gh-pages is a orphaned branch since it is


### PR DESCRIPTION
- cleaning up the release instructions to reflect new trunk-based workflow
- cleanup `README` road map section.