### PR TITLE
fix: make Spark backend compatible with spark.sql.ansi.enabled=true (Spark 4.x default)

### DIFF
--- a/datacompy/comparator/numeric.py
+++ b/datacompy/comparator/numeric.py
@@ -308,13 +308,17 @@ class SparkNumericComparator(BaseComparator):
                 nan_col1 = psf.isnan(col1_expr) if col1_can_be_nan else psf.lit(False)
                 nan_col2 = psf.isnan(col2_expr) if col2_can_be_nan else psf.lit(False)
                 return (
-                    psf.when(nan_col1 & nan_col2, psf.lit(True))   # NaN == NaN
-                    .when(nan_col1 | nan_col2, psf.lit(False))      # NaN != real, real != NaN
-                    .when(psf.col(col1).eqNullSafe(psf.col(col2)), psf.lit(True))  # NULL-safe equality
+                    psf.when(nan_col1 & nan_col2, psf.lit(True))  # NaN == NaN
+                    .when(
+                        nan_col1 | nan_col2, psf.lit(False)
+                    )  # NaN != real, real != NaN
+                    .when(
+                        psf.col(col1).eqNullSafe(psf.col(col2)), psf.lit(True)
+                    )  # NULL-safe equality
                     .when(
                         psf.abs(col1_expr - col2_expr)
                         <= psf.lit(atol) + (psf.lit(rtol) * psf.abs(col2_expr)),
-                        psf.lit(True),                              # within tolerance
+                        psf.lit(True),  # within tolerance
                     )
                     .otherwise(psf.lit(False))
                 )

--- a/datacompy/comparator/numeric.py
+++ b/datacompy/comparator/numeric.py
@@ -61,10 +61,12 @@ try:
         "double",
         decimal_comparator(),
     ]
+    SPARK_INTEGER_TYPES = {"tinyint", "smallint", "int", "bigint"}
 except ImportError:
     ps = None
     psf = None
     NUMERIC_PYSPARK_TYPES = None
+    SPARK_INTEGER_TYPES = None
 
 # Optional Snowflake dependencies
 try:
@@ -288,20 +290,34 @@ class SparkNumericComparator(BaseComparator):
             compare_dtype.startswith(t) for t in NUMERIC_PYSPARK_TYPES
         )
         if (base_numeric_type) and (compare_numeric_type):
+            # Cast integer types to double to avoid ANSI-mode overflow on subtraction
+            # and to prevent isnan() being called on non-float types.
+            col1_expr = (
+                psf.col(col1).cast("double")
+                if base_dtype in SPARK_INTEGER_TYPES
+                else psf.col(col1)
+            )
+            col2_expr = (
+                psf.col(col2).cast("double")
+                if compare_dtype in SPARK_INTEGER_TYPES
+                else psf.col(col2)
+            )
+            col1_can_be_nan = base_dtype in {"float", "double"}
+            col2_can_be_nan = compare_dtype in {"float", "double"}
             try:
-                return psf.when(
-                    (psf.col(col1).eqNullSafe(psf.col(col2)))
-                    | (
-                        psf.abs(psf.col(col1) - psf.col(col2))
-                        <= psf.lit(atol) + (psf.lit(rtol) * psf.abs(psf.col(col2)))
-                    ),
-                    # corner case of col1 != NaN and col2 == Nan returns True incorrectly
-                    psf.when(
-                        (psf.isnan(psf.col(col1)) == False)  # noqa: E712
-                        & (psf.isnan(psf.col(col2)) == True),  # noqa: E712
-                        psf.lit(False),
-                    ).otherwise(psf.lit(True)),
-                ).otherwise(psf.lit(False))
+                nan_col1 = psf.isnan(col1_expr) if col1_can_be_nan else psf.lit(False)
+                nan_col2 = psf.isnan(col2_expr) if col2_can_be_nan else psf.lit(False)
+                return (
+                    psf.when(nan_col1 & nan_col2, psf.lit(True))   # NaN == NaN
+                    .when(nan_col1 | nan_col2, psf.lit(False))      # NaN != real, real != NaN
+                    .when(psf.col(col1).eqNullSafe(psf.col(col2)), psf.lit(True))  # NULL-safe equality
+                    .when(
+                        psf.abs(col1_expr - col2_expr)
+                        <= psf.lit(atol) + (psf.lit(rtol) * psf.abs(col2_expr)),
+                        psf.lit(True),                              # within tolerance
+                    )
+                    .otherwise(psf.lit(False))
+                )
             except Exception:
                 return psf.lit(False)
         else:

--- a/datacompy/comparator/string.py
+++ b/datacompy/comparator/string.py
@@ -324,12 +324,16 @@ class SparkStringComparator(BaseComparator):
                     # Both strings: compare as-is with optional normalisation.
                     col1_expr = psf.col(col1)
                     col2_expr = psf.col(col2)
-                col1_expr = spark_normalize_string_column(col1_expr, ignore_space, ignore_case)
-                col2_expr = spark_normalize_string_column(col2_expr, ignore_space, ignore_case)
-
-                return psf.when(col1_expr.eqNullSafe(col2_expr), psf.lit(True)).otherwise(
-                    psf.lit(False)
+                col1_expr = spark_normalize_string_column(
+                    col1_expr, ignore_space, ignore_case
                 )
+                col2_expr = spark_normalize_string_column(
+                    col2_expr, ignore_space, ignore_case
+                )
+
+                return psf.when(
+                    col1_expr.eqNullSafe(col2_expr), psf.lit(True)
+                ).otherwise(psf.lit(False))
             except Exception:
                 return psf.lit(False)
         else:

--- a/datacompy/comparator/string.py
+++ b/datacompy/comparator/string.py
@@ -308,14 +308,26 @@ class SparkStringComparator(BaseComparator):
             or ((base_date_type) and (compare_date_type))  # date/date compare.
         ):
             try:
-                col1 = spark_normalize_string_column(
-                    psf.col(col1), ignore_space, ignore_case
-                )
-                col2 = spark_normalize_string_column(
-                    psf.col(col2), ignore_space, ignore_case
-                )
+                if base_date_type and compare_date_type:
+                    # Both are date/timestamp: compare directly, no string conversion needed.
+                    col1_expr = psf.col(col1)
+                    col2_expr = psf.col(col2)
+                elif base_date_type and compare_string_type:
+                    # Cast the string to match the date column's type using TRY_CAST so
+                    # malformed strings return NULL instead of throwing in ANSI mode.
+                    col1_expr = psf.col(col1)
+                    col2_expr = psf.expr(f"TRY_CAST(`{col2}` AS {base_dtype})")
+                elif base_string_type and compare_date_type:
+                    col1_expr = psf.expr(f"TRY_CAST(`{col1}` AS {compare_dtype})")
+                    col2_expr = psf.col(col2)
+                else:
+                    # Both strings: compare as-is with optional normalisation.
+                    col1_expr = psf.col(col1)
+                    col2_expr = psf.col(col2)
+                col1_expr = spark_normalize_string_column(col1_expr, ignore_space, ignore_case)
+                col2_expr = spark_normalize_string_column(col2_expr, ignore_space, ignore_case)
 
-                return psf.when(col1.eqNullSafe(col2), psf.lit(True)).otherwise(
+                return psf.when(col1_expr.eqNullSafe(col2_expr), psf.lit(True)).otherwise(
                     psf.lit(False)
                 )
             except Exception:

--- a/datacompy/spark.py
+++ b/datacompy/spark.py
@@ -1377,7 +1377,9 @@ def _generate_id_within_group(
     """
     default_value = "DATACOMPY_NULL"
     null_cols = [f"any(isnull({c}))" for c in join_columns]
-    default_cols = [f"any(CAST({c} AS STRING) == '{default_value}')" for c in join_columns]
+    default_cols = [
+        f"any(CAST({c} AS STRING) == '{default_value}')" for c in join_columns
+    ]
 
     null_check = any(list(dataframe.selectExpr(null_cols).first()))
     default_check = any(list(dataframe.selectExpr(default_cols).first()))

--- a/datacompy/spark.py
+++ b/datacompy/spark.py
@@ -1291,7 +1291,10 @@ def calculate_max_diff(
         )
         return 0
     diff = dataframe.select(
-        (F.col(col_1).astype("float") - F.col(col_2).astype("float")).alias("diff")
+        (
+            F.expr(f"TRY_CAST(`{col_1}` AS DOUBLE)")
+            - F.expr(f"TRY_CAST(`{col_2}` AS DOUBLE)")
+        ).alias("diff")
     )
     abs_diff = diff.select(F.abs(F.col("diff")).alias("abs_diff"))
     max_diff: float = (
@@ -1374,7 +1377,7 @@ def _generate_id_within_group(
     """
     default_value = "DATACOMPY_NULL"
     null_cols = [f"any(isnull({c}))" for c in join_columns]
-    default_cols = [f"any({c} == '{default_value}')" for c in join_columns]
+    default_cols = [f"any(CAST({c} AS STRING) == '{default_value}')" for c in join_columns]
 
     null_check = any(list(dataframe.selectExpr(null_cols).first()))
     default_check = any(list(dataframe.selectExpr(default_cols).first()))

--- a/pytest-ansi.ini
+++ b/pytest-ansi.ini
@@ -1,0 +1,10 @@
+[pytest]
+spark_options =
+  spark.master: local[*]
+  spark.sql.catalogImplementation: in-memory
+  spark.sql.shuffle.partitions: 4
+  spark.default.parallelism: 4
+  spark.executor.cores: 4
+  spark.sql.execution.arrow.pyspark.enabled: true
+  spark.sql.adaptive.enabled: false
+  spark.sql.ansi.enabled: true

--- a/tests/comparator/test_numeric_spark.py
+++ b/tests/comparator/test_numeric_spark.py
@@ -106,12 +106,18 @@ def test_spark_numeric_comparator_large_integers(spark_session):
     comparator = SparkNumericComparator()
     from pyspark.sql.types import LongType, StructField, StructType
 
-    schema = StructType([StructField("col1", LongType()), StructField("col2", LongType())])
+    schema = StructType(
+        [StructField("col1", LongType()), StructField("col2", LongType())]
+    )
     # Use values within double's exact integer range (< 2**53) so comparison is exact.
     # Use rtol=0, atol=0 to test pure equality without tolerance absorbing the diff.
     big = 2**40
-    df = spark_session.createDataFrame([(big, big), (big, big - 1000), (big, 0)], schema)
-    result_col = comparator.compare(dataframe=df, col1="col1", col2="col2", rtol=0, atol=0)
+    df = spark_session.createDataFrame(
+        [(big, big), (big, big - 1000), (big, 0)], schema
+    )
+    result_col = comparator.compare(
+        dataframe=df, col1="col1", col2="col2", rtol=0, atol=0
+    )
     result = df.withColumn("col_match", result_col).select("col_match").collect()
     assert result[0][0] is True
     assert result[1][0] is False

--- a/tests/comparator/test_numeric_spark.py
+++ b/tests/comparator/test_numeric_spark.py
@@ -99,3 +99,36 @@ def test_spark_numeric_comparator_error_handling(spark_session):
     )  # Invalid type for numeric comparison
     result_col = comparator.compare(dataframe=df, col1="col1", col2="col2")
     assert result_col is None
+
+
+def test_spark_numeric_comparator_large_integers(spark_session):
+    """Large bigint values must not overflow in ANSI mode."""
+    comparator = SparkNumericComparator()
+    from pyspark.sql.types import LongType, StructField, StructType
+
+    schema = StructType([StructField("col1", LongType()), StructField("col2", LongType())])
+    # Use values within double's exact integer range (< 2**53) so comparison is exact.
+    # Use rtol=0, atol=0 to test pure equality without tolerance absorbing the diff.
+    big = 2**40
+    df = spark_session.createDataFrame([(big, big), (big, big - 1000), (big, 0)], schema)
+    result_col = comparator.compare(dataframe=df, col1="col1", col2="col2", rtol=0, atol=0)
+    result = df.withColumn("col_match", result_col).select("col_match").collect()
+    assert result[0][0] is True
+    assert result[1][0] is False
+    assert result[2][0] is False
+
+
+def test_spark_numeric_comparator_integer_isnan_safe(spark_session):
+    """isnan() must not be called on integer columns (raises in ANSI mode)."""
+    comparator = SparkNumericComparator()
+    from pyspark.sql.types import IntegerType, StructField, StructType
+
+    schema = StructType(
+        [StructField("col1", IntegerType()), StructField("col2", IntegerType())]
+    )
+    df = spark_session.createDataFrame([(1, 1), (2, 3), (None, 4)], schema)
+    result_col = comparator.compare(dataframe=df, col1="col1", col2="col2")
+    result = df.withColumn("col_match", result_col).select("col_match").collect()
+    assert result[0][0] is True
+    assert result[1][0] is False
+    assert result[2][0] is False

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -1409,7 +1409,9 @@ def test_calculate_max_diff_with_integer_columns(spark_session):
     schema = StructType([StructField("a", LongType()), StructField("b", LongType())])
     # Use values within double's exact integer range (< 2**53) so subtraction is exact.
     big = 2**40
-    df = spark_session.createDataFrame([(big, big), (big, big - 10), (big, big + 5)], schema)
+    df = spark_session.createDataFrame(
+        [(big, big), (big, big - 10), (big, big + 5)], schema
+    )
     result = calculate_max_diff(df, "a", "b")
     assert isinstance(result, float)
     assert np.isclose(result, 10.0)

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -1388,6 +1388,33 @@ def test_calculate_max_diff(spark_session, column, expected):
     assert np.isclose(calculate_max_diff(MAX_DIFF_DF, "base", column), expected)
 
 
+def test_calculate_max_diff_with_non_numeric_strings(spark_session):
+    """Non-castable strings must not raise in ANSI mode; castable rows are used."""
+    pdf = pd.DataFrame(
+        {
+            "a": ["1", "2", "some string", "4"],
+            "b": ["1", "1", "other string", "3"],
+        }
+    )
+    df = spark_session.createDataFrame(pdf)
+    result = calculate_max_diff(df, "a", "b")
+    assert isinstance(result, float)
+    assert np.isclose(result, 1.0)
+
+
+def test_calculate_max_diff_with_integer_columns(spark_session):
+    """Large integer columns must produce a correct float result without overflow."""
+    from pyspark.sql.types import LongType, StructField, StructType
+
+    schema = StructType([StructField("a", LongType()), StructField("b", LongType())])
+    # Use values within double's exact integer range (< 2**53) so subtraction is exact.
+    big = 2**40
+    df = spark_session.createDataFrame([(big, big), (big, big - 10), (big, big + 5)], schema)
+    result = calculate_max_diff(df, "a", "b")
+    assert isinstance(result, float)
+    assert np.isclose(result, 10.0)
+
+
 def test_dupes_with_nulls_strings(spark_session):
     pdf1 = pd.DataFrame(
         {


### PR DESCRIPTION
Fixes #418 

- Spark 4.x defaults `spark.sql.ansi.enabled `to `true`, breaking the Spark backend which was written assuming false
- Replaced `CAST` with `TRY_CAST` in `calculate_max_diff()` so non-castable values return NULL instead of throwing
- Fixed cross-type string equality in `_generate_id_within_group()` to avoid `AnalysisException` on non-string join columns
- Cast integer columns to double before arithmetic in `SparkNumericComparator` to prevent ANSI-mode overflow
- Replaced `NaN` correction logic with a readable flat when chain that is also symmetric for both `NaN` positions
- Fixed mixed date/string comparisons in `SparkStringComparator` to use T`RY_CAST(string AS date)`: preserves truncation semantics and handles malformed input without throwing
