### PR TITLE
fix: update Spark versions and add ANSI mode tests for pytest

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11"]
-        spark-version: [3.5.7]
+        spark-version: [3.5.8]
         pandas-version: ["2.3.3", "3.0.3"]
         exclude:
           - python-version: "3.10"
@@ -69,6 +69,9 @@ jobs:
       - name: Test with pytest
         run: |
           python -m pytest --cov=datacompy --cov-report=xml --cov-report=term-missing
+      - name: Test with pytest (ANSI mode)
+        run: |
+          python -m pytest -c pytest-ansi.ini --cov=datacompy --cov-report=xml --cov-report=term-missing
 
 
   test-with-spark-4-install:
@@ -77,7 +80,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
-        spark-version: [4.0.1]
+        spark-version: [4.1.2]
         pandas-version: ["2.3.3", "3.0.3"]
         exclude:
           - python-version: "3.10"
@@ -111,6 +114,9 @@ jobs:
       - name: Test with pytest
         run: |
           python -m pytest --cov=datacompy --cov-report=xml --cov-report=term-missing
+      - name: Test with pytest (ANSI mode)
+        run: |
+          python -m pytest -c pytest-ansi.ini --cov=datacompy --cov-report=xml --cov-report=term-missing
 
   test-basic-install:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Added ANSI mode pytest steps to both Spark CI jobs in `test-package.yml` using `pytest-ansi.ini`.