### PR TITLE
Add Boolean comparison parity across backends

### DIFF
--- a/datacompy/comparator/__init__.py
+++ b/datacompy/comparator/__init__.py
@@ -21,7 +21,12 @@ from datacompy.comparator.array import (
     SnowflakeArrayLikeComparator,
     SparkArrayLikeComparator,
 )
-from datacompy.comparator.boolean import PandasBooleanComparator
+from datacompy.comparator.boolean import (
+    PandasBooleanComparator,
+    PolarsBooleanComparator,
+    SnowflakeBooleanComparator,
+    SparkBooleanComparator,
+)
 from datacompy.comparator.numeric import (
     PandasNumericComparator,
     PolarsNumericComparator,
@@ -41,12 +46,15 @@ __all__ = [
     "PandasNumericComparator",
     "PandasStringComparator",
     "PolarsArrayLikeComparator",
+    "PolarsBooleanComparator",
     "PolarsNumericComparator",
     "PolarsStringComparator",
     "SnowflakeArrayLikeComparator",
+    "SnowflakeBooleanComparator",
     "SnowflakeNumericComparator",
     "SnowflakeStringComparator",
     "SparkArrayLikeComparator",
+    "SparkBooleanComparator",
     "SparkNumericComparator",
     "SparkStringComparator",
 ]

--- a/datacompy/comparator/boolean.py
+++ b/datacompy/comparator/boolean.py
@@ -18,8 +18,44 @@
 from typing import Any
 
 import pandas as pd
+import polars as pl
 
 from datacompy.comparator.base import BaseComparator
+
+try:
+    import pyspark.sql.functions as psf
+
+    from datacompy.comparator.utility import get_spark_column_dtypes
+except ImportError:
+    psf = None
+    get_spark_column_dtypes = None
+
+try:
+    import snowflake.snowpark.functions as spf
+
+    from datacompy.comparator.utility import get_snowflake_column_dtypes
+except ImportError:
+    spf = None
+    get_snowflake_column_dtypes = None
+
+_NUMERIC_SPARK_TYPES = (
+    "tinyint",
+    "smallint",
+    "int",
+    "bigint",
+    "float",
+    "double",
+    "decimal",
+)
+_NUMERIC_SNOWFLAKE_TYPES = (
+    "tinyint",
+    "smallint",
+    "int",
+    "bigint",
+    "float",
+    "double",
+    "decimal",
+)
 
 
 class PandasBooleanComparator(BaseComparator):
@@ -31,19 +67,113 @@ class PandasBooleanComparator(BaseComparator):
         col2: pd.Series,
         **kwargs: Any,
     ) -> pd.Series | None:
-        """Compare columns when either Pandas dtype is Boolean.
-
-        Boolean comparisons are exact and null-safe. When a Boolean column is
-        compared with another dtype, normal Pandas equality semantics are used;
-        for example, ``True`` matches ``1`` and ``False`` matches ``0``.
-        """
+        """Compare columns when either Pandas dtype is Boolean."""
         if not (
             pd.api.types.is_bool_dtype(col1.dtype)
             or pd.api.types.is_bool_dtype(col2.dtype)
         ):
             return None
-
         if col1.shape != col2.shape:
             return None
-
         return (col1.eq(col2) | (col1.isna() & col2.isna())).fillna(False).astype(bool)
+
+
+class PolarsBooleanComparator(BaseComparator):
+    """Comparator for Boolean columns in Polars."""
+
+    def compare(
+        self, col1: pl.Series, col2: pl.Series, **kwargs: Any
+    ) -> pl.Series | None:
+        """Compare columns when either Polars dtype is Boolean."""
+        col1_is_bool = col1.dtype == pl.Boolean
+        col2_is_bool = col2.dtype == pl.Boolean
+        if not (col1_is_bool or col2_is_bool):
+            return None
+        if col1.shape != col2.shape:
+            return None
+        if col1_is_bool and col2_is_bool:
+            return col1.eq_missing(col2)
+        if (col1_is_bool and col2.dtype.is_numeric()) or (
+            col2_is_bool and col1.dtype.is_numeric()
+        ):
+            left = col1.cast(pl.Int8) if col1_is_bool else col1
+            right = col2.cast(pl.Int8) if col2_is_bool else col2
+            return left.eq_missing(right)
+        return col1.is_null() & col2.is_null()
+
+
+class SparkBooleanComparator(BaseComparator):
+    """Comparator for Boolean columns in PySpark."""
+
+    @staticmethod
+    def _compare_boolean_to_numeric(boolean_col: str, numeric_col: str) -> Any:
+        """Compare Boolean values with numeric 1/0 without casting the numeric column."""
+        boolean = psf.col(boolean_col)
+        numeric = psf.col(numeric_col)
+        both_null = boolean.isNull() & numeric.isNull()
+        values_equal = (
+            boolean.eqNullSafe(psf.lit(True)) & numeric.eqNullSafe(psf.lit(1))
+        ) | (boolean.eqNullSafe(psf.lit(False)) & numeric.eqNullSafe(psf.lit(0)))
+        return both_null | values_equal
+
+    def compare(
+        self, dataframe: Any, col1: str, col2: str, **kwargs: Any
+    ) -> Any | None:
+        """Compare columns when either Spark dtype is Boolean."""
+        if get_spark_column_dtypes is None or psf is None:
+            return None
+        dtype1, dtype2 = get_spark_column_dtypes(dataframe, col1, col2)
+        col1_is_bool = dtype1 == "boolean"
+        col2_is_bool = dtype2 == "boolean"
+        if not (col1_is_bool or col2_is_bool):
+            return None
+        if col1_is_bool and col2_is_bool:
+            return psf.col(col1).eqNullSafe(psf.col(col2))
+        dtype1_is_numeric = dtype1.startswith(_NUMERIC_SPARK_TYPES)
+        dtype2_is_numeric = dtype2.startswith(_NUMERIC_SPARK_TYPES)
+        if col1_is_bool and dtype2_is_numeric:
+            return self._compare_boolean_to_numeric(col1, col2)
+        if col2_is_bool and dtype1_is_numeric:
+            return self._compare_boolean_to_numeric(col2, col1)
+        return psf.col(col1).isNull() & psf.col(col2).isNull()
+
+
+class SnowflakeBooleanComparator(BaseComparator):
+    """Comparator for Boolean columns in Snowpark."""
+
+    @staticmethod
+    def _compare_boolean_to_numeric(boolean_col: str, numeric_col: str) -> Any:
+        """Compare Boolean values with numeric 1/0 without casting the numeric column."""
+        boolean = spf.col(boolean_col)
+        numeric = spf.col(numeric_col)
+        both_null = spf.is_null(boolean) & spf.is_null(numeric)
+        values_equal = (
+            boolean.eqNullSafe(spf.lit(True)) & numeric.eqNullSafe(spf.lit(1))
+        ) | (boolean.eqNullSafe(spf.lit(False)) & numeric.eqNullSafe(spf.lit(0)))
+        return both_null | values_equal
+
+    def compare(
+        self,
+        dataframe: Any,
+        col1: str,
+        col2: str,
+        col_match: str,
+        **kwargs: Any,
+    ) -> Any | None:
+        """Compare columns when either Snowflake dtype is Boolean."""
+        if get_snowflake_column_dtypes is None or spf is None:
+            return None
+        dtype1, dtype2 = get_snowflake_column_dtypes(dataframe, col1, col2)
+        col1_is_bool = dtype1 == "boolean"
+        col2_is_bool = dtype2 == "boolean"
+        if not (col1_is_bool or col2_is_bool):
+            return None
+        if col1_is_bool and col2_is_bool:
+            expression = spf.col(col1).eqNullSafe(spf.col(col2))
+        elif col1_is_bool and dtype2.startswith(_NUMERIC_SNOWFLAKE_TYPES):
+            expression = self._compare_boolean_to_numeric(col1, col2)
+        elif col2_is_bool and dtype1.startswith(_NUMERIC_SNOWFLAKE_TYPES):
+            expression = self._compare_boolean_to_numeric(col2, col1)
+        else:
+            expression = spf.is_null(spf.col(col1)) & spf.is_null(spf.col(col2))
+        return dataframe.withColumn(col_match, expression)

--- a/datacompy/polars.py
+++ b/datacompy/polars.py
@@ -37,6 +37,7 @@ from datacompy.base import (
 )
 from datacompy.comparator import (
     PolarsArrayLikeComparator,
+    PolarsBooleanComparator,
     PolarsNumericComparator,
     PolarsStringComparator,
 )
@@ -50,6 +51,7 @@ LIST_TYPE = ["List", "Array"]
 
 _POLARS_DEFAULT_COMPARATORS = [
     PolarsArrayLikeComparator(),
+    PolarsBooleanComparator(),
     PolarsNumericComparator(),
     PolarsStringComparator(),
 ]

--- a/datacompy/snowflake.py
+++ b/datacompy/snowflake.py
@@ -64,6 +64,7 @@ from datacompy.base import (
 )
 from datacompy.comparator import (
     SnowflakeArrayLikeComparator,
+    SnowflakeBooleanComparator,
     SnowflakeNumericComparator,
     SnowflakeStringComparator,
 )
@@ -84,6 +85,7 @@ NUMERIC_SNOWPARK_TYPES = [
 
 _SNOWFLAKE_DEFAULT_COMPARATORS = [
     SnowflakeArrayLikeComparator(),
+    SnowflakeBooleanComparator(),
     SnowflakeNumericComparator(),
     SnowflakeStringComparator(),
 ]

--- a/datacompy/spark.py
+++ b/datacompy/spark.py
@@ -41,6 +41,7 @@ from datacompy.base import (
 )
 from datacompy.comparator import (
     SparkArrayLikeComparator,
+    SparkBooleanComparator,
     SparkNumericComparator,
     SparkStringComparator,
 )
@@ -52,6 +53,7 @@ LOG = logging.getLogger(__name__)
 
 _SPARK_DEFAULT_COMPARATORS = [
     SparkArrayLikeComparator(),
+    SparkBooleanComparator(),
     SparkNumericComparator(),
     SparkStringComparator(),
 ]

--- a/tests/test_polars_boolean.py
+++ b/tests/test_polars_boolean.py
@@ -1,0 +1,52 @@
+#
+# Copyright 2026 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for Polars Boolean comparisons."""
+
+import polars as pl
+from datacompy.comparator import PolarsBooleanComparator
+from datacompy.polars import PolarsCompare, columns_equal
+from polars.testing import assert_series_equal
+
+
+def test_polars_boolean_columns_equal_with_nulls():
+    left = pl.Series("left", [True, False, None, None], dtype=pl.Boolean)
+    right = pl.Series("right", [True, True, None, False], dtype=pl.Boolean)
+    expected = pl.Series([True, False, True, False])
+
+    assert_series_equal(columns_equal(left, right), expected, check_names=False)
+
+
+def test_polars_boolean_numeric_cross_type_in_both_directions():
+    boolean = pl.Series("boolean", [True, False, True, False], dtype=pl.Boolean)
+    integer = pl.Series("integer", [1, 0, 0, 1], dtype=pl.Int64)
+    expected = pl.Series([True, True, False, False])
+
+    assert_series_equal(columns_equal(boolean, integer), expected, check_names=False)
+    assert_series_equal(columns_equal(integer, boolean), expected, check_names=False)
+
+
+def test_polars_boolean_comparator_ignores_non_boolean_columns():
+    left = pl.Series([1, 2], dtype=pl.Int64)
+    right = pl.Series([1, 2], dtype=pl.Int64)
+
+    assert PolarsBooleanComparator().compare(left, right) is None
+
+
+def test_polars_compare_matches_identical_boolean_values():
+    left = pl.DataFrame({"id": [1, 2], "flag": [True, False]})
+    right = pl.DataFrame({"id": [1, 2], "flag": [True, False]})
+
+    assert PolarsCompare(left, right, join_columns="id").matches()

--- a/tests/test_snowflake_boolean.py
+++ b/tests/test_snowflake_boolean.py
@@ -1,0 +1,165 @@
+#
+# Copyright 2026 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for Snowflake Boolean comparisons."""
+
+from decimal import Decimal
+
+import pytest
+
+pytest.importorskip("snowflake.snowpark")
+
+from datacompy.comparator import SnowflakeBooleanComparator
+from datacompy.snowflake import SnowflakeCompare, columns_equal
+
+
+def test_snowflake_boolean_columns_equal_with_nulls(snowflake_session):
+    dataframe = snowflake_session.createDataFrame(
+        [
+            (True, True, True),
+            (False, True, False),
+            (None, None, True),
+            (None, False, False),
+        ],
+        schema=["LEFT_VALUE", "RIGHT_VALUE", "EXPECTED"],
+    )
+
+    actual = (
+        columns_equal(
+            dataframe,
+            "LEFT_VALUE",
+            "RIGHT_VALUE",
+            "ACTUAL",
+        )
+        .select("ACTUAL")
+        .toPandas()["ACTUAL"]
+    )
+    expected = dataframe.select("EXPECTED").toPandas()["EXPECTED"]
+
+    assert actual.tolist() == expected.tolist()
+
+
+def test_snowflake_boolean_numeric_cross_type_in_both_directions(
+    snowflake_session,
+):
+    dataframe = snowflake_session.createDataFrame(
+        [
+            (True, 1, True),
+            (False, 0, True),
+            (True, 0, False),
+            (False, 1, False),
+        ],
+        schema=["BOOLEAN_VALUE", "INTEGER_VALUE", "EXPECTED"],
+    )
+
+    forward = (
+        columns_equal(
+            dataframe,
+            "BOOLEAN_VALUE",
+            "INTEGER_VALUE",
+            "FORWARD_MATCH",
+        )
+        .select("FORWARD_MATCH")
+        .toPandas()["FORWARD_MATCH"]
+    )
+    reverse = (
+        columns_equal(
+            dataframe,
+            "INTEGER_VALUE",
+            "BOOLEAN_VALUE",
+            "REVERSE_MATCH",
+        )
+        .select("REVERSE_MATCH")
+        .toPandas()["REVERSE_MATCH"]
+    )
+    expected = dataframe.select("EXPECTED").toPandas()["EXPECTED"]
+
+    assert forward.tolist() == expected.tolist()
+    assert reverse.tolist() == expected.tolist()
+
+
+def test_snowflake_boolean_decimal_comparison_preserves_precision(
+    snowflake_session,
+):
+    dataframe = snowflake_session.createDataFrame(
+        [
+            (True, Decimal("1.000000000000000001"), False),
+            (False, Decimal("0.000000000000000001"), False),
+            (True, Decimal("1.000000000000000000"), True),
+            (False, Decimal("0.000000000000000000"), True),
+            (None, None, True),
+            (None, Decimal("0.000000000000000000"), False),
+        ],
+        schema=["BOOLEAN_VALUE", "DECIMAL_VALUE", "EXPECTED"],
+    )
+
+    forward = (
+        columns_equal(
+            dataframe,
+            "BOOLEAN_VALUE",
+            "DECIMAL_VALUE",
+            "FORWARD_MATCH",
+        )
+        .select("FORWARD_MATCH")
+        .toPandas()["FORWARD_MATCH"]
+    )
+    reverse = (
+        columns_equal(
+            dataframe,
+            "DECIMAL_VALUE",
+            "BOOLEAN_VALUE",
+            "REVERSE_MATCH",
+        )
+        .select("REVERSE_MATCH")
+        .toPandas()["REVERSE_MATCH"]
+    )
+    expected = dataframe.select("EXPECTED").toPandas()["EXPECTED"]
+
+    assert forward.tolist() == expected.tolist()
+    assert reverse.tolist() == expected.tolist()
+
+
+def test_snowflake_boolean_comparator_ignores_non_boolean_columns(
+    snowflake_session,
+):
+    dataframe = snowflake_session.createDataFrame(
+        [(1, 1)], schema=["LEFT_VALUE", "RIGHT_VALUE"]
+    )
+
+    assert (
+        SnowflakeBooleanComparator().compare(
+            dataframe,
+            "LEFT_VALUE",
+            "RIGHT_VALUE",
+            "MATCH",
+        )
+        is None
+    )
+
+
+def test_snowflake_compare_matches_identical_boolean_values(snowflake_session):
+    left = snowflake_session.createDataFrame(
+        [(1, True), (2, False)], schema=["ID", "FLAG"]
+    )
+    right = snowflake_session.createDataFrame(
+        [(1, True), (2, False)], schema=["ID", "FLAG"]
+    )
+
+    assert SnowflakeCompare(
+        snowflake_session,
+        left,
+        right,
+        join_columns="ID",
+    ).matches()

--- a/tests/test_spark_boolean.py
+++ b/tests/test_spark_boolean.py
@@ -1,0 +1,123 @@
+#
+# Copyright 2026 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for Spark Boolean comparisons."""
+
+from decimal import Decimal
+
+import pytest
+
+pytest.importorskip("pyspark")
+
+from datacompy.comparator import SparkBooleanComparator
+from datacompy.spark import SparkSQLCompare, columns_equal
+
+
+def test_spark_boolean_columns_equal_with_nulls(spark_session):
+    dataframe = spark_session.createDataFrame(
+        [
+            (True, True, True),
+            (False, True, False),
+            (None, None, True),
+            (None, False, False),
+        ],
+        ["left", "right", "expected"],
+    )
+
+    actual = (
+        dataframe.withColumn("actual", columns_equal(dataframe, "left", "right"))
+        .select("actual")
+        .toPandas()["actual"]
+    )
+    expected = dataframe.select("expected").toPandas()["expected"]
+
+    assert actual.tolist() == expected.tolist()
+
+
+def test_spark_boolean_numeric_cross_type_in_both_directions(spark_session):
+    dataframe = spark_session.createDataFrame(
+        [
+            (True, 1, True),
+            (False, 0, True),
+            (True, 0, False),
+            (False, 1, False),
+        ],
+        ["boolean_value", "integer_value", "expected"],
+    )
+
+    forward = (
+        dataframe.withColumn(
+            "actual", columns_equal(dataframe, "boolean_value", "integer_value")
+        )
+        .select("actual")
+        .toPandas()["actual"]
+    )
+    reverse = (
+        dataframe.withColumn(
+            "actual", columns_equal(dataframe, "integer_value", "boolean_value")
+        )
+        .select("actual")
+        .toPandas()["actual"]
+    )
+    expected = dataframe.select("expected").toPandas()["expected"]
+
+    assert forward.tolist() == expected.tolist()
+    assert reverse.tolist() == expected.tolist()
+
+
+def test_spark_boolean_decimal_comparison_preserves_precision(spark_session):
+    dataframe = spark_session.createDataFrame(
+        [
+            (True, Decimal("1.000000000000000001"), False),
+            (False, Decimal("0.000000000000000001"), False),
+            (True, Decimal("1.000000000000000000"), True),
+            (False, Decimal("0.000000000000000000"), True),
+            (None, None, True),
+            (None, Decimal("0.000000000000000000"), False),
+        ],
+        ["boolean_value", "decimal_value", "expected"],
+    )
+
+    forward = (
+        dataframe.withColumn(
+            "actual", columns_equal(dataframe, "boolean_value", "decimal_value")
+        )
+        .select("actual")
+        .toPandas()["actual"]
+    )
+    reverse = (
+        dataframe.withColumn(
+            "actual", columns_equal(dataframe, "decimal_value", "boolean_value")
+        )
+        .select("actual")
+        .toPandas()["actual"]
+    )
+    expected = dataframe.select("expected").toPandas()["expected"]
+
+    assert forward.tolist() == expected.tolist()
+    assert reverse.tolist() == expected.tolist()
+
+
+def test_spark_boolean_comparator_ignores_non_boolean_columns(spark_session):
+    dataframe = spark_session.createDataFrame([(1, 1)], ["left", "right"])
+
+    assert SparkBooleanComparator().compare(dataframe, "left", "right") is None
+
+
+def test_spark_compare_matches_identical_boolean_values(spark_session):
+    left = spark_session.createDataFrame([(1, True), (2, False)], ["id", "flag"])
+    right = spark_session.createDataFrame([(1, True), (2, False)], ["id", "flag"])
+
+    assert SparkSQLCompare(spark_session, left, right, join_columns="id").matches()


### PR DESCRIPTION
## Summary

Add Boolean column comparison support for Polars, PySpark, and Snowflake to bring these backends to parity with the existing Pandas Boolean comparator.

## Root cause

The default comparator chains for Polars, PySpark, and Snowflake did not include dedicated Boolean handling.

As a result, Boolean columns could fall through the existing array-like, numeric, and string comparators and be reported as mismatches even when corresponding values were equal.

## Changes

- Add dedicated Boolean comparators for:
  - `PolarsBooleanComparator`
  - `SparkBooleanComparator`
  - `SnowflakeBooleanComparator`
- Export the new comparators through `datacompy.comparator`.
- Register each Boolean comparator before the numeric comparator in its backend.
- Preserve the existing numeric comparator implementations.
- Use exact, null-safe Boolean comparison semantics.
- Avoid lossy numeric casts in Spark and Snowflake.
- Add backend-specific regression tests.

## Comparison behavior

### Boolean versus Boolean

Boolean values are compared using exact, null-safe equality.

| Left | Right | Match |
|---|---|---|
| `True` | `True` | `True` |
| `False` | `False` | `True` |
| `True` | `False` | `False` |
| `None` | `None` | `True` |
| `None` | `False` | `False` |

### Boolean versus numeric

Boolean values are compared with exact numeric equivalents:

- `True` matches `1`
- `False` matches `0`
- `True` does not match `0`
- `False` does not match `1`
- aligned nulls match
- comparison works in either column order

The Spark and Snowflake implementations compare against native numeric literals rather than casting numeric columns to `double`. This preserves large integers and high-precision decimal values.

### Boolean versus unsupported types

When a Boolean column is compared with a nonnumeric, non-Boolean column, only aligned null values are considered equal.

## Backend integration

The Boolean comparators are registered before the existing numeric comparators:

```python
[
    ArrayLikeComparator(),
    BooleanComparator(),
    NumericComparator(),
    StringComparator(),
]