### PR TITLE
fix: name the delimiter as a likely cause when join columns are missing from a CSV input

### DIFF
--- a/datacompy/cli/backends.py
+++ b/datacompy/cli/backends.py
@@ -36,6 +36,7 @@ import re
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from contextlib import ExitStack
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, ClassVar
 
@@ -103,6 +104,41 @@ def infer_format(ref: str, override: str | None) -> str:
 def _is_ndjson(ref: str) -> bool:
     """Return ``True`` when *ref* looks like newline delimited JSON."""
     return Path(ref).suffix.lower() in _NDJSON_EXTENSIONS
+
+
+#: Delimiter characters worth naming when a CSV parse collapses to one column.
+#: A header line read with the wrong separator keeps whichever of these it was
+#: meant to be split on.
+_SUSPICIOUS_DELIMITERS = (",", "\t", ";", "|")
+
+
+@dataclass(frozen=True)
+class ParsedInput:
+    """What a file backend's :meth:`CLIBackend.load` did with one input.
+
+    Recorded per side and carried through
+    :func:`datacompy.cli.compare.run_compare` so that a later join column
+    failure can point at a delimiter mistake rather than leave the user
+    studying their join keys. The snowflake backend produces ``None`` instead,
+    since its inputs are table references, not parsed files.
+    """
+
+    ref: str
+    fmt: str
+    delimiter: str | None
+    columns: tuple[str, ...]
+
+    @property
+    def looks_misparsed(self) -> bool:
+        """Whether this looks like a CSV read with the wrong delimiter.
+
+        The tell is a CSV input that collapsed to a single column whose name
+        still carries a plausible delimiter, which is exactly the shape of a
+        header line split on the wrong character.
+        """
+        if self.fmt != "csv" or len(self.columns) != 1:
+            return False
+        return any(char in self.columns[0] for char in _SUSPICIOUS_DELIMITERS)
 
 
 def compare_kwargs(namespace: argparse.Namespace, backend: str) -> dict[str, Any]:
@@ -181,6 +217,27 @@ class CLIBackend(ABC):
     @abstractmethod
     def load(self, session: Any, ref: str, namespace: argparse.Namespace) -> Any:
         """Turn *ref* into whatever the backend's comparison accepts."""
+
+    def describe(
+        self, ref: str, namespace: argparse.Namespace, payload: Any
+    ) -> ParsedInput | None:
+        """Record how :meth:`load` read *ref*, for diagnostics after the fact.
+
+        Returns ``None`` when *payload* is not a parsed frame, which is the case
+        for the snowflake backend where *payload* is a table name. Called only
+        after :meth:`load` has succeeded, so :func:`infer_format` cannot raise
+        here.
+        """
+        columns = getattr(payload, "columns", None)
+        if columns is None:
+            return None
+        fmt = infer_format(ref, namespace.input_format)
+        return ParsedInput(
+            ref=ref,
+            fmt=fmt,
+            delimiter=namespace.csv_delimiter if fmt == "csv" else None,
+            columns=tuple(str(col) for col in columns),
+        )
 
     def build(
         self, namespace: argparse.Namespace, session: Any, left: Any, right: Any

--- a/datacompy/cli/compare.py
+++ b/datacompy/cli/compare.py
@@ -16,13 +16,24 @@
 """The ``datacompy compare`` subcommand."""
 
 import argparse
+import re
 from contextlib import ExitStack
 
-from datacompy.cli.backends import BACKENDS
+from datacompy.cli.backends import BACKENDS, ParsedInput
 from datacompy.cli.errors import BadArgsError
-from datacompy.cli.output import emit
+from datacompy.cli.output import emit, print_warning
 from datacompy.cli.parser import OPTIONS, OPTIONS_BY_FLAG, fill_defaults
 from datacompy.report import ReportData
+
+#: The join column error every backend raises, ``"df1 must have all columns
+#: from join_columns: ..."``. Group 1 names the offending side.
+_MISSING_JOIN_COLUMNS = re.compile(
+    r"^(df1|df2) must have all columns from join_columns\b"
+)
+
+#: The comparison classes speak of ``df1`` and ``df2``; the CLI user passed
+#: ``--left`` and ``--right``.
+_SIDE_FOR = {"df1": "left", "df2": "right"}
 
 
 def run_compare(namespace: argparse.Namespace) -> int:
@@ -52,6 +63,11 @@ def run_compare(namespace: argparse.Namespace) -> int:
         session = backend.open_session(namespace, stack)
         left = backend.load(session, namespace.left, namespace)
         right = backend.load(session, namespace.right, namespace)
+        parsed = {
+            "left": backend.describe(namespace.left, namespace, left),
+            "right": backend.describe(namespace.right, namespace, right),
+        }
+        warn_on_misparsed_index_join(namespace, parsed)
         try:
             comparison = backend.build(namespace, session, left, right)
         except ValueError as exc:
@@ -59,7 +75,7 @@ def run_compare(namespace: argparse.Namespace) -> int:
             # as join columns and tolerances with a plain ValueError. That is a
             # bad argument, not a bug, so report it as one instead of dumping a
             # traceback on the user.
-            raise BadArgsError(str(exc)) from exc
+            raise BadArgsError(add_delimiter_hint(str(exc), parsed)) from exc
 
         report_data = comparison.build_report_data(
             sample_count=namespace.sample_count,
@@ -73,6 +89,54 @@ def run_compare(namespace: argparse.Namespace) -> int:
         )
         matched = within_threshold(namespace, report_data)
     return 0 if matched else 1
+
+
+def _delimiter_hint(info: ParsedInput) -> str:
+    """Return the one line hint naming *info* as a likely delimiter mistake."""
+    return (
+        f"{info.ref!r} was read as CSV with delimiter {info.delimiter!r} and "
+        f"collapsed to a single column named {info.columns[0]!r}. The delimiter "
+        "is probably wrong; set it with --csv-delimiter."
+    )
+
+
+def add_delimiter_hint(message: str, parsed: dict[str, ParsedInput | None]) -> str:
+    """Append a delimiter hint to *message* when a join failure looks like a misparse.
+
+    Every backend reports an absent join column as ``"df1 must have all columns
+    from join_columns: ..."``. That is accurate but points nowhere near the
+    cause when the real problem is a CSV read with the wrong delimiter, which
+    collapses every row into a single column named after the header line. When
+    the side named in *message* looks exactly like that, say so; otherwise
+    return *message* untouched so genuine missing column errors are unchanged.
+    """
+    match = _MISSING_JOIN_COLUMNS.match(message)
+    if match is None:
+        return message
+    info = parsed.get(_SIDE_FOR[match.group(1)])
+    if info is None or not info.looks_misparsed:
+        return message
+    return f"{message}\nHint: {_delimiter_hint(info)}"
+
+
+def warn_on_misparsed_index_join(
+    namespace: argparse.Namespace, parsed: dict[str, ParsedInput | None]
+) -> None:
+    """Warn before an ``--on-index`` run that is about to compare a misparsed file.
+
+    A column join raises on the missing key and
+    :func:`add_delimiter_hint` gets its chance. ``--on-index`` joins on the row
+    index instead and will happily compare two mangled single string columns,
+    producing a report that means nothing and that nothing downstream flags.
+    Warn on stderr and let the comparison proceed, since the exit code should
+    still reflect the result.
+    """
+    if not namespace.on_index:
+        return
+    for side in ("left", "right"):
+        info = parsed[side]
+        if info is not None and info.looks_misparsed:
+            print_warning(_delimiter_hint(info))
 
 
 def validate_arguments(namespace: argparse.Namespace) -> None:

--- a/datacompy/cli/output.py
+++ b/datacompy/cli/output.py
@@ -103,3 +103,13 @@ def emit(
 def print_error(message: str) -> None:
     """Write *message* to stderr with a ``datacompy:`` prefix."""
     print(f"datacompy: {message}", file=sys.stderr)
+
+
+def print_warning(message: str) -> None:
+    """Write *message* to stderr with a ``datacompy: warning:`` prefix.
+
+    Unlike :func:`print_error` this does not accompany a non-zero exit. It is
+    for cases the CLI can see are probably wrong but cannot prove, such as a
+    comparison about to run on a file that looks misparsed.
+    """
+    print(f"datacompy: warning: {message}", file=sys.stderr)

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -82,6 +82,14 @@ unusual, and ``--csv-delimiter`` for anything other than a comma:
     use the same delimiter. Comparing a comma separated file against a tab
     separated one is not currently supported.
 
+When a CSV is read with the wrong delimiter every row collapses into a single
+column named after the header line, and the comparison then fails on a join
+column that appears to be missing. The CLI recognises that shape and appends a
+hint naming the file and the delimiter, rather than leaving the error pointing
+only at the join keys. Under ``--on-index`` the same misparse is reported as a
+warning before the report, since the comparison would otherwise run silently on
+the mangled column.
+
 Cloud URIs such as ``s3://``, ``gs://``, and ``abfs://`` are handed straight to
 the underlying reader, so they work once the matching filesystem library
 (``s3fs``, ``gcsfs``, ``adlfs``) is installed.

--- a/tests/cli/test_compare.py
+++ b/tests/cli/test_compare.py
@@ -586,6 +586,137 @@ def test_custom_csv_delimiter(tmp_path, left_frame, backend, capsys):
     )
 
 
+@pytest.mark.parametrize("delimiter", ["\t", ";", "|"])
+def test_wrong_delimiter_is_named_as_a_likely_cause(
+    tmp_path, left_frame, backend, delimiter, capsys
+):
+    """A CSV read with the wrong delimiter collapses to one column.
+
+    The join then fails on a column that "does not exist", and without the hint
+    the user is left staring at their join keys rather than the delimiter.
+    """
+    left = tmp_path / "left.csv"
+    right = tmp_path / "right.csv"
+    left_frame.to_csv(left, index=False, sep=delimiter)
+    left_frame.to_csv(right, index=False, sep=delimiter)
+
+    assert (
+        main(
+            [
+                "compare",
+                "--left",
+                str(left),
+                "--right",
+                str(right),
+                "--on",
+                "id",
+                "--backend",
+                backend,
+            ]
+        )
+        == ERROR
+    )
+    err = capsys.readouterr().err
+    assert "must have all columns from join_columns" in err
+    assert "Hint:" in err
+    assert "left.csv" in err
+    assert "--csv-delimiter" in err
+    # The hint names the delimiter that was actually used, a comma by default.
+    assert "','" in err
+
+
+def test_delimiter_hint_names_only_the_offending_side(
+    tmp_path, left_frame, right_frame, left_csv, backend, capsys
+):
+    """Only the left file is misparsed, so only the left file is named."""
+    mangled = tmp_path / "mangled.csv"
+    left_frame.to_csv(mangled, index=False, sep="\t")
+
+    assert (
+        main(
+            [
+                "compare",
+                "--left",
+                str(mangled),
+                "--right",
+                str(left_csv),
+                "--on",
+                "id",
+                "--backend",
+                backend,
+            ]
+        )
+        == ERROR
+    )
+    err = capsys.readouterr().err
+    assert "Hint:" in err
+    assert "mangled.csv" in err
+    assert "left.csv" not in err.split("Hint:", 1)[1]
+
+
+def test_genuine_missing_join_column_gets_no_hint(cli, backend, capsys):
+    """A correctly parsed file with a real typo in --on is left unchanged."""
+    assert cli("--on", "nope", "--backend", backend) == ERROR
+    err = capsys.readouterr().err
+    assert "nope" in err
+    assert "Hint:" not in err
+
+
+def test_single_column_csv_without_a_delimiter_in_the_header_gets_no_hint(
+    tmp_path, backend, capsys
+):
+    """One legitimate column whose name has no delimiter character is not flagged."""
+    single = tmp_path / "single.csv"
+    single.write_text("value\n1\n2\n")
+
+    assert (
+        main(
+            [
+                "compare",
+                "--left",
+                str(single),
+                "--right",
+                str(single),
+                "--on",
+                "missing",
+                "--backend",
+                backend,
+            ]
+        )
+        == ERROR
+    )
+    err = capsys.readouterr().err
+    assert "missing" in err
+    assert "Hint:" not in err
+
+
+def test_on_index_warns_when_a_side_looks_misparsed(tmp_path, left_frame, capsys):
+    """--on-index never raises on the mangled column, so warn before the report."""
+    left = tmp_path / "left.csv"
+    right = tmp_path / "right.csv"
+    left_frame.to_csv(left, index=False, sep="\t")
+    left_frame.to_csv(right, index=False, sep="\t")
+
+    exit_code = main(
+        [
+            "compare",
+            "--left",
+            str(left),
+            "--right",
+            str(right),
+            "--on-index",
+            "--backend",
+            "pandas",
+            "--quiet",
+        ]
+    )
+    assert exit_code in (MATCH, MISMATCH)
+    err = capsys.readouterr().err
+    assert "warning:" in err
+    assert "left.csv" in err
+    assert "--csv-delimiter" in err
+
+
 def test_tsv_extension_is_not_inferred(cli, tmp_path, left_frame, backend, capsys):
     """``.tsv`` is not in the extension table, so it asks for an explicit format.
 


### PR DESCRIPTION
Closes #553.

## What

When a CSV-family input is read with the wrong delimiter, every row collapses into a single column whose name is the whole header line. The comparison then fails on the join columns with a message that is correct but points nowhere near the cause:

$ datacompy compare --left left.csv --right right.csv --on id --backend pandas
datacompy: df1 must have all columns from join_columns: {'id'}

This adds a hint at the CLI layer, which is the only layer that knows the input was a file, what extension it had, and which delimiter was chosen. Library messages and exception types are untouched.

## Behaviour

**`--on` path** — when the side named in the error was read as CSV and collapsed to a single column whose name still contains a plausible delimiter (`,`, `\t`, `;`, `|`):

datacompy: df1 must have all columns from join_columns: {'id'}
Hint: 'left.csv' was read as CSV with delimiter ',' and collapsed to a single
column named 'id\tname\tamount'. The delimiter is probably wrong; set it with
--csv-delimiter.

The hint names only the offending side. A genuine missing column on a correctly parsed file, and a legitimate single-column CSV whose header has no delimiter character, get no hint.

**`--on-index` path** — nothing raises today; the comparison runs silently on two mangled string columns. Now a single suspicious column on either side produces a warning on stderr before the report, and the exit code still reflects the comparison result.

## How

- `ParsedInput` (new, `datacompy/cli/backends.py`): a per-side record of what `load()` did (reference, resolved format, resolved delimiter, column names) with a `looks_misparsed` predicate. `CLIBackend.describe()` builds it after a successful load and returns `None` for the snowflake backend, whose inputs are table references rather than parsed files.
- `datacompy/cli/compare.py`: `run_compare` carries the two records through; `add_delimiter_hint()` augments the `ValueError` message on the `--on` path, `warn_on_misparsed_index_join()` covers `--on-index`.
- `print_warning()` (new, `datacompy/cli/output.py`).
- Doc paragraph in `docs/source/cli.rst`.

## Tests

13 cases added to `tests/cli/test_compare.py`: the hint across `\t` / `;` / `|` on both in-memory backends, the hint naming only the offending side, no hint for a real missing column, no hint for a delimiter-free single-column CSV, and the `--on-index` stderr warning.

- `pytest tests/cli` and `pytest tests/test_pandas.py tests/test_polars.py tests/test_base.py` pass
- `ruff check`, `ruff format --check`, `pre-commit run --files ...` clean
- `mypy datacompy/cli` introduces no new errors against the baseline
